### PR TITLE
v1.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All Sniffnet releases with the relative changes are documented in this file.
 
 
-## [1.1.4] - UNRELEASED
+## [1.1.4] - 2023-04-xx
 
 - Added new translations of the GUI:
   * Portuguese 🇵🇹 ([#134](https://github.com/GyulyVGC/sniffnet/pull/134))
@@ -12,6 +12,8 @@ All Sniffnet releases with the relative changes are documented in this file.
   * ...the total number of supported languages is now 13 🎉
 - Changed adapter buttons format and improved volume slider layout (see [#119](https://github.com/GyulyVGC/sniffnet/issues/119) for more details or to give me further suggestions)
 - Scrollbars are now highlighted when hovering on the respective scrollable area
+- Set up `iced_glow` feature on branch [`glow-renderer`](https://github.com/GyulyVGC/sniffnet/tree/glow-renderer) to overcome unsupported graphics ([#155](https://github.com/GyulyVGC/sniffnet/pull/155))
+- Modified `dependabot` configuration to update GitHub Actions as needed ([#141](https://github.com/GyulyVGC/sniffnet/pull/141))
 - Fixed problem causing a crash on macOS when starting Sniffnet's Homebrew package or building from source in release mode ([#109](https://github.com/GyulyVGC/sniffnet/issues/109) - [#137](https://github.com/GyulyVGC/sniffnet/issues/137))
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All Sniffnet releases with the relative changes are documented in this file.
 
 
-## [1.1.4] - 2023-04-xx
+## [1.1.4] - 2023-04-18
 
 - Added new translations of the GUI:
   * Portuguese 🇵🇹 ([#134](https://github.com/GyulyVGC/sniffnet/pull/134))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3255,7 +3255,7 @@ dependencies = [
 
 [[package]]
 name = "sniffnet"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "chrono",
  "confy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sniffnet"
-version = "1.1.3"
+version = "1.1.4"
 authors = ["Giuliano Bellini"]
 edition = "2021"
 description = "Application to comfortably monitor your network traffic"

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You can install Sniffnet in one of the following ways:
   You can install Sniffnet through the installers available in the [latest release](https://github.com/GyulyVGC/sniffnet/releases). <br>
   Choose from a Windows installer, a macOS disk image, or a DEB package (depending on your operating system). <br>
   Here for your convenience you can find the direct link to the downloads:
-  - [Windows](https://github.com/GyulyVGC/sniffnet/releases/download/v1.1.4/Sniffnet_Windows.msi) (8.4 MB)
+  - [Windows](https://github.com/GyulyVGC/sniffnet/releases/download/v1.1.4/Sniffnet_Windows.msi) (8.8 MB)
   - [macOS](https://github.com/GyulyVGC/sniffnet/releases/download/v1.1.4/Sniffnet_MacOS.dmg) (7.3 MB)
   - [Linux (.deb)](https://github.com/GyulyVGC/sniffnet/releases/download/v1.1.4/Sniffnet_Linux.deb) (5.3 MB)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Multithreaded, cross-platform, reliable
 <div align="center">
 
 Graphical interface translated in:<br>
-🇬🇧&nbsp;&nbsp;🇩🇪&nbsp;&nbsp;🇪🇦&nbsp;&nbsp;🇫🇷&nbsp;&nbsp;🇮🇹&nbsp;&nbsp;🇵🇱&nbsp;&nbsp;🇷🇴&nbsp;&nbsp;🇺🇦&nbsp;&nbsp;🇨🇳<br>
+🇬🇧&nbsp;&nbsp;🇩🇪&nbsp;&nbsp;🇪🇦&nbsp;&nbsp;🇫🇷&nbsp;&nbsp;🇮🇹&nbsp;&nbsp;🇰🇷&nbsp;&nbsp;🇵🇱&nbsp;&nbsp;🇵🇹&nbsp;&nbsp;🇷🇴&nbsp;&nbsp;🇷🇺&nbsp;&nbsp;🇹🇷&nbsp;&nbsp;🇺🇦&nbsp;&nbsp;🇨🇳<br>
 [Would you like to add support for your native language?](https://github.com/GyulyVGC/sniffnet/issues/60)
 
 </div>
@@ -51,9 +51,9 @@ You can install Sniffnet in one of the following ways:
   You can install Sniffnet through the installers available in the [latest release](https://github.com/GyulyVGC/sniffnet/releases). <br>
   Choose from a Windows installer, a macOS disk image, or a DEB package (depending on your operating system). <br>
   Here for your convenience you can find the direct link to the downloads:
-  - [Windows](https://github.com/GyulyVGC/sniffnet/releases/download/v1.1.3/Sniffnet_Windows.msi) (8.4 MB)
-  - [macOS](https://github.com/GyulyVGC/sniffnet/releases/download/v1.1.3/Sniffnet_MacOS.dmg) (6.9 MB)
-  - [Linux (.deb)](https://github.com/GyulyVGC/sniffnet/releases/download/v1.1.3/Sniffnet_Linux.deb) (5.3 MB)
+  - [Windows](https://github.com/GyulyVGC/sniffnet/releases/download/v1.1.4/Sniffnet_Windows.msi) (8.4 MB)
+  - [macOS](https://github.com/GyulyVGC/sniffnet/releases/download/v1.1.4/Sniffnet_MacOS.dmg) (7.3 MB)
+  - [Linux (.deb)](https://github.com/GyulyVGC/sniffnet/releases/download/v1.1.4/Sniffnet_Linux.deb) (5.3 MB)
 
     
 </details>

--- a/src/translations/translations_2.rs
+++ b/src/translations/translations_2.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::match_same_arms)]
+
 use crate::Language;
 
 pub fn new_version_available_translation(language: Language) -> &'static str {


### PR DESCRIPTION
Release of Sniffnet version 1.1.4.
See the [CHANGELOG](https://github.com/GyulyVGC/sniffnet/blob/main/CHANGELOG.md) for more details.