### PR TITLE
Get informed when a newer version of Sniffnet is available on GitHub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+
+[[package]]
 name = "bindgen"
 version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,6 +813,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "errno-dragonfly"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -868,6 +885,15 @@ dependencies = [
  "smallvec",
  "threadpool",
  "zune-inflate",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -960,6 +986,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "freetype-rs"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -983,9 +1018,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
+checksum = "531ac96c6ff5fd7c62263c5e3c67a603af4fcaee2e1a0ae5565ba3a11e69e549"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -998,9 +1033,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
+checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1008,15 +1043,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
+checksum = "1997dd9df74cdac935c76252744c1ed5794fac083242ea4fe77ef3ed60ba0f83"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1026,15 +1061,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
+checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
+checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1043,15 +1078,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
+checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
 
 [[package]]
 name = "futures-task"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
 
 [[package]]
 name = "futures-timer"
@@ -1061,9 +1096,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
+checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1243,6 +1278,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1270,10 +1324,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
 name = "hexf-parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+
+[[package]]
+name = "http"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "hyper"
+version = "0.14.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -1445,6 +1576,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "image"
 version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1486,6 +1627,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
+
+[[package]]
 name = "ipnetwork"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1493,6 +1651,12 @@ checksum = "4088d739b183546b239688ddbc79891831df421773df95e236daf7867866d355"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "jni"
@@ -1639,6 +1803,12 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd550e73688e6d578f0ac2119e32b797a327631a42f9433e59d02e139c8df60d"
 
 [[package]]
 name = "lock_api"
@@ -1789,6 +1959,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1848,6 +2024,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -2013,7 +2207,7 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
@@ -2107,6 +2301,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
+name = "openssl"
+version = "0.10.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "518915b97df115dd36109bfa429a48b8f737bd05508cf9588977b599648926d2"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666416d899cf077260dac8698d60a60b435a46d57e82acb1be3d0dad87284e5b"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "ordered-float"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2178,7 +2417,7 @@ dependencies = [
  "cfg-if",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "winapi",
 ]
@@ -2191,7 +2430,7 @@ checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "windows-sys 0.45.0",
 ]
@@ -2203,7 +2442,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d536b12f51fa925b590a6681765ed2bd9f1beb1d2953fa5fe5a20f7c1087b994"
 dependencies = [
  "bitflags",
- "errno",
+ "errno 0.2.8",
  "libc",
  "libloading 0.6.7",
  "pkg-config",
@@ -2481,13 +2720,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "thiserror",
 ]
 
@@ -2513,6 +2761,43 @@ name = "renderdoc-sys"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1382d1f0a252c4bf97dc20d979a2fdd05b024acd7c2ed0f7595d7817666a157"
+
+[[package]]
+name = "reqwest"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
 
 [[package]]
 name = "rodio"
@@ -2566,6 +2851,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b24138615de35e32031d041a09032ef3487a616d901ca4db224e7d557efae2"
+dependencies = [
+ "bitflags",
+ "errno 0.3.0",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+
+[[package]]
 name = "safe_arch"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2581,6 +2886,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+dependencies = [
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2620,6 +2934,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "security-framework"
+version = "2.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys 0.8.3",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
+dependencies = [
+ "core-foundation-sys 0.8.3",
+ "libc",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2643,6 +2980,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.4",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -2751,10 +3111,21 @@ dependencies = [
  "pcap",
  "plotters",
  "plotters-iced",
+ "reqwest",
  "rodio",
  "rstest",
  "serde",
  "thousands",
+]
+
+[[package]]
+name = "socket2"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -2873,6 +3244,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall 0.3.5",
+ "rustix",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2953,15 +3337,58 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.25.0"
+name = "tinyvec"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
 dependencies = [
  "autocfg",
+ "bytes",
+ "libc",
+ "mio",
  "num_cpus",
  "pin-project-lite",
- "windows-sys 0.42.0",
+ "socket2",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2991,6 +3418,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
+name = "tracing"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+
+[[package]]
 name = "ttf-parser"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3008,10 +3467,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -3030,6 +3504,23 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "url"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"
@@ -3052,6 +3543,16 @@ dependencies = [
  "same-file",
  "winapi",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
 ]
 
 [[package]]
@@ -3554,6 +4055,15 @@ dependencies = [
  "web-sys",
  "windows-sys 0.36.1",
  "x11-dl",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ maxminddb = "0.23.0"
 confy = "0.5.1"
 serde = { version = "1.0.158", default_features = false, features = ["derive"] }
 rodio = { version = "0.17.1", default_features = false, features = ["mp3"] }
+reqwest = { version = "0.11.16", features = ["json", "blocking"] }
 
 [dev-dependencies]
 rstest = "0.17.0"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Graphical interface translated in:<br>
 </div>
 
 <p>
-<a href="#">
+<a href="#x">
 <img alt="" src="https://github.com/GyulyVGC/sniffnet/blob/main/resources/repository/hr.png?raw=true" width="100%"/>
 </a>
 </p>
@@ -33,7 +33,7 @@ Graphical interface translated in:<br>
 </div>
 
 <p>
-<a href="#installation">
+<a href="#x">
 <img alt="" src="https://github.com/GyulyVGC/sniffnet/blob/main/resources/repository/hr.png?raw=true" width="100%"/>
 </a>
 </p>
@@ -42,19 +42,6 @@ Graphical interface translated in:<br>
 ## Installation
 
 You can install Sniffnet in one of the following ways:
-
-<details>
-
-  <summary>from Crates.io&ensp;<img alt="" src="https://img.shields.io/crates/d/sniffnet?color=success&label=downloads&logo=rust"/></summary>
-
-  Follow this method only if you have [Rust installed](https://www.rust-lang.org/tools/install) on your machine. <br>
-  In this case, the application binary can be installed with: 
-
-```sh
-cargo install sniffnet
-```
-    
-</details>
 
 
 <details>
@@ -74,9 +61,23 @@ cargo install sniffnet
 
 <details>
 
-  <summary>from Homebrew&ensp;<img alt="" src="https://img.shields.io/homebrew/installs/dy/sniffnet?color=success&logo=homebrew"/></summary>
+  <summary>from Crates.io&ensp;<img alt="" src="https://img.shields.io/crates/d/sniffnet?color=success&label=downloads&logo=rust"/></summary>
 
-  You can install Sniffnet's Homebrew package with:
+Follow this method only if you have [Rust installed](https://www.rust-lang.org/tools/install) on your machine. <br>
+In this case, the application binary can be installed with:
+
+```sh
+cargo install sniffnet
+```
+
+</details>
+
+
+<details>
+
+  <summary>from Homebrew</summary>
+
+  You can install [Sniffnet Homebrew package](https://github.com/Homebrew/homebrew-core/pkgs/container/core%2Fsniffnet) with:
   
   ```sh
 brew install sniffnet
@@ -181,7 +182,7 @@ sudo apt-get install libfontconfig libfontconfig1-dev
   
   This format potentially allows Sniffnet to execute different hundreds of IP lookups in a matter of a few milliseconds.
 
-  Sometimes it is not possible to determine the location of an IP address; this is most likely due to the address being a private IP address.
+  Sometimes it is not possible to determine the location of an IP address (in this case the country will be marked as `?`); this is most likely due to the address being a private IP address.
 
 </details>
 
@@ -193,7 +194,16 @@ sudo apt-get install libfontconfig libfontconfig1-dev
   
   <br>
   
-  Please, note that application layer protocols are just inferred from the transport port numbers.
+  Application layer protocols are inferred from the transport port numbers,
+  following the convention maintained by [IANA](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml).
+
+  Please, remember that this is just a convention:
+  > The Internet Assigned Numbers Authority (IANA) is responsible for maintaining
+  > the official assignments of port numbers for specific uses. <br>
+  > However, many unofficial uses of well-known port numbers occur in practice.
+
+  The following table reports the port-to-service mappings used by Sniffnet,
+  chosen from the most common assignments by IANA.
   
   <br>
   
@@ -296,14 +306,6 @@ Reach me out, and I'll try to generate an installer for your specific operating 
 
 </details>
 
-<!---
-## Contribute
-
-Do you want to improve Sniffnet? Check [here](https://github.com/GyulyVGC/sniffnet/blob/main/CONTRIBUTING.md) 
-
-Sniffnet is also open to design contributions: <br>
-[![contribute.design](https://contribute.design/api/shield/GyulyVGC/sniffnet)](https://contribute.design/GyulyVGC/sniffnet)
---->
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -205,8 +205,6 @@ sudo apt-get install libfontconfig libfontconfig1-dev
   The following table reports the port-to-service mappings used by Sniffnet,
   chosen from the most common assignments by IANA.
   
-  <br>
-  
 <div align="center">
 
 |Port number(s)|Application protocol  |  Description |

--- a/src/check_updates.rs
+++ b/src/check_updates.rs
@@ -1,0 +1,64 @@
+use crate::utility::get_formatted_strings::APP_VERSION;
+use reqwest::header::USER_AGENT;
+use serde::Deserialize;
+use std::thread;
+use std::time::Duration;
+
+#[derive(Deserialize, Debug)]
+struct AppVersion {
+    name: String,
+}
+
+pub fn check_updates() {
+    let _ = is_newer_version_available(6, 30);
+}
+
+/// Checks if a newer version of Sniffnet is available on GitHub
+fn is_newer_version_available(
+    max_retries: u8,
+    seconds_between_retries: u8,
+) -> Result<bool, String> {
+    let client = reqwest::blocking::Client::new();
+    let response = client
+        .get("https://api.github.com/repos/GyulyVGC/Sniffnet/releases/latest")
+        .header(USER_AGENT, format!("sniffnet/{APP_VERSION}"))
+        .send();
+
+    if let Ok(result) = response {
+        let mut latest_version = result
+            .json::<AppVersion>()
+            .unwrap_or(AppVersion {
+                name: String::new(),
+            })
+            .name;
+        if latest_version.len() == 6 {
+            latest_version.remove(0);
+            return if latest_version.gt(&APP_VERSION.to_string()) {
+                Ok(true)
+            } else {
+                Ok(false)
+            };
+        }
+        Err("Cannot parse latest version name".to_string())
+    } else {
+        let retries_left = max_retries - 1;
+        if retries_left > 0 {
+            // sleep 30 seconds and retries the request
+            thread::sleep(Duration::from_secs(u64::from(seconds_between_retries)));
+            is_newer_version_available(retries_left, seconds_between_retries)
+        } else {
+            Err(response.err().unwrap().to_string())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fetch_latest_release_from_github() {
+        let result = is_newer_version_available(6, 2);
+        result.expect("Latest release request from GitHub error");
+    }
+}

--- a/src/enums/message.rs
+++ b/src/enums/message.rs
@@ -29,8 +29,8 @@ pub enum Message {
     UnSaveConnection(usize),
     /// Open Sniffnet's complete textual report
     OpenReport,
-    /// Open Sniffnet's GitHub page
-    OpenGithub,
+    /// Open Sniffnet's GitHub main page if true is passed, latest release page otherwise
+    OpenGithub(bool),
     /// Start sniffing packets
     Start,
     /// Stop sniffing process and return to initial page

--- a/src/gui/components/footer.rs
+++ b/src/gui/components/footer.rs
@@ -6,29 +6,35 @@ use crate::enums::style_type::StyleType;
 use crate::structs::style_tuple::StyleTuple;
 use crate::utility::get_formatted_strings::APP_VERSION;
 use crate::utility::style_constants::{get_font, get_font_headers, FONT_SIZE_FOOTER, ICONS};
+use crate::utility::translations_2::new_version_available_translation;
+use crate::Language;
 use iced::alignment::{Horizontal, Vertical};
 use iced::widget::{button, Container, Row, Text, Tooltip};
-use iced::{Alignment, Length};
+use iced::{Alignment, Font, Length};
 use iced_native::widget::horizontal_space;
 use iced_native::widget::tooltip::Position;
+use std::sync::{Arc, Mutex};
 
-pub fn footer(style: StyleType) -> Container<'static, Message> {
+pub fn footer(
+    language: Language,
+    style: StyleType,
+    newer_release_available: &Arc<Mutex<Result<bool, String>>>,
+) -> Container<'static, Message> {
     let font_footer = get_font_headers(style);
+
+    let release_details_row =
+        get_release_details(language, style, font_footer, newer_release_available);
 
     let footer_row = Row::new()
         .width(Length::Fill)
         .padding([0, 20])
         .align_items(Alignment::Center)
-        .push(
-            Text::new(format!("Version {APP_VERSION}                  "))
-                .size(FONT_SIZE_FOOTER)
-                .font(font_footer),
-        )
-        .push(horizontal_space(Length::FillPortion(1)))
+        .push(release_details_row)
         .push(get_button_github(style))
-        .push(horizontal_space(Length::FillPortion(1)))
         .push(
             Text::new("Made with ❤ by Giuliano Bellini")
+                .width(Length::FillPortion(1))
+                .horizontal_alignment(Horizontal::Right)
                 .size(FONT_SIZE_FOOTER)
                 .font(font_footer),
         );
@@ -54,11 +60,65 @@ pub fn get_button_github(style: StyleType) -> Tooltip<'static, Message> {
     .height(Length::Fixed(40.0))
     .width(Length::Fixed(40.0))
     .style(StyleTuple(style, ElementType::Standard).into())
-    .on_press(Message::OpenGithub);
+    .on_press(Message::OpenGithub(true));
 
     Tooltip::new(content, "GitHub", Position::Top)
         .font(get_font(style))
         .style(<StyleTuple as Into<iced::theme::Container>>::into(
             StyleTuple(style, ElementType::Tooltip),
         ))
+}
+
+fn get_release_details(
+    language: Language,
+    style: StyleType,
+    font_footer: Font,
+    newer_release_available: &Arc<Mutex<Result<bool, String>>>,
+) -> Row<'static, Message> {
+    let mut ret_val = Row::new()
+        .align_items(Alignment::Center)
+        .height(Length::Fill)
+        .width(Length::FillPortion(1))
+        .push(
+            Text::new(format!("Version {APP_VERSION}"))
+                .size(FONT_SIZE_FOOTER)
+                .font(font_footer),
+        );
+    if let Ok(boolean_response) = *newer_release_available.lock().unwrap() {
+        if boolean_response {
+            // a newer release is available on GitHub
+            let button = button(
+                Text::new('T'.to_string())
+                    .font(ICONS)
+                    .size(25)
+                    .horizontal_alignment(Horizontal::Center)
+                    .vertical_alignment(Vertical::Center),
+            )
+            .padding(5)
+            .height(Length::Fixed(40.0))
+            .width(Length::Fixed(40.0))
+            .style(StyleTuple(style, ElementType::Alert).into())
+            .on_press(Message::OpenGithub(false));
+            let tooltip = Tooltip::new(
+                button,
+                new_version_available_translation(language),
+                Position::Top,
+            )
+            .font(get_font(style))
+            .style(<StyleTuple as Into<iced::theme::Container>>::into(
+                StyleTuple(style, ElementType::Tooltip),
+            ));
+            ret_val = ret_val
+                .push(horizontal_space(Length::Fixed(10.0)))
+                .push(tooltip);
+        } else {
+            // this is the latest release
+            ret_val = ret_val.push(
+                Text::new(" (latest)")
+                    .size(FONT_SIZE_FOOTER)
+                    .font(font_footer),
+            );
+        }
+    }
+    ret_val
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use std::{panic, process, thread};
 use iced::window::Position;
 use iced::{window, Application, Settings};
 
-use crate::check_updates::check_updates;
+use crate::thread_check_updates::set_newer_release_status;
 use utility::style_constants::FONT_SIZE_BODY;
 
 use crate::enums::app_protocol::AppProtocol;
@@ -30,10 +30,10 @@ use crate::structs::traffic_chart::TrafficChart;
 use crate::thread_write_report::sleep_and_write_report_loop;
 use crate::utility::get_formatted_strings::print_cli_welcome_message;
 
-mod check_updates;
 mod enums;
 mod gui;
 mod structs;
+mod thread_check_updates;
 mod thread_parse_packets;
 mod thread_write_report;
 mod utility;
@@ -50,6 +50,9 @@ pub fn main() -> iced::Result {
 
     let status_pair1 = Arc::new((Mutex::new(Status::Init), Condvar::new()));
     let status_pair2 = status_pair1.clone();
+
+    let newer_release_available1 = Arc::new(Mutex::new(Err(String::new())));
+    let newer_release_available2 = newer_release_available1.clone();
 
     let runtime_data = Rc::new(RefCell::new(RunTimeData::new()));
 
@@ -85,7 +88,7 @@ pub fn main() -> iced::Result {
     thread::Builder::new()
         .name("thread_check_updates".to_string())
         .spawn(move || {
-            check_updates();
+            set_newer_release_status(&newer_release_available2);
         })
         .unwrap();
 
@@ -112,6 +115,7 @@ pub fn main() -> iced::Result {
             status_pair1,
             &config_settings,
             &config_device,
+            newer_release_available1,
         ),
         default_font: Some(include_bytes!(
             "../resources/fonts/subset/sarasa-mono-sc-regular.subset.ttf"

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use std::{panic, process, thread};
 use iced::window::Position;
 use iced::{window, Application, Settings};
 
+use crate::check_updates::check_updates;
 use utility::style_constants::FONT_SIZE_BODY;
 
 use crate::enums::app_protocol::AppProtocol;
@@ -29,6 +30,7 @@ use crate::structs::traffic_chart::TrafficChart;
 use crate::thread_write_report::sleep_and_write_report_loop;
 use crate::utility::get_formatted_strings::print_cli_welcome_message;
 
+mod check_updates;
 mod enums;
 mod gui;
 mod structs;
@@ -77,6 +79,13 @@ pub fn main() -> iced::Result {
         .name("thread_write_report".to_string())
         .spawn(move || {
             sleep_and_write_report_loop(&current_capture_id2, &mutex_map2, &status_pair2);
+        })
+        .unwrap();
+
+    thread::Builder::new()
+        .name("thread_check_updates".to_string())
+        .spawn(move || {
+            check_updates();
         })
         .unwrap();
 

--- a/src/structs/sniffer.rs
+++ b/src/structs/sniffer.rs
@@ -26,6 +26,8 @@ pub struct Sniffer {
     pub info_traffic: Arc<Mutex<InfoTraffic>>,
     /// Status of the application (init or running) and the associated condition variable
     pub status_pair: Arc<(Mutex<Status>, Condvar)>,
+    /// Reports if a newer release of the software is available on GitHub
+    pub newer_release_available: Arc<Mutex<Result<bool, String>>>,
     /// Traffic data displayed in GUI
     pub runtime_data: Rc<RefCell<RunTimeData>>,
     /// Network adapter to be analyzed
@@ -68,11 +70,13 @@ impl Sniffer {
         status_pair: Arc<(Mutex<Status>, Condvar)>,
         config_settings: &ConfigSettings,
         config_device: &ConfigDevice,
+        is_newer_release_available: Arc<Mutex<Result<bool, String>>>,
     ) -> Self {
         Self {
             current_capture_id,
             info_traffic,
             status_pair,
+            newer_release_available: is_newer_release_available,
             runtime_data: runtime_data.clone(),
             device: config_device.to_pcap_device(),
             last_device_name_sniffed: config_device.device_name.clone(),

--- a/src/utility/mod.rs
+++ b/src/utility/mod.rs
@@ -6,3 +6,4 @@ pub mod manage_packets;
 pub mod manage_report_data;
 pub mod style_constants;
 pub mod translations;
+pub mod translations_2;

--- a/src/utility/translations_2.rs
+++ b/src/utility/translations_2.rs
@@ -1,0 +1,9 @@
+use crate::Language;
+
+pub fn new_version_available_translation(language: Language) -> &'static str {
+    match language {
+        Language::EN => "A newer version is available on GitHub",
+        Language::IT => "Una versione più recente è disponibile su GitHub",
+        _ => "A newer version is available on GitHub",
+    }
+}


### PR DESCRIPTION
This PR introduces a feature to inform you when a newer version of Sniffnet is available on GitHub.
In order to not be intrusive, this information is placed on the left side of the application footer.

- This is what you'd see if your version was the latest:

<div align="center">

![Screenshot 2023-03-29 at 16 40 37](https://user-images.githubusercontent.com/100347457/228575874-5ffc1997-e13f-4a04-a148-9588442956a1.png)

</div>

- This is what you'd see if a newer version was available (second picture when hovering on the alert button):

<div align="center">

<img width="40%" src="https://user-images.githubusercontent.com/100347457/228575791-6d8fd92e-54da-4ba8-9770-7dacf435a005.png">
&nbsp;
<img height="140" src="https://user-images.githubusercontent.com/100347457/228576566-c443a56d-537b-4d26-87fa-0b713567dae0.png">

</div>

<hr><br>I hope this feature will help you to never miss again any new update! 🆕 