### PR TITLE
ICMP handling

### DIFF
--- a/src/networking/manage_packets.rs
+++ b/src/networking/manage_packets.rs
@@ -107,6 +107,18 @@ pub fn analyze_transport_header(
                 *application_protocol = from_port_to_application_protocol(*port2);
             }
         }
+        Some(TransportHeader::Icmpv4(_icmpv4_header)) => {
+            *transport_protocol = TransProtocol::ICMP;
+            *application_protocol = AppProtocol::ICMP;
+            *port1 = 0;
+            *port2 = 0;
+        }
+        Some(TransportHeader::Icmpv6(_icmpv6_header)) => {
+            *transport_protocol = TransProtocol::ICMP;
+            *application_protocol = AppProtocol::ICMP;
+            *port1 = 0;
+            *port2 = 0;
+        }
         _ => {
             *skip_packet = true;
         }

--- a/src/networking/types/app_protocol.rs
+++ b/src/networking/types/app_protocol.rs
@@ -55,6 +55,7 @@ pub enum AppProtocol {
     XMPP,
     /// not identified
     Other,
+    ICMP,
 }
 
 /// Given an integer in the range `0..=65535`, this function returns an `Option<AppProtocol>` containing
@@ -120,7 +121,7 @@ impl fmt::Display for AppProtocol {
 
 impl AppProtocol {
     /// Defines a constant to be used in the picklist in gui initial page
-    pub(crate) const ALL: [AppProtocol; 25] = [
+    pub(crate) const ALL: [AppProtocol; 26] = [
         AppProtocol::Other,
         AppProtocol::BGP,
         AppProtocol::DHCP,
@@ -146,6 +147,7 @@ impl AppProtocol {
         AppProtocol::Telnet,
         AppProtocol::TFTP,
         AppProtocol::XMPP,
+        AppProtocol::ICMP,
     ];
 }
 

--- a/src/networking/types/trans_protocol.rs
+++ b/src/networking/types/trans_protocol.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::translations::translations::both_translation;
+use crate::translations::translations::all_translation;
 use crate::Language;
 
 /// Enum representing the possible observed values of transport layer protocol.
@@ -11,6 +11,8 @@ pub enum TransProtocol {
     TCP,
     /// User Datagram Protocol
     UDP,
+    /// Internet Control Message Protocol
+    ICMP,
     /// Not identified
     Other,
 }
@@ -22,14 +24,15 @@ impl fmt::Display for TransProtocol {
 }
 
 impl TransProtocol {
-    pub(crate) const ALL: [TransProtocol; 3] =
-        [TransProtocol::TCP, TransProtocol::UDP, TransProtocol::Other];
+    pub(crate) const ALL: [TransProtocol; 4] =
+        [TransProtocol::TCP, TransProtocol::UDP, TransProtocol::ICMP, TransProtocol::Other];
 
     pub fn get_radio_label(&self, language: Language) -> &str {
         match self {
             TransProtocol::TCP => "TCP",
             TransProtocol::UDP => "UDP",
-            TransProtocol::Other => both_translation(language),
+            TransProtocol::ICMP => "ICMP",
+            TransProtocol::Other => all_translation(language),
         }
     }
 }


### PR DESCRIPTION
Identifies ICMP v4 or v6 packets, and collapses them to a single ICMP transport type. 
Ports are undefined by ICMP, therefore to zero. 
Protocol type set to ICMP to allow filtering.
Issue #288 