### PR TITLE
feat: support --help and --version CLI arguments

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7,7 +7,7 @@ pub fn parse_cli_args() {
     for arg in args {
         match arg.as_str() {
             "--help" | "-h" => print_help(),
-            "--version" | "-v" | "-V" => print_version(),
+            "--version" | "-v" => print_version(),
             _ => {
                 unknown_argument(&arg);
                 std::process::exit(1);
@@ -18,26 +18,23 @@ pub fn parse_cli_args() {
 }
 
 fn print_help() {
-    print_version();
-    eprintln!(
-        "Application to comfortably monitor your Internet traffic
-
-Usage: sniffnet [OPTIONS]
-
-Options:
-    -h, --help      Print help
-    -v, --version   Print version info"
+    println!(
+        "Application to comfortably monitor your Internet traffic\n\
+        Usage: sniffnet [OPTIONS]\n\
+        Options:\n\
+        \t-h, --help      Print help\n\
+        \t-v, --version   Print version info\n\
+        (Run without options to start the app)"
     );
 }
 
 fn print_version() {
-    eprintln!("sniffnet {APP_VERSION}");
+    println!("sniffnet {APP_VERSION}");
 }
 
 fn unknown_argument(arg: &str) {
     eprintln!(
-        "error: unknown argument '{arg}'
-
-For more information, try '--help'"
+        "sniffnet: unknown option '{arg}'\n\
+        For more information, try 'sniffnet --help'"
     );
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -10,7 +10,7 @@ pub fn parse_cli_args() {
                 print_help();
                 break;
             }
-            "--version" | "-V" => {
+            "--version" | "-v" | "-V" => {
                 print_version();
                 break;
             }
@@ -32,7 +32,7 @@ Usage: sniffnet [OPTIONS]
 
 Options:
     -h, --help      Print help
-    -V, --version   Print version info"
+    -v, --version   Print version info"
     );
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6,21 +6,15 @@ pub fn parse_cli_args() {
     let args = std::env::args().skip(1);
     for arg in args {
         match arg.as_str() {
-            "--help" | "-h" => {
-                print_help();
-                break;
-            }
-            "--version" | "-v" | "-V" => {
-                print_version();
-                break;
-            }
+            "--help" | "-h" => print_help(),
+            "--version" | "-v" | "-V" => print_version(),
             _ => {
                 unknown_argument(&arg);
                 std::process::exit(1);
             }
         }
+        std::process::exit(0);
     }
-    std::process::exit(0);
 }
 
 fn print_help() {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,49 @@
+use crate::utils::formatted_strings::APP_VERSION;
+
+/// Parse CLI arguments, and exit if `--help`, `--version`, or an
+/// unknown argument was supplied
+pub fn parse_cli_args() {
+    let args = std::env::args().skip(1);
+    for arg in args {
+        match arg.as_str() {
+            "--help" | "-h" => {
+                print_help();
+                break;
+            }
+            "--version" | "-V" => {
+                print_version();
+                break;
+            }
+            _ => {
+                unknown_argument(&arg);
+                std::process::exit(1);
+            }
+        }
+    }
+    std::process::exit(0);
+}
+
+fn print_help() {
+    print_version();
+    eprintln!(
+        "Application to comfortably monitor your Internet traffic
+
+Usage: sniffnet [OPTIONS]
+
+Options:
+    -h, --help      Print help
+    -V, --version   Print version info"
+    );
+}
+
+fn print_version() {
+    eprintln!("sniffnet {APP_VERSION}");
+}
+
+fn unknown_argument(arg: &str) {
+    eprintln!(
+        "error: unknown argument '{arg}'
+
+For more information, try '--help'"
+    );
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 use std::sync::{Arc, Condvar, Mutex};
 use std::{panic, process, thread};
 
+use cli::parse_cli_args;
 use iced::window::{PlatformSpecific, Position};
 use iced::{window, Application, Settings};
 
@@ -32,6 +33,7 @@ use utils::formatted_strings::print_cli_welcome_message;
 use crate::secondary_threads::check_updates::set_newer_release_status;
 
 mod chart;
+mod cli;
 mod configs;
 mod countries;
 mod gui;
@@ -95,6 +97,7 @@ pub fn main() -> iced::Result {
         })
         .unwrap();
 
+    parse_cli_args();
     print_cli_welcome_message();
 
     Sniffer::run(Settings {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,12 +5,12 @@
 use std::sync::{Arc, Condvar, Mutex};
 use std::{panic, process, thread};
 
-use cli::parse_cli_args;
 use iced::window::{PlatformSpecific, Position};
 use iced::{window, Application, Settings};
 
 use chart::types::chart_type::ChartType;
 use chart::types::traffic_chart::TrafficChart;
+use cli::parse_cli_args;
 use configs::types::config_device::ConfigDevice;
 use configs::types::config_settings::ConfigSettings;
 use gui::pages::types::running_page::RunningPage;
@@ -48,6 +48,8 @@ mod utils;
 ///
 /// It initializes shared variables and loads configuration parameters
 pub fn main() -> iced::Result {
+    parse_cli_args();
+
     let current_capture_id1 = Arc::new(Mutex::new(0));
     let current_capture_id2 = current_capture_id1.clone();
 
@@ -97,7 +99,6 @@ pub fn main() -> iced::Result {
         })
         .unwrap();
 
-    parse_cli_args();
     print_cli_welcome_message();
 
     Sniffer::run(Settings {

--- a/src/networking/types/data_info.rs
+++ b/src/networking/types/data_info.rs
@@ -1,7 +1,8 @@
 //! Module defining the `DataInfo` struct, which represents incoming and outgoing packets and bytes.
 
-use crate::networking::types::traffic_direction::TrafficDirection;
 use std::ops::AddAssign;
+
+use crate::networking::types::traffic_direction::TrafficDirection;
 
 /// Amount of exchanged data (packets and bytes) incoming and outgoing
 #[derive(Clone, Default, Copy)]


### PR DESCRIPTION
This adds `--help`/`-h` and `--version`/`-V` CLI arguments, following the defaults used by [clap](https://docs.rs/clap/latest/clap/). When any of these options is found, we exit with status code 0, which indicates success. When an unknown argument is supplied, we exit with the status code 1. Arguments after `--help`/`--version` are ignored, which I think is not a big deal.

If the plan is to support more CLI arguments, it would make sense to switch to a proper argument parser like clap or [lexopt](https://docs.rs/lexopt/).

Closes #264 