### PR TITLE
fix: ignore tab switch when user focused on window just now

### DIFF
--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -104,10 +104,14 @@ impl Application for Sniffer {
 
     fn subscription(&self) -> Subscription<Message> {
         use iced_native::keyboard::{Event, KeyCode, Modifiers};
+        use iced_native::window;
         const NO_MODIFIER: iced_native::keyboard::Modifiers =
             iced_native::keyboard::Modifiers::empty();
         let hot_keys_subscription =
             iced_native::subscription::events_with(|event, _| match event {
+                iced_native::Event::Window(window::Event::Focused) => {
+                    Some(Message::WindowFocused)
+                }
                 iced_native::Event::Keyboard(Event::KeyPressed {
                     key_code,
                     modifiers,

--- a/src/gui/types/message.rs
+++ b/src/gui/types/message.rs
@@ -80,4 +80,6 @@ pub enum Message {
     UpdatePageNumber(bool),
     /// Left (false) or Right (true) arrow key has been pressed
     ArrowPressed(bool),
+    /// Emit when the main window be focused
+    WindowFocused,
 }

--- a/src/gui/types/status.rs
+++ b/src/gui/types/status.rs
@@ -6,3 +6,32 @@ pub enum Status {
     /// The sniffing process is running: the application parses packets and periodically update the output report.
     Running,
 }
+
+/// A struct to record last focus status of the window.
+pub struct FocusState {
+    /// The time of the window be focused on
+    last_focus_time: std::time::Instant,
+    /// A fixed short period of time to determine
+    /// if we focused on the window just now.
+    just_focus_timeout: std::time::Duration,
+}
+
+impl FocusState {
+    pub fn new(focus_timeout: u64) -> Self {
+        Self {
+            last_focus_time: std::time::Instant::now(),
+            just_focus_timeout: std::time::Duration::from_millis(focus_timeout),
+        }
+    }
+
+    /// Update last focus time to current time
+    pub fn update(&mut self) {
+        self.last_focus_time = std::time::Instant::now();
+    }
+
+    /// Check if the window be focused just now
+    pub fn is_just_focus(&self) -> bool {
+        self.last_focus_time.elapsed() < self.just_focus_timeout
+    }
+}
+


### PR DESCRIPTION
related to: #262 

When pressing `Alt` + `Tab` to switch back to the app, the Tab pressed event will be captured immediately, which causes this issue.

I resolve to use the iced window focus event to determine if users switched between the windows and record the timestamp of the focus event meanwhile.
When the `SwitchPage` message is emitted, first check if users just switched windows within a short period. If so, just ignore this request.