### PR TITLE
Correction of awkward Korean expressions

### DIFF
--- a/src/translations/types/language.rs
+++ b/src/translations/types/language.rs
@@ -75,7 +75,7 @@ impl Language {
             Language::UK => "Українська",
             Language::ZH => "简体中文",
             Language::RO => "Română",
-            Language::KO => "한국인",
+            Language::KO => "한국어",
             Language::TR => "Türkçe",
             Language::RU => "Русский",
             Language::PT => "Português",


### PR DESCRIPTION
'한국인' is a Korean expression that refers to a person living in Korea, and '한국어' is correct.