### PR TITLE
Brazilian Portuguese Translation

### DIFF
--- a/src/gui/pages/settings_language_page.rs
+++ b/src/gui/pages/settings_language_page.rs
@@ -25,15 +25,17 @@ pub fn settings_language_page(sniffer: &Sniffer) -> Container<Message, Renderer<
     let row_language_radio_4 = language_radios(language_active, &Language::ROW4, font);
     let row_language_radio_5 = language_radios(language_active, &Language::ROW5, font);
     let row_language_radio_6 = language_radios(language_active, &Language::ROW6, font);
+    let row_language_radio_7 = language_radios(language_active, &Language::ROW7, font);
     let col_language_radio_all = Column::new()
-        .spacing(12)
+        .spacing(7)
         .align_items(Alignment::Center)
         .push(row_language_radio_1)
         .push(row_language_radio_2)
         .push(row_language_radio_3)
         .push(row_language_radio_4)
         .push(row_language_radio_5)
-        .push(row_language_radio_6);
+        .push(row_language_radio_6)
+        .push(row_language_radio_7);
 
     let mut content = Column::new()
         .align_items(Alignment::Center)

--- a/src/translations/translations.rs
+++ b/src/translations/translations.rs
@@ -25,7 +25,7 @@ pub fn choose_adapters_translation(language: Language) -> Text<'static, Renderer
         Language::FI => "Valitse tarkasteltava verkkosovitin",
         Language::JA => "使用するネットワーク アダプターを選択してください",
         Language::UZ => "Tekshirish uchun tarmoq adapterini tanlang",
-        Language::BR => "Selecione o adaptador de rede a ser inspecionado",
+        Language::PT_BR => "Selecione o adaptador de rede a ser inspecionado",
     })
 }
 
@@ -43,7 +43,7 @@ pub fn application_protocol_translation(language: Language) -> &'static str {
         Language::KO => "어플리케이션 프로토콜",
         Language::TR => "Uygulama protokolü",
         Language::RU => "Прикладной протокол",
-        Language::PT | Language::BR => "Protocolo de aplicação",
+        Language::PT | Language::PT_BR => "Protocolo de aplicação",
         Language::EL => "Πρωτόκολλο εφαρμογής",
         // Language::FA => "پیوندنامهٔ درخواست",
         Language::SV => "Applikationsprotokoll",
@@ -67,7 +67,9 @@ pub fn select_filters_translation(language: Language) -> Text<'static, Renderer<
         Language::KO => "네트워크 트레픽에 적용할 필터 선택",
         Language::TR => "Ağ trafiğine uygulanacak filtreleri seçiniz",
         Language::RU => "Выберите фильтры для применения к сетевому трафику",
-        Language::PT | Language::BR => "Selecione os filtros a serem aplicados no tráfego de rede",
+        Language::PT | Language::PT_BR => {
+            "Selecione os filtros a serem aplicados no tráfego de rede"
+        }
         Language::EL => "Επίλεξε τα φίλτρα για εφαρμογή στην κίνηση του δικτύου",
         // Language::FA => "صافی ها را جهت اعمال بر آمد و شد شبکه انتخاب کنید",
         Language::SV => "Välj filtren som ska appliceras på nätverkstrafiken",
@@ -95,7 +97,7 @@ pub fn start_translation(language: Language) -> &'static str {
         Language::FI => "Aloita!",
         Language::JA => "開始！",
         Language::UZ => "Boshlash!",
-        Language::BR => "Iniciar!",
+        Language::PT_BR => "Iniciar!",
     }
 }
 
@@ -111,7 +113,7 @@ pub fn address_translation(language: Language) -> &'static str {
         Language::RO => "Adresă",
         Language::KO => "주소",
         Language::RU => "Адрес",
-        Language::PT | Language::BR => "Endereço",
+        Language::PT | Language::PT_BR => "Endereço",
         Language::EL => "Διεύθυνση",
         // Language::FA => "نشانی",
         Language::SV => "Adress",
@@ -135,7 +137,7 @@ pub fn addresses_translation(language: Language) -> &'static str {
         Language::KO => "주소",
         Language::TR => "Adresler",
         Language::RU => "Адреса",
-        Language::PT | Language::BR => "Endereços",
+        Language::PT | Language::PT_BR => "Endereços",
         Language::EL => "Διευθύνσεις",
         // Language::FA => "نشانی ها",
         Language::SV => "Adresser",
@@ -159,7 +161,7 @@ pub fn ip_version_translation(language: Language) -> Text<'static, Renderer<Styl
         Language::KO => "IP 버전",
         Language::TR => "IP versiyonu",
         Language::RU => "Версия IP",
-        Language::PT | Language::BR => "Versão de IP",
+        Language::PT | Language::PT_BR => "Versão de IP",
         Language::EL => "Έκδοση IP",
         // Language::FA => "نسخهٔ IP",
         Language::SV => "IP-version",
@@ -174,7 +176,7 @@ pub fn transport_protocol_translation(language: Language) -> &'static str {
         Language::EN => "Transport protocol",
         Language::IT => "Protocollo di trasporto",
         Language::FR => "Protocole de transport",
-        Language::ES | Language::PT | Language::BR => "Protocolo de transporte",
+        Language::ES | Language::PT | Language::PT_BR => "Protocolo de transporte",
         Language::PL => "Protokół transportowy",
         Language::DE => "Netzwerkprotokoll",
         Language::UK => "Транспортний протокол",
@@ -206,7 +208,7 @@ pub fn traffic_rate_translation(language: Language) -> Text<'static, Renderer<St
         Language::KO => "트레픽 속도",
         Language::TR => "Trafik oranı",
         Language::RU => "Cкорость трафика",
-        Language::PT | Language::BR => "Taxa de tráfego",
+        Language::PT | Language::PT_BR => "Taxa de tráfego",
         Language::EL => "Ρυθμός κίνησης",
         // Language::FA => "نرخ آمد و شد",
         Language::SV => "Datafrekvens",
@@ -252,7 +254,7 @@ pub fn settings_translation(language: Language) -> &'static str {
         Language::KO => "설정",
         Language::TR => "Ayarlar",
         Language::RU => "Настройки",
-        Language::PT | Language::BR => "Configurações",
+        Language::PT | Language::PT_BR => "Configurações",
         Language::EL => "Ρυθμίσεις",
         // Language::FA => "پیکربندی",
         Language::SV => "Inställningar",
@@ -276,7 +278,7 @@ pub fn yes_translation(language: Language) -> Text<'static, Renderer<StyleType>>
         Language::KO => "네",
         Language::TR => "Evet",
         Language::RU => "Да",
-        Language::PT | Language::BR => "Sim",
+        Language::PT | Language::PT_BR => "Sim",
         Language::EL => "Ναι",
         // Language::FA => "بله",
         Language::FI => "Kyllä",
@@ -306,7 +308,7 @@ pub fn ask_quit_translation(language: Language) -> Text<'static, Renderer<StyleT
         Language::FI => "Haluatko varmasti lopettaa analyysin?",
         Language::JA => "分析を終了しますか？",
         Language::UZ => "Tahlildan chiqishga ishonchingiz komilmi?",
-        Language::BR => "Tem certeza que deseja sair desta análise?",
+        Language::PT_BR => "Tem certeza que deseja sair desta análise?",
     })
 }
 
@@ -324,7 +326,7 @@ pub fn quit_analysis_translation(language: Language) -> String {
         Language::KO => "분석종료".to_string(),
         Language::TR => "Analizden çık".to_string(),
         Language::RU => "Закончить анализ".to_string(),
-        Language::PT | Language::BR => "Sair da análise".to_string(),
+        Language::PT | Language::PT_BR => "Sair da análise".to_string(),
         Language::EL => "Έξοδος ανάλυσης".to_string(),
         // Language::FA => "خروج از تحلیل".to_string(),
         Language::SV => "Avsluta analys".to_string(),
@@ -355,7 +357,7 @@ pub fn ask_clear_all_translation(language: Language) -> Text<'static, Renderer<S
         Language::FI => "Haluatko varmasti tyhjentää ilmoitukset?",
         Language::JA => "すべての通知を削除します。よろしいですか？",
         Language::UZ => "Haqiqatan ham bildirishnomalarni tozalamoqchimisiz?",
-        Language::BR => "Tem certeza que deseja remover as notificações?",
+        Language::PT_BR => "Tem certeza que deseja remover as notificações?",
     })
 }
 
@@ -380,7 +382,7 @@ pub fn clear_all_translation(language: Language) -> String {
         Language::FI => "Tyhjennä kaikki".to_string(),
         Language::JA => "すべて削除".to_string(),
         Language::UZ => "Barchasini tozalash".to_string(),
-        Language::BR => "Remover tudo".to_string(),   
+        Language::PT_BR => "Remover tudo".to_string(),
     }
 }
 
@@ -398,7 +400,7 @@ pub fn hide_translation(language: Language) -> &'static str {
         Language::KO => "숨기기",
         Language::TR => "Gizle",
         Language::RU => "Скрыть",
-        Language::PT | Language::BR => "Esconder",
+        Language::PT | Language::PT_BR => "Esconder",
         Language::EL => "Κλείσιμο",
         // Language::FA => "پنهان کردن",
         Language::SV => "Göm",
@@ -422,7 +424,7 @@ pub fn network_adapter_translation(language: Language) -> &'static str {
         Language::KO => "네트워크 어뎁터",
         Language::TR => "Ağ adaptörü",
         Language::RU => "Сетевой интерфейс",
-        Language::PT | Language::BR => "Adaptador de rede",
+        Language::PT | Language::PT_BR => "Adaptador de rede",
         Language::EL => "Προσαρμογέας δικτύου",
         // Language::FA => "مبدل شبکه",
         Language::SV => "Nätverksadapter",
@@ -494,7 +496,7 @@ pub fn no_addresses_translation(
         Language::UZ => format!("Trafik kuzatilmaydi, chunki siz tanlagan adapterda faol manzillar yo'q...\n\n\
                                 Tarmoq adapteri: {adapter}\n\n\
                                 Internetga ulanganingizga ishonchingiz komil bo'lsa, boshqa adapterni tanlashga harakat qiling"),
-        Language::BR => format!("Não é possível captar tráfego porque o adaptador selecionado não possui endereços ativos...\n\n\
+        Language::PT_BR => format!("Não é possível captar tráfego porque o adaptador selecionado não possui endereços ativos...\n\n\
                                 Adaptador de rede: {adapter}\n\n\
                                 Se tiver certeza que está conectado à internet, tente escolher outro adaptador."),
     })
@@ -563,7 +565,7 @@ pub fn waiting_translation(
             "Hali hech qanday trafik aniqlanmadi. Tarmoq paketlari kutilmoqda...\n\n\
             Tarmoq adapteri: {adapter}\n\n\
             Internetga ulanganingizga va to'g'ri adapterni tanlaganingizga ishonchingiz komilmi?"),
-        Language::BR => format!(
+        Language::PT_BR => format!(
             "Por enquanto nenhum tráfego foi captado. Aguardando por pacotes...\n\n\
             Adaptador de rede: {adapter}\n\n\
             Tem certeza de que está conectado à internet e selecionou o adaptador correto?"),
@@ -611,7 +613,7 @@ pub fn some_observed_translation(
         Language::RU => format!("Всего пакетов перехвачено: {observed}\n\n\
                                  Фильтровано пакетов: 0\n\n\
                                  Сетевые пакеты были перехвачены, но ни один из них не соответствует заданным фильтрам..."),
-        Language::PT | Language::BR => format!("Total de pacotes interceptados: {observed}\n\n\
+        Language::PT | Language::PT_BR => format!("Total de pacotes interceptados: {observed}\n\n\
                                 Pacotes filtrados: 0\n\n\
                                 Alguns pacotes foram interceptados, mas nenhum deles foi selecionado de acordo com os filtros especificados..."),
         Language::EL => format!("Συνολικά αναχαιτισμένα πακέτα: {observed}\n\n\
@@ -650,7 +652,7 @@ pub fn filtered_packets_translation(language: Language) -> &'static str {
         Language::KO => "필터링된 패킷",
         Language::TR => "Filtrelenen paketler",
         Language::RU => "Отфильтровано пакетов",
-        Language::PT | Language::BR => "Pacotes filtrados",
+        Language::PT | Language::PT_BR => "Pacotes filtrados",
         Language::EL => "Φιλτραρισμένα πακέτα",
         // Language::FA => "بسته های صاف شده",
         Language::SV => "Filtrerade paket",
@@ -665,7 +667,7 @@ pub fn filtered_bytes_translation(language: Language) -> &'static str {
         Language::EN => "Filtered bytes",
         Language::IT => "Byte filtrati",
         Language::FR => "Octets filtrés",
-        Language::ES | Language::PT | Language::BR => "Bytes filtrados",
+        Language::ES | Language::PT | Language::PT_BR => "Bytes filtrados",
         Language::PL => "Przechwycone bajty",
         Language::DE => "Gefilterte Bytes",
         Language::UK => "Відфільтровані байти",
@@ -707,7 +709,7 @@ pub fn of_total_translation(language: Language, percentage: &str) -> String {
         Language::RU => {
             format!("({percentage} от общего числа)")
         }
-        Language::PT | Language::BR => {
+        Language::PT | Language::PT_BR => {
             format!("({percentage} do total)")
         }
         Language::EL => {
@@ -834,7 +836,7 @@ pub fn error_translation(language: Language, error: &str) -> Text<'static, Rende
             "Произошла ошибка! \n\n\
                                  {error}"
         ),
-        Language::PT | Language::BR => format!(
+        Language::PT | Language::PT_BR => format!(
             "Ocorreu um erro! \n\n\
                                 {error}"
         ),
@@ -870,7 +872,7 @@ pub fn both_translation(language: Language) -> &'static str {
         Language::EN => "both",
         Language::IT => "entrambi",
         Language::FR => "les deux",
-        Language::ES | Language::PT | Language::BR => "ambos",
+        Language::ES | Language::PT | Language::PT_BR => "ambos",
         Language::PL => "oba",
         Language::DE => "beide",
         Language::UK => "обидва",
@@ -909,7 +911,7 @@ pub fn all_translation(language: Language) -> &'static str {
         Language::EN => "All",
         Language::IT => "Tutti",
         Language::FR => "Tous",
-        Language::ES | Language::PT | Language::BR => "Todos",
+        Language::ES | Language::PT | Language::PT_BR => "Todos",
         Language::PL => "Wszystkie",
         Language::DE => "Alle",
         Language::UK => "Усі",
@@ -941,7 +943,7 @@ pub fn packets_translation(language: Language) -> &'static str {
         Language::KO => "패킷",
         Language::TR | Language::SV => "paket",
         Language::RU => "пакетов",
-        Language::PT | Language::BR => "pacotes",
+        Language::PT | Language::PT_BR => "pacotes",
         Language::EL => "πακέτα",
         // Language::FA => "بسته ها",
         Language::FI => "paketit",
@@ -964,7 +966,7 @@ pub fn packets_chart_translation(language: Language) -> &'static str {
         Language::KO => "초당 패킷",
         Language::TR => "saniye başı paket",
         Language::RU => "пакетов в секунду",
-        Language::PT | Language::BR => "pacotes por segundo",
+        Language::PT | Language::PT_BR => "pacotes por segundo",
         Language::EL => "πακέτα ανά δευτερόλεπτο",
         // Language::FA => "بسته در ثانیه",
         Language::SV => "paket per sekund",
@@ -976,9 +978,13 @@ pub fn packets_chart_translation(language: Language) -> &'static str {
 
 pub fn bytes_translation(language: Language) -> &'static str {
     match language {
-        Language::EN | Language::ES | Language::PT | Language::DE | Language::EL | Language::SV | Language::BR => {
-            "bytes"
-        }
+        Language::EN
+        | Language::ES
+        | Language::PT
+        | Language::DE
+        | Language::EL
+        | Language::SV
+        | Language::PT_BR => "bytes",
         Language::IT => "byte",
         Language::FR => "octets",
         Language::PL => "bajty",
@@ -999,7 +1005,7 @@ pub fn bytes_chart_translation(language: Language) -> &'static str {
         Language::EN => "bytes per second",
         Language::IT => "byte al secondo",
         Language::FR => "octets par seconde",
-        Language::ES | Language::PT | Language::BR => "bytes por segundo",
+        Language::ES | Language::PT | Language::PT_BR => "bytes por segundo",
         Language::PL => "bajty na sekundę",
         Language::DE => "bytes pro Sekunde",
         Language::UK => "байти на секунду",
@@ -1031,7 +1037,7 @@ pub fn recent_report_translation(language: Language) -> &'static str {
         Language::KO => "가장 최근",
         Language::TR => "en son",
         Language::RU => "новейшие",
-        Language::PT | Language::BR => "mais recente",
+        Language::PT | Language::PT_BR => "mais recente",
         Language::EL => "πιο πρόσφατα",
         // Language::FA => "آخرین",
         Language::SV => "senaste",
@@ -1055,7 +1061,7 @@ pub fn packets_report_translation(language: Language) -> &'static str {
         Language::KO => "대부분의 패킷",
         Language::TR => "en çok paket",
         Language::RU => "больше всего пакетов",
-        Language::PT | Language::BR => "mais pacotes",
+        Language::PT | Language::PT_BR => "mais pacotes",
         Language::EL => "περισσότερα πακέτα",
         // Language::FA => "بیشترین بسته ها",
         Language::SV => "flest paket",
@@ -1079,7 +1085,7 @@ pub fn bytes_report_translation(language: Language) -> &'static str {
         Language::KO => "대부분의 바이트",
         Language::TR => "en çok bayt",
         Language::RU => "больше всего байт",
-        Language::PT | Language::BR => "mais bytes",
+        Language::PT | Language::PT_BR => "mais bytes",
         Language::EL => "περισσότερα bytes",
         // Language::FA => "بیشترین بایت ها",
         Language::SV => "flest bytes",
@@ -1124,7 +1130,7 @@ pub fn notifications_title_translation(language: Language) -> Text<'static, Rend
         Language::KO => "사용자 지정 알림",
         Language::TR => "Bildirimlerinizi özelleştirin",
         Language::RU => "Настройка уведомлений",
-        Language::PT | Language::BR => "Personalize as suas notificações",
+        Language::PT | Language::PT_BR => "Personalize as suas notificações",
         Language::EL => "Εξατομίκευση ειδοποιήσεων",
         // Language::FA => "اعلان های خود را سفارشی کنید",
         Language::SV => "Anpassa dina notifikationer",
@@ -1148,7 +1154,7 @@ pub fn appearance_title_translation(language: Language) -> Text<'static, Rendere
         Language::KO => "태마를 선택하세요",
         Language::TR => "Favori temanızı seçin",
         Language::RU => "Выберите предпочительную тему",
-        Language::PT | Language::BR => "Escolha o seu tema favorito",
+        Language::PT | Language::PT_BR => "Escolha o seu tema favorito",
         Language::EL => "Επίλεξε το αγαπημένο σου θέμα",
         // Language::FA => "زمینه دلخواه خود را انتخاب کنید",
         Language::SV => "Välj ditt favorittema",
@@ -1172,7 +1178,7 @@ pub fn languages_title_translation(language: Language) -> Text<'static, Renderer
         Language::KO => "언어를 선택하세요",
         Language::TR => "Dilinizi seçin",
         Language::RU => "Выберите язык",
-        Language::PT | Language::BR => "Selecione o seu idioma",
+        Language::PT | Language::PT_BR => "Selecione o seu idioma",
         Language::EL => "Επίλεξε τη γλώσσα σου",
         // Language::FA => "زبان خود را انتخاب کنید",
         Language::SV => "Välj ditt språk",
@@ -1196,7 +1202,7 @@ pub fn active_filters_translation(language: Language) -> &'static str {
         Language::KO => "활성화된 필터",
         Language::TR => "Aktif filtreler",
         Language::RU => "Выбранные фильтры",
-        Language::PT | Language::BR => "Filtros ativos",
+        Language::PT | Language::PT_BR => "Filtros ativos",
         Language::EL => "Ενεργά φίλτρα",
         // Language::FA => "صافی های فعال",
         Language::SV => "Aktiva filter",
@@ -1220,7 +1226,7 @@ pub fn none_translation(language: Language) -> String {
         Language::KO => "없음",
         Language::TR => "hiç biri",
         Language::RU => "ничего",
-        Language::PT | Language::BR => "nenhum",
+        Language::PT | Language::PT_BR => "nenhum",
         Language::EL => "κανένα",
         // Language::FA => "هیچ کدام",
         Language::SV => "inga",
@@ -1252,7 +1258,7 @@ pub fn yeti_night_translation(language: Language) -> &'static str {
         Language::FI => "Sniffnetin alkuperäinen tumma teema",
         Language::JA => "Sniffnet のオリジナル テーマ",
         Language::UZ => "Sniffnet-ning asl qora mavzusi",
-        Language::BR => "Tema escuro original do Sniffnet",
+        Language::PT_BR => "Tema escuro original do Sniffnet",
     }
 }
 
@@ -1276,7 +1282,7 @@ pub fn yeti_day_translation(language: Language) -> &'static str {
         Language::FI => "Sniffnetin alkuperäinen vaalea teema",
         Language::JA => "Sniffnet のオリジナル ライト テーマ",
         Language::UZ => "Sniffnet-ning asl oq mavzusi",
-        Language::BR => "Tema claro original do Sniffnet",
+        Language::PT_BR => "Tema claro original do Sniffnet",
     }
 }
 
@@ -1294,7 +1300,7 @@ pub fn deep_sea_translation(language: Language) -> &'static str {
         Language::KO => "네트워크 트레픽으로 바로가기",
         Language::TR => "Ağ trafiğine dalmak",
         Language::RU => "Для погружения в сетевой трафик",
-        Language::PT | Language::BR => "Para mergulhar no tráfego de rede",
+        Language::PT | Language::PT_BR => "Para mergulhar no tráfego de rede",
         Language::EL => "Βουτιά μέσα στην κίνηση του δικτύου",
         // Language::FA => "شیرجه رفتن در آمد و شد شبکه",
         Language::SV => "För att dyka ned i nätverkstrafiken",
@@ -1318,7 +1324,7 @@ pub fn mon_amour_translation(language: Language) -> &'static str {
         Language::KO => "사랑스러운 몽환가들을 위한 테마",
         Language::TR => "Hayal perestler için yapılmış güzel tema",
         Language::RU => "Милая тема для мечтателей",
-        Language::PT | Language::BR => "Tema encantador feito para sonhadores",
+        Language::PT | Language::PT_BR => "Tema encantador feito para sonhadores",
         Language::EL => "Φτιαγμένο για ονειροπόλους",
         // Language::FA => "زمینه دلپذیر ساخته شده برای رویا پردازان",
         Language::SV => "Ljuvligt tema gjort för drömmare",
@@ -1342,7 +1348,7 @@ pub fn incoming_translation(language: Language) -> &'static str {
         Language::KO => "수신중",
         Language::TR => "Gelen",
         Language::RU => "Входящий",
-        Language::PT | Language::BR => "Entrando",
+        Language::PT | Language::PT_BR => "Entrando",
         Language::EL => "Εισερχόμενα",
         // Language::FA => "ورودی",
         Language::SV => "Inkommande",
@@ -1366,7 +1372,7 @@ pub fn outgoing_translation(language: Language) -> &'static str {
         Language::KO => "발신중",
         Language::TR => "Giden",
         Language::RU => "Исходящий",
-        Language::PT | Language::BR => "Saindo",
+        Language::PT | Language::PT_BR => "Saindo",
         Language::EL => "Εξερχόμενα",
         // Language::FA => "خروجی",
         Language::SV => "Utgående",
@@ -1389,7 +1395,7 @@ pub fn notifications_translation(language: Language) -> &'static str {
         Language::KO => "알림",
         Language::TR => "Bildirimler",
         Language::RU => "Уведомления",
-        Language::PT | Language::BR => "Notificações",
+        Language::PT | Language::PT_BR => "Notificações",
         Language::EL => "Ειδοποιήσεις",
         // Language::FA => "اعلان ها",
         Language::SV => "Notifikationer",
@@ -1402,7 +1408,7 @@ pub fn style_translation(language: Language) -> &'static str {
     match language {
         Language::EN | Language::FR => "Style",
         Language::IT => "Stile",
-        Language::ES | Language::PT | Language::BR => "Estilo",
+        Language::ES | Language::PT | Language::PT_BR => "Estilo",
         Language::PL => "Styl",
         Language::DE | Language::RO | Language::TR | Language::SV => "Stil",
         Language::UK | Language::RU => "Стиль",
@@ -1430,7 +1436,7 @@ pub fn language_translation(language: Language) -> &'static str {
         Language::KO => "언어",
         Language::TR => "Dil",
         Language::RU => "Язык",
-        Language::PT | Language::BR => "Língua",
+        Language::PT | Language::PT_BR => "Língua",
         Language::EL => "Γλώσσα",
         // Language::FA => "زبان",
         Language::SV => "Språk",
@@ -1454,7 +1460,7 @@ pub fn overview_translation(language: Language) -> &'static str {
         Language::KO => "개요",
         Language::TR => "Ön izleme",
         Language::RU => "Обзор",
-        Language::PT | Language::BR => "Visão geral",
+        Language::PT | Language::PT_BR => "Visão geral",
         Language::EL => "επισκόπηση",
         // Language::FA => "نمای کلی",
         Language::SV => "Översikt",
@@ -1485,7 +1491,7 @@ pub fn packets_threshold_translation(language: Language) -> &'static str {
         Language::FI => "Ilmoita minulle, kun pakettiraja on ylittynyt",
         Language::JA => "パケット数の閾値を超過した場合に通知する",
         Language::UZ => "Paket chegarasi oshib ketganda xabar bering",
-        Language::BR => "Notifique-me quando algum limite de pacotes for excedido",
+        Language::PT_BR => "Notifique-me quando algum limite de pacotes for excedido",
     }
 }
 
@@ -1510,7 +1516,7 @@ pub fn bytes_threshold_translation(language: Language) -> &'static str {
         Language::FI => "Ilmoita minulle, kun tavuraja on ylittynyt",
         Language::JA => "バイト量の閾値を超過した場合に通知する",
         Language::UZ => "Bayt chegarasi oshib ketganda menga xabar bering",
-        Language::BR => "Notifique-me quando algum limite de bytes for excedido",
+        Language::PT_BR => "Notifique-me quando algum limite de bytes for excedido",
     }
 }
 
@@ -1519,7 +1525,7 @@ pub fn per_second_translation(language: Language) -> &'static str {
         Language::EN => "(per second)",
         Language::IT => "(al secondo)",
         Language::FR => "(par seconde)",
-        Language::ES | Language::PT | Language::BR => "(por segundo)",
+        Language::ES | Language::PT | Language::PT_BR => "(por segundo)",
         Language::PL => "(na sekundę)",
         Language::DE => "(pro Sekunde)",
         Language::UK => "(на секунду)",
@@ -1557,7 +1563,7 @@ pub fn specify_multiples_translation(language: Language) -> &'static str {
         Language::FI => "; voit myös määrittää 'K', 'M' tai 'G'",
         Language::JA => "; 'K', 'M', 'G' が選択可能です",
         Language::UZ => "; 'K', 'M' va 'G' ni ham belgilashingiz mumkin",
-        Language::BR => "; você também pode especificar 'K', 'M' e 'G'",
+        Language::PT_BR => "; você também pode especificar 'K', 'M' e 'G'",
     }
 }
 
@@ -1577,7 +1583,9 @@ pub fn favorite_notification_translation(language: Language) -> &'static str {
         Language::KO => "즐겨찾기에서 새 데이터가 교환될 때 알림",
         Language::TR => "Favorilerimde veri akışı olduğunda beni uyar",
         Language::RU => "Уведомить, если произошёл обмен данными в соединениях из избранного",
-        Language::PT | Language::BR => "Notificar-me quando novos dados forem trocados dos meus favoritos",
+        Language::PT | Language::PT_BR => {
+            "Notificar-me quando novos dados forem trocados dos meus favoritos"
+        }
         Language::EL => "Ειδοποίησέ με όταν νέα δεδομένα έχουν ανταλλαγεί από τα αγαπημένα μου",
         // Language::FA => "به من اطلاع بده وقتی داده جدید از پسندیده های من مبادله شد",
         Language::SV => "Notifiera mig när ny data utbyts av mina favoriter",
@@ -1601,7 +1609,7 @@ pub fn threshold_translation(language: Language) -> String {
         Language::KO => "임계값".to_string(),
         Language::TR => "Eşik".to_string(),
         Language::RU => "Порог".to_string(),
-        Language::PT | Language::BR => "Limite".to_string(),
+        Language::PT | Language::PT_BR => "Limite".to_string(),
         Language::EL => "όριο".to_string(),
         // Language::FA => "آستانه".to_string(),
         Language::SV => "Gräns".to_string(),
@@ -1613,7 +1621,7 @@ pub fn threshold_translation(language: Language) -> String {
 
 pub fn volume_translation(language: Language) -> &'static str {
     match language {
-        Language::EN | Language::IT | Language::FR | Language::PT | Language::BR => "Volume",
+        Language::EN | Language::IT | Language::FR | Language::PT | Language::PT_BR => "Volume",
         Language::ES => "Volumen",
         Language::PL => "Głośność",
         Language::DE => "Lautstärke",
@@ -1644,7 +1652,7 @@ pub fn sound_translation(language: Language) -> &'static str {
         Language::RO => "Sunet",
         Language::KO => "사운드",
         Language::TR => "Ses",
-        Language::PT | Language::BR => "Som",
+        Language::PT | Language::PT_BR => "Som",
         Language::EL => "Ήχος",
         // Language::FA => "صدا",
         Language::SV => "Ljud",
@@ -1667,7 +1675,7 @@ pub fn open_report_translation(language: Language) -> &'static str {
         Language::KO => "전체 보고서 열기",
         Language::TR => "Tam raporu aç",
         Language::RU => "Открыть полный отчёт",
-        Language::PT | Language::BR => "Abrir relatório completo",
+        Language::PT | Language::PT_BR => "Abrir relatório completo",
         Language::EL => "Άνοιγμα της πλήρους αναφοράς",
         // Language::FA => "گزارش کامل را باز کن",
         Language::SV => "Öppna fullständig rapport",
@@ -1691,7 +1699,7 @@ pub fn bytes_exceeded_translation(language: Language) -> &'static str {
         Language::KO => "바이트 임계값 초과!",
         Language::TR => "Bayt eşik değeri aşıldı!",
         Language::RU => "Порог в байтах превышен!",
-        Language::PT | Language::BR => "Limite de bytes excedido!",
+        Language::PT | Language::PT_BR => "Limite de bytes excedido!",
         Language::EL => "Το όριο των bytes ξεπεράστηκε!",
         // Language::FA => "آستانه بایت فراتر رفت!",
         Language::SV => "Gräns för bytes överskriden!",
@@ -1715,7 +1723,7 @@ pub fn bytes_exceeded_value_translation(language: Language, value: &str) -> Stri
         Language::KO => format!("바이트 {value} 가 교환되었습니다"),
         Language::TR => format!("{value} aktarıldı"),
         Language::RU => format!("{value} обмена информацией"),
-        Language::PT | Language::BR => format!("Foram trocados {value}"),
+        Language::PT | Language::PT_BR => format!("Foram trocados {value}"),
         Language::EL => format!("{value} έχουν ανταλλαγεί"),
         // Language::FA => format!("{value} بایت مبادله شده است"),
         Language::SV => format!("{value} har utbytts"),
@@ -1739,7 +1747,7 @@ pub fn packets_exceeded_translation(language: Language) -> &'static str {
         Language::KO => "패킷 임계값 초과!",
         Language::TR => "Paket eşik değeri aşıldı!",
         Language::RU => "Порог по числу пакетов превышен!",
-        Language::PT | Language::BR => "Limite de pacotes excedido!",
+        Language::PT | Language::PT_BR => "Limite de pacotes excedido!",
         Language::EL => "Το όριο των πακέτων ξεπεράστηκε!",
         // Language::FA => "آستانه بسته فراتر رفت!",
         Language::SV => "Paketgräns överskriden!",
@@ -1772,7 +1780,7 @@ pub fn packets_exceeded_value_translation(language: Language, value: u32) -> Str
         Language::KO => format!("패킷 {value} 가 교환되었습니다"),
         Language::TR => format!("{value} paket aktarıldı"),
         Language::RU => format!("{value} пакет(ов) обмена информацией"),
-        Language::PT | Language::BR => match value {
+        Language::PT | Language::PT_BR => match value {
             1 => "Foi trocado 1 pacote".to_owned(),
             npackets => format!("Foram trocados {npackets} pacotes"),
         },
@@ -1808,7 +1816,7 @@ pub fn favorite_transmitted_translation(language: Language) -> &'static str {
         Language::KO => "즐겨찾기에서 새 데이터 교환",
         Language::TR => "Favorilerden yeni veri aktarıldı!",
         Language::RU => "Новый обмен данными в избранных соедиениях!",
-        Language::PT | Language::BR => "Novos dados trocados dos favoritos!",
+        Language::PT | Language::PT_BR => "Novos dados trocados dos favoritos!",
         Language::EL => "Καινούρια δεδομένα έχουν ανταλλαγεί στα αγαπημένα!",
         // Language::FA => "مبادله داده جدید از پسندیده ها!",
         Language::SV => "Ny data utbytt av favoriter!",
@@ -1877,7 +1885,7 @@ pub fn no_notifications_set_translation(language: Language) -> Text<'static, Ren
         Language::UZ => "Siz hali bildirishnomalarni yoqmagansiz!\n\n\
                         Ularni faollashtirgandan so'ng, bu sahifada bildirishnomalaringiz jurnali ko'rsatiladi\n\n\
                         Sozlamalardan bildirishnomalarni yoqishingiz mumkin:",
-        Language::BR => "Ainda não ativou as notificações!\n\n\
+        Language::PT_BR => "Ainda não ativou as notificações!\n\n\
                         Depois de ativá-las, esta página irá mostrar um registo das suas notificações\n\n\
                         Pode ativar as notificações nas configurações:",
     })
@@ -1963,7 +1971,7 @@ pub fn no_notifications_received_translation(
             "Ayni paytda ko'rsatiladigan hech narsa yo'q...\n\n\
                                 Bildirishnomalar kelganda, ular shu yerda ko'rsatiladi"
         }
-        Language::BR => {
+        Language::PT_BR => {
             "Nada para ver no momento...\n\n\
                                 Quando receber uma notificação, ela será mostrada aqui"
         }
@@ -1984,7 +1992,7 @@ pub fn only_last_30_translation(language: Language) -> &'static str {
         Language::KO => "최근 30개의 알림만 표시됩니다",
         Language::TR => "Sadece son 30 bildirim gösterilmektedir",
         Language::RU => "Тут показываются только последние 30 уведомлений",
-        Language::PT | Language::BR => "São mostradas apenas as últimas 30 notificações",
+        Language::PT | Language::PT_BR => "São mostradas apenas as últimas 30 notificações",
         Language::EL => "Μόνο οι τελευταίες 30 ειδοποιήσεις απεικονίζονται",
         // Language::FA => "تنها ۳۰ اعلان آخر نمایش داده شده اند",
         Language::SV => "Endast de senaste 30 notifikationerna visas",

--- a/src/translations/translations.rs
+++ b/src/translations/translations.rs
@@ -25,6 +25,7 @@ pub fn choose_adapters_translation(language: Language) -> Text<'static, Renderer
         Language::FI => "Valitse tarkasteltava verkkosovitin",
         Language::JA => "使用するネットワーク アダプターを選択してください",
         Language::UZ => "Tekshirish uchun tarmoq adapterini tanlang",
+        Language::BR => "Selecione o adaptador de rede a ser inspecionado",
     })
 }
 
@@ -42,7 +43,7 @@ pub fn application_protocol_translation(language: Language) -> &'static str {
         Language::KO => "어플리케이션 프로토콜",
         Language::TR => "Uygulama protokolü",
         Language::RU => "Прикладной протокол",
-        Language::PT => "Protocolo de aplicação",
+        Language::PT | Language::BR => "Protocolo de aplicação",
         Language::EL => "Πρωτόκολλο εφαρμογής",
         // Language::FA => "پیوندنامهٔ درخواست",
         Language::SV => "Applikationsprotokoll",
@@ -66,7 +67,7 @@ pub fn select_filters_translation(language: Language) -> Text<'static, Renderer<
         Language::KO => "네트워크 트레픽에 적용할 필터 선택",
         Language::TR => "Ağ trafiğine uygulanacak filtreleri seçiniz",
         Language::RU => "Выберите фильтры для применения к сетевому трафику",
-        Language::PT => "Selecione os filtros a serem aplicados no tráfego de rede",
+        Language::PT | Language::BR => "Selecione os filtros a serem aplicados no tráfego de rede",
         Language::EL => "Επίλεξε τα φίλτρα για εφαρμογή στην κίνηση του δικτύου",
         // Language::FA => "صافی ها را جهت اعمال بر آمد و شد شبکه انتخاب کنید",
         Language::SV => "Välj filtren som ska appliceras på nätverkstrafiken",
@@ -94,6 +95,7 @@ pub fn start_translation(language: Language) -> &'static str {
         Language::FI => "Aloita!",
         Language::JA => "開始！",
         Language::UZ => "Boshlash!",
+        Language::BR => "Iniciar!",
     }
 }
 
@@ -109,7 +111,7 @@ pub fn address_translation(language: Language) -> &'static str {
         Language::RO => "Adresă",
         Language::KO => "주소",
         Language::RU => "Адрес",
-        Language::PT => "Endereço",
+        Language::PT | Language::BR => "Endereço",
         Language::EL => "Διεύθυνση",
         // Language::FA => "نشانی",
         Language::SV => "Adress",
@@ -133,7 +135,7 @@ pub fn addresses_translation(language: Language) -> &'static str {
         Language::KO => "주소",
         Language::TR => "Adresler",
         Language::RU => "Адреса",
-        Language::PT => "Endereços",
+        Language::PT | Language::BR => "Endereços",
         Language::EL => "Διευθύνσεις",
         // Language::FA => "نشانی ها",
         Language::SV => "Adresser",
@@ -157,7 +159,7 @@ pub fn ip_version_translation(language: Language) -> Text<'static, Renderer<Styl
         Language::KO => "IP 버전",
         Language::TR => "IP versiyonu",
         Language::RU => "Версия IP",
-        Language::PT => "Versão de IP",
+        Language::PT | Language::BR => "Versão de IP",
         Language::EL => "Έκδοση IP",
         // Language::FA => "نسخهٔ IP",
         Language::SV => "IP-version",
@@ -172,7 +174,7 @@ pub fn transport_protocol_translation(language: Language) -> &'static str {
         Language::EN => "Transport protocol",
         Language::IT => "Protocollo di trasporto",
         Language::FR => "Protocole de transport",
-        Language::ES | Language::PT => "Protocolo de transporte",
+        Language::ES | Language::PT | Language::BR => "Protocolo de transporte",
         Language::PL => "Protokół transportowy",
         Language::DE => "Netzwerkprotokoll",
         Language::UK => "Транспортний протокол",
@@ -204,7 +206,7 @@ pub fn traffic_rate_translation(language: Language) -> Text<'static, Renderer<St
         Language::KO => "트레픽 속도",
         Language::TR => "Trafik oranı",
         Language::RU => "Cкорость трафика",
-        Language::PT => "Taxa de tráfego",
+        Language::PT | Language::BR => "Taxa de tráfego",
         Language::EL => "Ρυθμός κίνησης",
         // Language::FA => "نرخ آمد و شد",
         Language::SV => "Datafrekvens",
@@ -228,7 +230,7 @@ pub fn traffic_rate_translation(language: Language) -> Text<'static, Renderer<St
 //         Language::KO => "관련 연결:",
 //         Language::TR => "İlgili bağlantılar:",
 //         Language::RU => "Важные подключения:",
-//         Language::PT => "Conexões relevantes:",
+//         Language::PT | Language::BR => "Conexões relevantes:",
 //         Language::EL => "Σχετικές συνδέσεις:",
 //         Language::FA => "پیوند های خویشاوند:",
 //         Language::SE => "Relevanta anslutningar:",
@@ -250,7 +252,7 @@ pub fn settings_translation(language: Language) -> &'static str {
         Language::KO => "설정",
         Language::TR => "Ayarlar",
         Language::RU => "Настройки",
-        Language::PT => "Configurações",
+        Language::PT | Language::BR => "Configurações",
         Language::EL => "Ρυθμίσεις",
         // Language::FA => "پیکربندی",
         Language::SV => "Inställningar",
@@ -274,7 +276,7 @@ pub fn yes_translation(language: Language) -> Text<'static, Renderer<StyleType>>
         Language::KO => "네",
         Language::TR => "Evet",
         Language::RU => "Да",
-        Language::PT => "Sim",
+        Language::PT | Language::BR => "Sim",
         Language::EL => "Ναι",
         // Language::FA => "بله",
         Language::FI => "Kyllä",
@@ -304,6 +306,7 @@ pub fn ask_quit_translation(language: Language) -> Text<'static, Renderer<StyleT
         Language::FI => "Haluatko varmasti lopettaa analyysin?",
         Language::JA => "分析を終了しますか？",
         Language::UZ => "Tahlildan chiqishga ishonchingiz komilmi?",
+        Language::BR => "Tem certeza que deseja sair desta análise?",
     })
 }
 
@@ -321,7 +324,7 @@ pub fn quit_analysis_translation(language: Language) -> String {
         Language::KO => "분석종료".to_string(),
         Language::TR => "Analizden çık".to_string(),
         Language::RU => "Закончить анализ".to_string(),
-        Language::PT => "Sair da análise".to_string(),
+        Language::PT | Language::BR => "Sair da análise".to_string(),
         Language::EL => "Έξοδος ανάλυσης".to_string(),
         // Language::FA => "خروج از تحلیل".to_string(),
         Language::SV => "Avsluta analys".to_string(),
@@ -352,6 +355,7 @@ pub fn ask_clear_all_translation(language: Language) -> Text<'static, Renderer<S
         Language::FI => "Haluatko varmasti tyhjentää ilmoitukset?",
         Language::JA => "すべての通知を削除します。よろしいですか？",
         Language::UZ => "Haqiqatan ham bildirishnomalarni tozalamoqchimisiz?",
+        Language::BR => "Tem certeza que deseja remover as notificações?",
     })
 }
 
@@ -376,6 +380,7 @@ pub fn clear_all_translation(language: Language) -> String {
         Language::FI => "Tyhjennä kaikki".to_string(),
         Language::JA => "すべて削除".to_string(),
         Language::UZ => "Barchasini tozalash".to_string(),
+        Language::BR => "Remover tudo".to_string(),   
     }
 }
 
@@ -393,7 +398,7 @@ pub fn hide_translation(language: Language) -> &'static str {
         Language::KO => "숨기기",
         Language::TR => "Gizle",
         Language::RU => "Скрыть",
-        Language::PT => "Esconder",
+        Language::PT | Language::BR => "Esconder",
         Language::EL => "Κλείσιμο",
         // Language::FA => "پنهان کردن",
         Language::SV => "Göm",
@@ -417,7 +422,7 @@ pub fn network_adapter_translation(language: Language) -> &'static str {
         Language::KO => "네트워크 어뎁터",
         Language::TR => "Ağ adaptörü",
         Language::RU => "Сетевой интерфейс",
-        Language::PT => "Adaptador de rede",
+        Language::PT | Language::BR => "Adaptador de rede",
         Language::EL => "Προσαρμογέας δικτύου",
         // Language::FA => "مبدل شبکه",
         Language::SV => "Nätverksadapter",
@@ -489,6 +494,9 @@ pub fn no_addresses_translation(
         Language::UZ => format!("Trafik kuzatilmaydi, chunki siz tanlagan adapterda faol manzillar yo'q...\n\n\
                                 Tarmoq adapteri: {adapter}\n\n\
                                 Internetga ulanganingizga ishonchingiz komil bo'lsa, boshqa adapterni tanlashga harakat qiling"),
+        Language::BR => format!("Não é possível captar tráfego porque o adaptador selecionado não possui endereços ativos...\n\n\
+                                Adaptador de rede: {adapter}\n\n\
+                                Se tiver certeza que está conectado à internet, tente escolher outro adaptador."),
     })
 }
 
@@ -555,6 +563,10 @@ pub fn waiting_translation(
             "Hali hech qanday trafik aniqlanmadi. Tarmoq paketlari kutilmoqda...\n\n\
             Tarmoq adapteri: {adapter}\n\n\
             Internetga ulanganingizga va to'g'ri adapterni tanlaganingizga ishonchingiz komilmi?"),
+        Language::BR => format!(
+            "Por enquanto nenhum tráfego foi captado. Aguardando por pacotes...\n\n\
+            Adaptador de rede: {adapter}\n\n\
+            Tem certeza de que está conectado à internet e selecionou o adaptador correto?"),
     })
 }
 
@@ -599,7 +611,7 @@ pub fn some_observed_translation(
         Language::RU => format!("Всего пакетов перехвачено: {observed}\n\n\
                                  Фильтровано пакетов: 0\n\n\
                                  Сетевые пакеты были перехвачены, но ни один из них не соответствует заданным фильтрам..."),
-        Language::PT => format!("Total de pacotes interceptados: {observed}\n\n\
+        Language::PT | Language::BR => format!("Total de pacotes interceptados: {observed}\n\n\
                                 Pacotes filtrados: 0\n\n\
                                 Alguns pacotes foram interceptados, mas nenhum deles foi selecionado de acordo com os filtros especificados..."),
         Language::EL => format!("Συνολικά αναχαιτισμένα πακέτα: {observed}\n\n\
@@ -638,7 +650,7 @@ pub fn filtered_packets_translation(language: Language) -> &'static str {
         Language::KO => "필터링된 패킷",
         Language::TR => "Filtrelenen paketler",
         Language::RU => "Отфильтровано пакетов",
-        Language::PT => "Pacotes filtrados",
+        Language::PT | Language::BR => "Pacotes filtrados",
         Language::EL => "Φιλτραρισμένα πακέτα",
         // Language::FA => "بسته های صاف شده",
         Language::SV => "Filtrerade paket",
@@ -653,7 +665,7 @@ pub fn filtered_bytes_translation(language: Language) -> &'static str {
         Language::EN => "Filtered bytes",
         Language::IT => "Byte filtrati",
         Language::FR => "Octets filtrés",
-        Language::ES | Language::PT => "Bytes filtrados",
+        Language::ES | Language::PT | Language::BR => "Bytes filtrados",
         Language::PL => "Przechwycone bajty",
         Language::DE => "Gefilterte Bytes",
         Language::UK => "Відфільтровані байти",
@@ -695,7 +707,7 @@ pub fn of_total_translation(language: Language, percentage: &str) -> String {
         Language::RU => {
             format!("({percentage} от общего числа)")
         }
-        Language::PT => {
+        Language::PT | Language::BR => {
             format!("({percentage} do total)")
         }
         Language::EL => {
@@ -723,7 +735,7 @@ pub fn of_total_translation(language: Language, percentage: &str) -> String {
 //         Language::KO => "애플리케이션 프로토콜당 필터링된 패킷 수:",
 //         Language::TR => "Uygulama protokolü bazında filtrelenen paketler:",
 //         Language::RU => "Отфильтровано пакетов прикладного протокола:",
-//         Language::PT => "Pacotes filtrados por protocolo de aplicação:",
+//         Language::PT | Language::BR => "Pacotes filtrados por protocolo de aplicação:",
 //         Language::EL => "Φιλτραρισμένα πακέτα ανά πρωτόκολλο εφαρμογής:",
 //         Language::FA => "بسته های صاف شده برای هر پیوندنامهٔ درخواست:",
 //         Language::SE => "Filtrerade paket per applikationsprotokoll:",
@@ -767,6 +779,8 @@ pub fn of_total_translation(language: Language, percentage: &str) -> String {
 //                          För att lägga till anslutningar till dina favoriter, klicka på stjärnsymbolen nära anslutningen.",
 //         Language::UZ => "Ayni paytda ko'rsatiladigan hech narsa yo'q.\n\
 //         Ulanishni sevimlilar ro'yhatiga qo'shish uchun ulanish yaqinidagi yulduzcha belgisini bosing."
+//         Language::BR => "Nada para mostrar no momento.\n\
+//                          Para favoritar uma conexão, clique na estrela perto da mesma.",
 //     })
 // }
 
@@ -820,7 +834,7 @@ pub fn error_translation(language: Language, error: &str) -> Text<'static, Rende
             "Произошла ошибка! \n\n\
                                  {error}"
         ),
-        Language::PT => format!(
+        Language::PT | Language::BR => format!(
             "Ocorreu um erro! \n\n\
                                 {error}"
         ),
@@ -856,7 +870,7 @@ pub fn both_translation(language: Language) -> &'static str {
         Language::EN => "both",
         Language::IT => "entrambi",
         Language::FR => "les deux",
-        Language::ES | Language::PT => "ambos",
+        Language::ES | Language::PT | Language::BR => "ambos",
         Language::PL => "oba",
         Language::DE => "beide",
         Language::UK => "обидва",
@@ -886,6 +900,7 @@ pub fn both_translation(language: Language) -> &'static str {
 //         Language::FA => "همهٔ پیوندنامه ها",
 //         Language::SE => "Alla protokoll",
 //         Language::UZ => "Barcha protokollar"
+//         Language::BR => "Todos os protocolos",
 //     }
 // }
 
@@ -894,7 +909,7 @@ pub fn all_translation(language: Language) -> &'static str {
         Language::EN => "All",
         Language::IT => "Tutti",
         Language::FR => "Tous",
-        Language::ES | Language::PT => "Todos",
+        Language::ES | Language::PT | Language::BR => "Todos",
         Language::PL => "Wszystkie",
         Language::DE => "Alle",
         Language::UK => "Усі",
@@ -926,7 +941,7 @@ pub fn packets_translation(language: Language) -> &'static str {
         Language::KO => "패킷",
         Language::TR | Language::SV => "paket",
         Language::RU => "пакетов",
-        Language::PT => "pacotes",
+        Language::PT | Language::BR => "pacotes",
         Language::EL => "πακέτα",
         // Language::FA => "بسته ها",
         Language::FI => "paketit",
@@ -949,7 +964,7 @@ pub fn packets_chart_translation(language: Language) -> &'static str {
         Language::KO => "초당 패킷",
         Language::TR => "saniye başı paket",
         Language::RU => "пакетов в секунду",
-        Language::PT => "pacotes por segundo",
+        Language::PT | Language::BR => "pacotes por segundo",
         Language::EL => "πακέτα ανά δευτερόλεπτο",
         // Language::FA => "بسته در ثانیه",
         Language::SV => "paket per sekund",
@@ -961,7 +976,7 @@ pub fn packets_chart_translation(language: Language) -> &'static str {
 
 pub fn bytes_translation(language: Language) -> &'static str {
     match language {
-        Language::EN | Language::ES | Language::PT | Language::DE | Language::EL | Language::SV => {
+        Language::EN | Language::ES | Language::PT | Language::DE | Language::EL | Language::SV | Language::BR => {
             "bytes"
         }
         Language::IT => "byte",
@@ -984,7 +999,7 @@ pub fn bytes_chart_translation(language: Language) -> &'static str {
         Language::EN => "bytes per second",
         Language::IT => "byte al secondo",
         Language::FR => "octets par seconde",
-        Language::ES | Language::PT => "bytes por segundo",
+        Language::ES | Language::PT | Language::BR => "bytes por segundo",
         Language::PL => "bajty na sekundę",
         Language::DE => "bytes pro Sekunde",
         Language::UK => "байти на секунду",
@@ -1016,7 +1031,7 @@ pub fn recent_report_translation(language: Language) -> &'static str {
         Language::KO => "가장 최근",
         Language::TR => "en son",
         Language::RU => "новейшие",
-        Language::PT => "mais recente",
+        Language::PT | Language::BR => "mais recente",
         Language::EL => "πιο πρόσφατα",
         // Language::FA => "آخرین",
         Language::SV => "senaste",
@@ -1040,7 +1055,7 @@ pub fn packets_report_translation(language: Language) -> &'static str {
         Language::KO => "대부분의 패킷",
         Language::TR => "en çok paket",
         Language::RU => "больше всего пакетов",
-        Language::PT => "mais pacotes",
+        Language::PT | Language::BR => "mais pacotes",
         Language::EL => "περισσότερα πακέτα",
         // Language::FA => "بیشترین بسته ها",
         Language::SV => "flest paket",
@@ -1064,7 +1079,7 @@ pub fn bytes_report_translation(language: Language) -> &'static str {
         Language::KO => "대부분의 바이트",
         Language::TR => "en çok bayt",
         Language::RU => "больше всего байт",
-        Language::PT => "mais bytes",
+        Language::PT | Language::BR => "mais bytes",
         Language::EL => "περισσότερα bytes",
         // Language::FA => "بیشترین بایت ها",
         Language::SV => "flest bytes",
@@ -1079,7 +1094,7 @@ pub fn bytes_report_translation(language: Language) -> &'static str {
 //         Language::EN => "favorites",
 //         Language::IT => "preferiti",
 //         Language::FR => "favoris",
-//         Language::ES | Language::PT => "favoritos",
+//         Language::ES | Language::PT | Language::BR => "favoritos",
 //         Language::PL => "ulubione",
 //         Language::DE => "Favoriten",
 //         Language::UK => "улюблені",
@@ -1109,7 +1124,7 @@ pub fn notifications_title_translation(language: Language) -> Text<'static, Rend
         Language::KO => "사용자 지정 알림",
         Language::TR => "Bildirimlerinizi özelleştirin",
         Language::RU => "Настройка уведомлений",
-        Language::PT => "Personalize as suas notificações",
+        Language::PT | Language::BR => "Personalize as suas notificações",
         Language::EL => "Εξατομίκευση ειδοποιήσεων",
         // Language::FA => "اعلان های خود را سفارشی کنید",
         Language::SV => "Anpassa dina notifikationer",
@@ -1133,7 +1148,7 @@ pub fn appearance_title_translation(language: Language) -> Text<'static, Rendere
         Language::KO => "태마를 선택하세요",
         Language::TR => "Favori temanızı seçin",
         Language::RU => "Выберите предпочительную тему",
-        Language::PT => "Escolha o seu tema favorito",
+        Language::PT | Language::BR => "Escolha o seu tema favorito",
         Language::EL => "Επίλεξε το αγαπημένο σου θέμα",
         // Language::FA => "زمینه دلخواه خود را انتخاب کنید",
         Language::SV => "Välj ditt favorittema",
@@ -1157,7 +1172,7 @@ pub fn languages_title_translation(language: Language) -> Text<'static, Renderer
         Language::KO => "언어를 선택하세요",
         Language::TR => "Dilinizi seçin",
         Language::RU => "Выберите язык",
-        Language::PT => "Selecione o seu idioma",
+        Language::PT | Language::BR => "Selecione o seu idioma",
         Language::EL => "Επίλεξε τη γλώσσα σου",
         // Language::FA => "زبان خود را انتخاب کنید",
         Language::SV => "Välj ditt språk",
@@ -1181,7 +1196,7 @@ pub fn active_filters_translation(language: Language) -> &'static str {
         Language::KO => "활성화된 필터",
         Language::TR => "Aktif filtreler",
         Language::RU => "Выбранные фильтры",
-        Language::PT => "Filtros ativos",
+        Language::PT | Language::BR => "Filtros ativos",
         Language::EL => "Ενεργά φίλτρα",
         // Language::FA => "صافی های فعال",
         Language::SV => "Aktiva filter",
@@ -1205,7 +1220,7 @@ pub fn none_translation(language: Language) -> String {
         Language::KO => "없음",
         Language::TR => "hiç biri",
         Language::RU => "ничего",
-        Language::PT => "nenhum",
+        Language::PT | Language::BR => "nenhum",
         Language::EL => "κανένα",
         // Language::FA => "هیچ کدام",
         Language::SV => "inga",
@@ -1237,6 +1252,7 @@ pub fn yeti_night_translation(language: Language) -> &'static str {
         Language::FI => "Sniffnetin alkuperäinen tumma teema",
         Language::JA => "Sniffnet のオリジナル テーマ",
         Language::UZ => "Sniffnet-ning asl qora mavzusi",
+        Language::BR => "Tema escuro original do Sniffnet",
     }
 }
 
@@ -1260,6 +1276,7 @@ pub fn yeti_day_translation(language: Language) -> &'static str {
         Language::FI => "Sniffnetin alkuperäinen vaalea teema",
         Language::JA => "Sniffnet のオリジナル ライト テーマ",
         Language::UZ => "Sniffnet-ning asl oq mavzusi",
+        Language::BR => "Tema claro original do Sniffnet",
     }
 }
 
@@ -1277,7 +1294,7 @@ pub fn deep_sea_translation(language: Language) -> &'static str {
         Language::KO => "네트워크 트레픽으로 바로가기",
         Language::TR => "Ağ trafiğine dalmak",
         Language::RU => "Для погружения в сетевой трафик",
-        Language::PT => "Para mergulhar no tráfego de rede",
+        Language::PT | Language::BR => "Para mergulhar no tráfego de rede",
         Language::EL => "Βουτιά μέσα στην κίνηση του δικτύου",
         // Language::FA => "شیرجه رفتن در آمد و شد شبکه",
         Language::SV => "För att dyka ned i nätverkstrafiken",
@@ -1301,7 +1318,7 @@ pub fn mon_amour_translation(language: Language) -> &'static str {
         Language::KO => "사랑스러운 몽환가들을 위한 테마",
         Language::TR => "Hayal perestler için yapılmış güzel tema",
         Language::RU => "Милая тема для мечтателей",
-        Language::PT => "Tema encantador feito para sonhadores",
+        Language::PT | Language::BR => "Tema encantador feito para sonhadores",
         Language::EL => "Φτιαγμένο για ονειροπόλους",
         // Language::FA => "زمینه دلپذیر ساخته شده برای رویا پردازان",
         Language::SV => "Ljuvligt tema gjort för drömmare",
@@ -1325,7 +1342,7 @@ pub fn incoming_translation(language: Language) -> &'static str {
         Language::KO => "수신중",
         Language::TR => "Gelen",
         Language::RU => "Входящий",
-        Language::PT => "Entrando",
+        Language::PT | Language::BR => "Entrando",
         Language::EL => "Εισερχόμενα",
         // Language::FA => "ورودی",
         Language::SV => "Inkommande",
@@ -1349,7 +1366,7 @@ pub fn outgoing_translation(language: Language) -> &'static str {
         Language::KO => "발신중",
         Language::TR => "Giden",
         Language::RU => "Исходящий",
-        Language::PT => "Saindo",
+        Language::PT | Language::BR => "Saindo",
         Language::EL => "Εξερχόμενα",
         // Language::FA => "خروجی",
         Language::SV => "Utgående",
@@ -1372,7 +1389,7 @@ pub fn notifications_translation(language: Language) -> &'static str {
         Language::KO => "알림",
         Language::TR => "Bildirimler",
         Language::RU => "Уведомления",
-        Language::PT => "Notificações",
+        Language::PT | Language::BR => "Notificações",
         Language::EL => "Ειδοποιήσεις",
         // Language::FA => "اعلان ها",
         Language::SV => "Notifikationer",
@@ -1385,7 +1402,7 @@ pub fn style_translation(language: Language) -> &'static str {
     match language {
         Language::EN | Language::FR => "Style",
         Language::IT => "Stile",
-        Language::ES | Language::PT => "Estilo",
+        Language::ES | Language::PT | Language::BR => "Estilo",
         Language::PL => "Styl",
         Language::DE | Language::RO | Language::TR | Language::SV => "Stil",
         Language::UK | Language::RU => "Стиль",
@@ -1413,7 +1430,7 @@ pub fn language_translation(language: Language) -> &'static str {
         Language::KO => "언어",
         Language::TR => "Dil",
         Language::RU => "Язык",
-        Language::PT => "Língua",
+        Language::PT | Language::BR => "Língua",
         Language::EL => "Γλώσσα",
         // Language::FA => "زبان",
         Language::SV => "Språk",
@@ -1437,7 +1454,7 @@ pub fn overview_translation(language: Language) -> &'static str {
         Language::KO => "개요",
         Language::TR => "Ön izleme",
         Language::RU => "Обзор",
-        Language::PT => "Visão geral",
+        Language::PT | Language::BR => "Visão geral",
         Language::EL => "επισκόπηση",
         // Language::FA => "نمای کلی",
         Language::SV => "Översikt",
@@ -1468,6 +1485,7 @@ pub fn packets_threshold_translation(language: Language) -> &'static str {
         Language::FI => "Ilmoita minulle, kun pakettiraja on ylittynyt",
         Language::JA => "パケット数の閾値を超過した場合に通知する",
         Language::UZ => "Paket chegarasi oshib ketganda xabar bering",
+        Language::BR => "Notifique-me quando algum limite de pacotes for excedido",
     }
 }
 
@@ -1492,6 +1510,7 @@ pub fn bytes_threshold_translation(language: Language) -> &'static str {
         Language::FI => "Ilmoita minulle, kun tavuraja on ylittynyt",
         Language::JA => "バイト量の閾値を超過した場合に通知する",
         Language::UZ => "Bayt chegarasi oshib ketganda menga xabar bering",
+        Language::BR => "Notifique-me quando algum limite de bytes for excedido",
     }
 }
 
@@ -1500,7 +1519,7 @@ pub fn per_second_translation(language: Language) -> &'static str {
         Language::EN => "(per second)",
         Language::IT => "(al secondo)",
         Language::FR => "(par seconde)",
-        Language::ES | Language::PT => "(por segundo)",
+        Language::ES | Language::PT | Language::BR => "(por segundo)",
         Language::PL => "(na sekundę)",
         Language::DE => "(pro Sekunde)",
         Language::UK => "(на секунду)",
@@ -1538,6 +1557,7 @@ pub fn specify_multiples_translation(language: Language) -> &'static str {
         Language::FI => "; voit myös määrittää 'K', 'M' tai 'G'",
         Language::JA => "; 'K', 'M', 'G' が選択可能です",
         Language::UZ => "; 'K', 'M' va 'G' ni ham belgilashingiz mumkin",
+        Language::BR => "; você também pode especificar 'K', 'M' e 'G'",
     }
 }
 
@@ -1557,7 +1577,7 @@ pub fn favorite_notification_translation(language: Language) -> &'static str {
         Language::KO => "즐겨찾기에서 새 데이터가 교환될 때 알림",
         Language::TR => "Favorilerimde veri akışı olduğunda beni uyar",
         Language::RU => "Уведомить, если произошёл обмен данными в соединениях из избранного",
-        Language::PT => "Notificar-me quando novos dados forem trocados dos meus favoritos",
+        Language::PT | Language::BR => "Notificar-me quando novos dados forem trocados dos meus favoritos",
         Language::EL => "Ειδοποίησέ με όταν νέα δεδομένα έχουν ανταλλαγεί από τα αγαπημένα μου",
         // Language::FA => "به من اطلاع بده وقتی داده جدید از پسندیده های من مبادله شد",
         Language::SV => "Notifiera mig när ny data utbyts av mina favoriter",
@@ -1581,7 +1601,7 @@ pub fn threshold_translation(language: Language) -> String {
         Language::KO => "임계값".to_string(),
         Language::TR => "Eşik".to_string(),
         Language::RU => "Порог".to_string(),
-        Language::PT => "Limite".to_string(),
+        Language::PT | Language::BR => "Limite".to_string(),
         Language::EL => "όριο".to_string(),
         // Language::FA => "آستانه".to_string(),
         Language::SV => "Gräns".to_string(),
@@ -1593,7 +1613,7 @@ pub fn threshold_translation(language: Language) -> String {
 
 pub fn volume_translation(language: Language) -> &'static str {
     match language {
-        Language::EN | Language::IT | Language::FR | Language::PT => "Volume",
+        Language::EN | Language::IT | Language::FR | Language::PT | Language::BR => "Volume",
         Language::ES => "Volumen",
         Language::PL => "Głośność",
         Language::DE => "Lautstärke",
@@ -1624,7 +1644,7 @@ pub fn sound_translation(language: Language) -> &'static str {
         Language::RO => "Sunet",
         Language::KO => "사운드",
         Language::TR => "Ses",
-        Language::PT => "Som",
+        Language::PT | Language::BR => "Som",
         Language::EL => "Ήχος",
         // Language::FA => "صدا",
         Language::SV => "Ljud",
@@ -1647,7 +1667,7 @@ pub fn open_report_translation(language: Language) -> &'static str {
         Language::KO => "전체 보고서 열기",
         Language::TR => "Tam raporu aç",
         Language::RU => "Открыть полный отчёт",
-        Language::PT => "Abrir relatório completo",
+        Language::PT | Language::BR => "Abrir relatório completo",
         Language::EL => "Άνοιγμα της πλήρους αναφοράς",
         // Language::FA => "گزارش کامل را باز کن",
         Language::SV => "Öppna fullständig rapport",
@@ -1671,7 +1691,7 @@ pub fn bytes_exceeded_translation(language: Language) -> &'static str {
         Language::KO => "바이트 임계값 초과!",
         Language::TR => "Bayt eşik değeri aşıldı!",
         Language::RU => "Порог в байтах превышен!",
-        Language::PT => "Limite de bytes excedido!",
+        Language::PT | Language::BR => "Limite de bytes excedido!",
         Language::EL => "Το όριο των bytes ξεπεράστηκε!",
         // Language::FA => "آستانه بایت فراتر رفت!",
         Language::SV => "Gräns för bytes överskriden!",
@@ -1695,7 +1715,7 @@ pub fn bytes_exceeded_value_translation(language: Language, value: &str) -> Stri
         Language::KO => format!("바이트 {value} 가 교환되었습니다"),
         Language::TR => format!("{value} aktarıldı"),
         Language::RU => format!("{value} обмена информацией"),
-        Language::PT => format!("Foram trocados {value}"),
+        Language::PT | Language::BR => format!("Foram trocados {value}"),
         Language::EL => format!("{value} έχουν ανταλλαγεί"),
         // Language::FA => format!("{value} بایت مبادله شده است"),
         Language::SV => format!("{value} har utbytts"),
@@ -1719,7 +1739,7 @@ pub fn packets_exceeded_translation(language: Language) -> &'static str {
         Language::KO => "패킷 임계값 초과!",
         Language::TR => "Paket eşik değeri aşıldı!",
         Language::RU => "Порог по числу пакетов превышен!",
-        Language::PT => "Limite de pacotes excedido!",
+        Language::PT | Language::BR => "Limite de pacotes excedido!",
         Language::EL => "Το όριο των πακέτων ξεπεράστηκε!",
         // Language::FA => "آستانه بسته فراتر رفت!",
         Language::SV => "Paketgräns överskriden!",
@@ -1752,7 +1772,7 @@ pub fn packets_exceeded_value_translation(language: Language, value: u32) -> Str
         Language::KO => format!("패킷 {value} 가 교환되었습니다"),
         Language::TR => format!("{value} paket aktarıldı"),
         Language::RU => format!("{value} пакет(ов) обмена информацией"),
-        Language::PT => match value {
+        Language::PT | Language::BR => match value {
             1 => "Foi trocado 1 pacote".to_owned(),
             npackets => format!("Foram trocados {npackets} pacotes"),
         },
@@ -1788,7 +1808,7 @@ pub fn favorite_transmitted_translation(language: Language) -> &'static str {
         Language::KO => "즐겨찾기에서 새 데이터 교환",
         Language::TR => "Favorilerden yeni veri aktarıldı!",
         Language::RU => "Новый обмен данными в избранных соедиениях!",
-        Language::PT => "Novos dados trocados dos favoritos!",
+        Language::PT | Language::BR => "Novos dados trocados dos favoritos!",
         Language::EL => "Καινούρια δεδομένα έχουν ανταλλαγεί στα αγαπημένα!",
         // Language::FA => "مبادله داده جدید از پسندیده ها!",
         Language::SV => "Ny data utbytt av favoriter!",
@@ -1857,6 +1877,9 @@ pub fn no_notifications_set_translation(language: Language) -> Text<'static, Ren
         Language::UZ => "Siz hali bildirishnomalarni yoqmagansiz!\n\n\
                         Ularni faollashtirgandan so'ng, bu sahifada bildirishnomalaringiz jurnali ko'rsatiladi\n\n\
                         Sozlamalardan bildirishnomalarni yoqishingiz mumkin:",
+        Language::BR => "Ainda não ativou as notificações!\n\n\
+                        Depois de ativá-las, esta página irá mostrar um registo das suas notificações\n\n\
+                        Pode ativar as notificações nas configurações:",
     })
 }
 
@@ -1940,6 +1963,10 @@ pub fn no_notifications_received_translation(
             "Ayni paytda ko'rsatiladigan hech narsa yo'q...\n\n\
                                 Bildirishnomalar kelganda, ular shu yerda ko'rsatiladi"
         }
+        Language::BR => {
+            "Nada para ver no momento...\n\n\
+                                Quando receber uma notificação, ela será mostrada aqui"
+        }
     })
 }
 
@@ -1957,7 +1984,7 @@ pub fn only_last_30_translation(language: Language) -> &'static str {
         Language::KO => "최근 30개의 알림만 표시됩니다",
         Language::TR => "Sadece son 30 bildirim gösterilmektedir",
         Language::RU => "Тут показываются только последние 30 уведомлений",
-        Language::PT => "São mostradas apenas as últimas 30 notificações",
+        Language::PT | Language::BR => "São mostradas apenas as últimas 30 notificações",
         Language::EL => "Μόνο οι τελευταίες 30 ειδοποιήσεις απεικονίζονται",
         // Language::FA => "تنها ۳۰ اعلان آخر نمایش داده شده اند",
         Language::SV => "Endast de senaste 30 notifikationerna visas",

--- a/src/translations/translations_2.rs
+++ b/src/translations/translations_2.rs
@@ -22,7 +22,7 @@ pub fn new_version_available_translation(language: Language) -> &'static str {
         Language::FR => "Une nouvelle version est disponible!",
         Language::JA => "新しいバージョンが利用可能になりました!",
         Language::UZ => "Yangi versiya mavjud!",
-        Language::BR => "Uma nova versão está disponível!",
+        Language::PT_BR => "Uma nova versão está disponível!",
         _ => "A newer version is available!",
     }
 }
@@ -46,7 +46,7 @@ pub fn inspect_translation(language: Language) -> &'static str {
         Language::RO => "Inspectați",
         Language::JA => "検査",
         Language::UZ => "Tekshirish",
-        Language::BR => "Inspecionar",
+        Language::PT_BR => "Inspecionar",
         _ => "Inspect",
     }
 }
@@ -70,7 +70,7 @@ pub fn connection_details_translation(language: Language) -> &'static str {
         Language::FR => "Détails de la connexion",
         Language::JA => "接続の詳細",
         Language::UZ => "Ulanish tafsilotlari",
-        Language::BR => "Detalhes da conexão",
+        Language::PT_BR => "Detalhes da conexão",
         _ => "Connection details",
     }
 }
@@ -94,7 +94,7 @@ pub fn dropped_packets_translation(language: Language) -> &'static str {
         Language::FR => "Packets perdus",
         Language::JA => "ドロップしたパケット",
         Language::UZ => "Yig'ilgan paketlar",
-        Language::BR => "Pacotes perdidos",
+        Language::PT_BR => "Pacotes perdidos",
         _ => "Dropped packets",
     }
 }
@@ -118,7 +118,7 @@ pub fn data_representation_translation(language: Language) -> &'static str {
         Language::FR => "Représentation de données",
         Language::JA => "データ表示",
         Language::UZ => "Ma'lumotlarni taqdim etish",
-        Language::BR => "Representação dos dados",
+        Language::PT_BR => "Representação dos dados",
         _ => "Data representation",
     }
 }
@@ -142,7 +142,7 @@ pub fn host_translation(language: Language) -> &'static str {
         Language::FR => "Host réseaux",
         Language::JA => "ネットワーク ホスト",
         Language::UZ => "Tarmoq serveri",
-        Language::BR => "Host da rede",
+        Language::PT_BR => "Host da rede",
         _ => "Network host",
     }
 }
@@ -166,9 +166,8 @@ pub fn only_top_30_hosts_translation(language: Language) -> &'static str {
         Language::FR => "Seuls les 30 premiers hôtes sont affichés ici",
         Language::JA => "上位 30 件のホストのみが表示されます",
         Language::UZ => "Bu erda faqat dastlabki 30 ta server ko'rsatiladi",
-        Language::BR => "Apenas os 30 melhores hosts são expostos aqui",
+        Language::PT_BR => "Apenas os 30 melhores hosts são expostos aqui",
         _ => "Only the top 30 hosts are displayed here",
-
     }
 }
 
@@ -182,7 +181,7 @@ pub fn sort_by_translation(language: Language) -> &'static str {
         Language::DE => "Sortieren nach",
         Language::TR => "Şuna göre sırala",
         // Language::FA => "مرتب سازی بر اساس",
-        Language::ES | Language::BR => "Ordenar por",
+        Language::ES | Language::PT_BR => "Ordenar por",
         Language::KO => "정렬",
         Language::ZH => "排序",
         Language::UK => "Сортувати за",
@@ -214,7 +213,7 @@ pub fn local_translation(language: Language) -> String {
         Language::FR => "Réseau local",
         Language::JA => "ローカル ネットワーク",
         Language::UZ => "Mahalliy tarmoq",
-        Language::BR => "Rede local",
+        Language::PT_BR => "Rede local",
         _ => "Local network",
     }
     .to_string()
@@ -239,7 +238,7 @@ pub fn unknown_translation(language: Language) -> String {
         Language::FR => "Localisation inconnue",
         Language::JA => "不明なロケーション",
         Language::UZ => "Noma'lum joylashuv",
-        Language::BR => "Localização desconhecida",
+        Language::PT_BR => "Localização desconhecida",
         _ => "Unknown location",
     }
     .to_string()
@@ -264,7 +263,7 @@ pub fn your_network_adapter_translation(language: Language) -> String {
         Language::FR => "Votre carte réseau",
         Language::JA => "自身のネットワーク アダプター",
         Language::UZ => "Sizning tarmoq adapteringiz",
-        Language::BR => "Seu adaptador de rede",
+        Language::PT_BR => "Seu adaptador de rede",
         _ => "Your network adapter",
     }
     .to_string()
@@ -289,7 +288,7 @@ pub fn socket_address_translation(language: Language) -> &'static str {
         Language::FR => "Adresse du socket",
         Language::JA => "ソケット アドレス",
         Language::UZ => "Soket manzili",
-        Language::BR => "Endereço da socket",
+        Language::PT_BR => "Endereço da socket",
         _ => "Socket address",
     }
 }
@@ -313,7 +312,7 @@ pub fn mac_address_translation(language: Language) -> &'static str {
         Language::FR => "Adresse MAC",
         Language::JA => "MAC アドレス",
         Language::UZ => "MAC manzili",
-        Language::BR => "Endereço MAC",
+        Language::PT_BR => "Endereço MAC",
         _ => "MAC address",
     }
 }
@@ -337,7 +336,7 @@ pub fn source_translation(language: Language) -> &'static str {
         Language::FR => "Source",
         Language::JA => "送信元",
         Language::UZ => "Manba",
-        Language::BR => "Fonte",
+        Language::PT_BR => "Fonte",
         _ => "Source",
     }
 }
@@ -351,7 +350,7 @@ pub fn destination_translation(language: Language) -> &'static str {
         Language::DE => "Ziel",
         Language::TR => "Hedef",
         // Language::FA => "مقصد",
-        Language::ES | Language::BR => "Destino",
+        Language::ES | Language::PT_BR => "Destino",
         Language::KO => "목적지",
         Language::ZH => "目标",
         Language::UK => "Призначення",
@@ -382,7 +381,7 @@ pub fn fqdn_translation(language: Language) -> &'static str {
         Language::PL => "Pełna nazwa domeny",
         Language::FR => "Nom de domaine complètement qualifié",
         Language::UZ => "To'liq domen nomi",
-        Language::BR => "Nome de domínio completo",
+        Language::PT_BR => "Nome de domínio completo",
         _ => "Fully qualified domain name",
     }
 }
@@ -406,7 +405,7 @@ pub fn administrative_entity_translation(language: Language) -> &'static str {
         Language::FR => "Nom du système autonome",
         Language::JA => "AS 名",
         Language::UZ => "Avtonom tizim nomi",
-        Language::BR => "Entidade administrativa",
+        Language::PT_BR => "Entidade administrativa",
         _ => "Autonomous System name",
     }
 }
@@ -430,7 +429,7 @@ pub fn transmitted_data_translation(language: Language) -> &'static str {
         Language::FR => "Données transmises",
         Language::JA => "転送データ",
         Language::UZ => "Uzatilgan ma'lumotlar",
-        Language::BR => "Dados transmitidos",
+        Language::PT_BR => "Dados transmitidos",
         _ => "Transmitted data",
     }
 }
@@ -445,7 +444,7 @@ pub fn country_translation(language: Language) -> &'static str {
         Language::DE => "Land",
         Language::TR => "Ülke",
         // Language::FA => "کشور",
-        Language::ES | Language::BR => "País",
+        Language::ES | Language::PT_BR => "País",
         Language::KO => "국가",
         Language::ZH => "国家",
         Language::UK => "Країна",
@@ -477,7 +476,7 @@ pub fn domain_name_translation(language: Language) -> &'static str {
         Language::FR => "Nom de domaine",
         Language::JA => "ドメイン名",
         Language::UZ => "Domen nomi",
-        Language::BR => "Nome do domínio",
+        Language::PT_BR => "Nome do domínio",
         _ => "Domain name",
     }
 }
@@ -501,7 +500,7 @@ pub fn only_show_favorites_translation(language: Language) -> &'static str {
         Language::FR => "Afficher uniquement les favoris",
         Language::JA => "お気に入りのみを表示する",
         Language::UZ => "Faqat sevimlilarni ko'rsatish",
-        Language::BR => "Apenas mostrar os favoritos",
+        Language::PT_BR => "Apenas mostrar os favoritos",
         _ => "Only show favorites",
     }
 }
@@ -525,7 +524,7 @@ pub fn search_filters_translation(language: Language) -> &'static str {
         Language::FR => "Filtres de recherche",
         Language::JA => "検索フィルター",
         Language::UZ => "Qidiruv filtrlari",
-        Language::BR => "Filtros de busca",
+        Language::PT_BR => "Filtros de busca",
         _ => "Search filters",
     }
 }
@@ -549,7 +548,7 @@ pub fn no_search_results_translation(language: Language) -> &'static str {
         Language::FR => "Aucun résultat disponible selon les filtres de recherche spécifiés",
         Language::JA => "指定されたフィルター条件で表示できる結果はありません",
         Language::UZ => "Belgilangan qidiruv filtrlari bo'yicha hech qanday natija mavjud emas",
-        Language::BR => "Nenhum resultado disponível de acordo com os filtros selecionados",
+        Language::PT_BR => "Nenhum resultado disponível de acordo com os filtros selecionados",
         _ => "No result available according to the specified search filters",
     }
 }
@@ -578,7 +577,7 @@ pub fn showing_results_translation(
         Language::FR => format!("Affichage de {start}-{end} de {total} résultats totaux"),
         Language::JA => format!("{total} 件中の {start}-{end} 件を表示"),
         Language::UZ => format!("Jami {total} natijadan {start}-{end} ko'rsatilyapti"),
-        Language::BR => "Mostrando {start}-{end} de {total} resultados totais",
+        Language::PT_BR => format!("Mostrando {start}-{end} de {total} resultados totais"),
         _ => format!("Showing {start}-{end} of {total} total results"),
     }
 }
@@ -603,7 +602,7 @@ pub fn color_gradients_translation(language: Language) -> &'static str {
         Language::FR => "Appliquer des gradients de couleur",
         Language::JA => "グラデーションを適用する",
         Language::UZ => "Rang gradientlarini qo'llang",
-        Language::BR => "Aplicar gradientes de cor",
+        Language::PT_BR => "Aplicar gradientes de cor",
         _ => "Apply color gradients",
     }
 }

--- a/src/translations/translations_2.rs
+++ b/src/translations/translations_2.rs
@@ -22,6 +22,7 @@ pub fn new_version_available_translation(language: Language) -> &'static str {
         Language::FR => "Une nouvelle version est disponible!",
         Language::JA => "新しいバージョンが利用可能になりました!",
         Language::UZ => "Yangi versiya mavjud!",
+        Language::BR => "Uma nova versão está disponível!",
         _ => "A newer version is available!",
     }
 }
@@ -45,6 +46,7 @@ pub fn inspect_translation(language: Language) -> &'static str {
         Language::RO => "Inspectați",
         Language::JA => "検査",
         Language::UZ => "Tekshirish",
+        Language::BR => "Inspecionar",
         _ => "Inspect",
     }
 }
@@ -68,6 +70,7 @@ pub fn connection_details_translation(language: Language) -> &'static str {
         Language::FR => "Détails de la connexion",
         Language::JA => "接続の詳細",
         Language::UZ => "Ulanish tafsilotlari",
+        Language::BR => "Detalhes da conexão",
         _ => "Connection details",
     }
 }
@@ -91,6 +94,7 @@ pub fn dropped_packets_translation(language: Language) -> &'static str {
         Language::FR => "Packets perdus",
         Language::JA => "ドロップしたパケット",
         Language::UZ => "Yig'ilgan paketlar",
+        Language::BR => "Pacotes perdidos",
         _ => "Dropped packets",
     }
 }
@@ -114,6 +118,7 @@ pub fn data_representation_translation(language: Language) -> &'static str {
         Language::FR => "Représentation de données",
         Language::JA => "データ表示",
         Language::UZ => "Ma'lumotlarni taqdim etish",
+        Language::BR => "Representação dos dados",
         _ => "Data representation",
     }
 }
@@ -137,6 +142,7 @@ pub fn host_translation(language: Language) -> &'static str {
         Language::FR => "Host réseaux",
         Language::JA => "ネットワーク ホスト",
         Language::UZ => "Tarmoq serveri",
+        Language::BR => "Host da rede",
         _ => "Network host",
     }
 }
@@ -160,7 +166,9 @@ pub fn only_top_30_hosts_translation(language: Language) -> &'static str {
         Language::FR => "Seuls les 30 premiers hôtes sont affichés ici",
         Language::JA => "上位 30 件のホストのみが表示されます",
         Language::UZ => "Bu erda faqat dastlabki 30 ta server ko'rsatiladi",
+        Language::BR => "Apenas os 30 melhores hosts são expostos aqui",
         _ => "Only the top 30 hosts are displayed here",
+
     }
 }
 
@@ -174,7 +182,7 @@ pub fn sort_by_translation(language: Language) -> &'static str {
         Language::DE => "Sortieren nach",
         Language::TR => "Şuna göre sırala",
         // Language::FA => "مرتب سازی بر اساس",
-        Language::ES => "Ordenar por",
+        Language::ES | Language::BR => "Ordenar por",
         Language::KO => "정렬",
         Language::ZH => "排序",
         Language::UK => "Сортувати за",
@@ -206,6 +214,7 @@ pub fn local_translation(language: Language) -> String {
         Language::FR => "Réseau local",
         Language::JA => "ローカル ネットワーク",
         Language::UZ => "Mahalliy tarmoq",
+        Language::BR => "Rede local",
         _ => "Local network",
     }
     .to_string()
@@ -230,6 +239,7 @@ pub fn unknown_translation(language: Language) -> String {
         Language::FR => "Localisation inconnue",
         Language::JA => "不明なロケーション",
         Language::UZ => "Noma'lum joylashuv",
+        Language::BR => "Localização desconhecida",
         _ => "Unknown location",
     }
     .to_string()
@@ -254,6 +264,7 @@ pub fn your_network_adapter_translation(language: Language) -> String {
         Language::FR => "Votre carte réseau",
         Language::JA => "自身のネットワーク アダプター",
         Language::UZ => "Sizning tarmoq adapteringiz",
+        Language::BR => "Seu adaptador de rede",
         _ => "Your network adapter",
     }
     .to_string()
@@ -278,6 +289,7 @@ pub fn socket_address_translation(language: Language) -> &'static str {
         Language::FR => "Adresse du socket",
         Language::JA => "ソケット アドレス",
         Language::UZ => "Soket manzili",
+        Language::BR => "Endereço da socket",
         _ => "Socket address",
     }
 }
@@ -301,6 +313,7 @@ pub fn mac_address_translation(language: Language) -> &'static str {
         Language::FR => "Adresse MAC",
         Language::JA => "MAC アドレス",
         Language::UZ => "MAC manzili",
+        Language::BR => "Endereço MAC",
         _ => "MAC address",
     }
 }
@@ -324,6 +337,7 @@ pub fn source_translation(language: Language) -> &'static str {
         Language::FR => "Source",
         Language::JA => "送信元",
         Language::UZ => "Manba",
+        Language::BR => "Fonte",
         _ => "Source",
     }
 }
@@ -337,7 +351,7 @@ pub fn destination_translation(language: Language) -> &'static str {
         Language::DE => "Ziel",
         Language::TR => "Hedef",
         // Language::FA => "مقصد",
-        Language::ES => "Destino",
+        Language::ES | Language::BR => "Destino",
         Language::KO => "목적지",
         Language::ZH => "目标",
         Language::UK => "Призначення",
@@ -368,6 +382,7 @@ pub fn fqdn_translation(language: Language) -> &'static str {
         Language::PL => "Pełna nazwa domeny",
         Language::FR => "Nom de domaine complètement qualifié",
         Language::UZ => "To'liq domen nomi",
+        Language::BR => "Nome de domínio completo",
         _ => "Fully qualified domain name",
     }
 }
@@ -391,6 +406,7 @@ pub fn administrative_entity_translation(language: Language) -> &'static str {
         Language::FR => "Nom du système autonome",
         Language::JA => "AS 名",
         Language::UZ => "Avtonom tizim nomi",
+        Language::BR => "Entidade administrativa",
         _ => "Autonomous System name",
     }
 }
@@ -414,6 +430,7 @@ pub fn transmitted_data_translation(language: Language) -> &'static str {
         Language::FR => "Données transmises",
         Language::JA => "転送データ",
         Language::UZ => "Uzatilgan ma'lumotlar",
+        Language::BR => "Dados transmitidos",
         _ => "Transmitted data",
     }
 }
@@ -428,7 +445,7 @@ pub fn country_translation(language: Language) -> &'static str {
         Language::DE => "Land",
         Language::TR => "Ülke",
         // Language::FA => "کشور",
-        Language::ES => "País",
+        Language::ES | Language::BR => "País",
         Language::KO => "국가",
         Language::ZH => "国家",
         Language::UK => "Країна",
@@ -460,6 +477,7 @@ pub fn domain_name_translation(language: Language) -> &'static str {
         Language::FR => "Nom de domaine",
         Language::JA => "ドメイン名",
         Language::UZ => "Domen nomi",
+        Language::BR => "Nome do domínio",
         _ => "Domain name",
     }
 }
@@ -483,6 +501,7 @@ pub fn only_show_favorites_translation(language: Language) -> &'static str {
         Language::FR => "Afficher uniquement les favoris",
         Language::JA => "お気に入りのみを表示する",
         Language::UZ => "Faqat sevimlilarni ko'rsatish",
+        Language::BR => "Apenas mostrar os favoritos",
         _ => "Only show favorites",
     }
 }
@@ -506,6 +525,7 @@ pub fn search_filters_translation(language: Language) -> &'static str {
         Language::FR => "Filtres de recherche",
         Language::JA => "検索フィルター",
         Language::UZ => "Qidiruv filtrlari",
+        Language::BR => "Filtros de busca",
         _ => "Search filters",
     }
 }
@@ -529,6 +549,7 @@ pub fn no_search_results_translation(language: Language) -> &'static str {
         Language::FR => "Aucun résultat disponible selon les filtres de recherche spécifiés",
         Language::JA => "指定されたフィルター条件で表示できる結果はありません",
         Language::UZ => "Belgilangan qidiruv filtrlari bo'yicha hech qanday natija mavjud emas",
+        Language::BR => "Nenhum resultado disponível de acordo com os filtros selecionados",
         _ => "No result available according to the specified search filters",
     }
 }
@@ -557,6 +578,7 @@ pub fn showing_results_translation(
         Language::FR => format!("Affichage de {start}-{end} de {total} résultats totaux"),
         Language::JA => format!("{total} 件中の {start}-{end} 件を表示"),
         Language::UZ => format!("Jami {total} natijadan {start}-{end} ko'rsatilyapti"),
+        Language::BR => "Mostrando {start}-{end} de {total} resultados totais",
         _ => format!("Showing {start}-{end} of {total} total results"),
     }
 }
@@ -581,6 +603,7 @@ pub fn color_gradients_translation(language: Language) -> &'static str {
         Language::FR => "Appliquer des gradients de couleur",
         Language::JA => "グラデーションを適用する",
         Language::UZ => "Rang gradientlarini qo'llang",
+        Language::BR => "Aplicar gradientes de cor",
         _ => "Apply color gradients",
     }
 }

--- a/src/translations/types/language.rs
+++ b/src/translations/types/language.rs
@@ -4,7 +4,7 @@ use iced::{Length, Renderer};
 use serde::{Deserialize, Serialize};
 
 use crate::countries::flags_pictures::{
-    CN, DE, ES, FI, FLAGS_WIDTH_SMALL, FR, GB, GR, IT, JP, KR, PL, PT, RO, RU, SE, TR, UA, UZ,
+    CN, DE, ES, FI, FLAGS_WIDTH_SMALL, FR, GB, GR, IT, JP, KR, PL, PT, RO, RU, SE, TR, UA, UZ, BR,
 };
 use crate::StyleType;
 
@@ -31,7 +31,7 @@ pub enum Language {
     RO,
     /// Korean
     KO,
-    /// Portuguese
+    /// European Portuguese
     PT,
     /// Turkish
     TR,
@@ -49,6 +49,8 @@ pub enum Language {
     JA,
     /// Uzbek
     UZ,
+    /// Brazilian Portuguese
+    BR,
 }
 
 impl Default for Language {
@@ -79,13 +81,14 @@ impl Language {
             Language::KO => "한국어",
             Language::TR => "Türkçe",
             Language::RU => "Русский",
-            Language::PT => "Português",
+            Language::PT => "Português Europeu",
             Language::EL => "Ελληνικά",
             // Language::FA => "فارسی",
             Language::SV => "Svenska",
             Language::FI => "Suomi",
             Language::JA => "日本語",
             Language::UZ => "O'zbekcha",
+            Language::BR => "Português Brasileiro",
         }
     }
 
@@ -110,6 +113,7 @@ impl Language {
             Language::FI => FI,
             Language::JA => JP,
             Language::UZ => UZ,
+            Language::BR => BR,
         })))
         .width(Length::Fixed(FLAGS_WIDTH_SMALL))
     }

--- a/src/translations/types/language.rs
+++ b/src/translations/types/language.rs
@@ -4,7 +4,7 @@ use iced::{Length, Renderer};
 use serde::{Deserialize, Serialize};
 
 use crate::countries::flags_pictures::{
-    CN, DE, ES, FI, FLAGS_WIDTH_SMALL, FR, GB, GR, IT, JP, KR, PL, PT, RO, RU, SE, TR, UA, UZ, BR,
+    BR, CN, DE, ES, FI, FLAGS_WIDTH_SMALL, FR, GB, GR, IT, JP, KR, PL, PT, RO, RU, SE, TR, UA, UZ,
 };
 use crate::StyleType;
 
@@ -50,7 +50,7 @@ pub enum Language {
     /// Uzbek
     UZ,
     /// Brazilian Portuguese
-    BR,
+    PT_BR,
 }
 
 impl Default for Language {
@@ -60,12 +60,13 @@ impl Default for Language {
 }
 
 impl Language {
-    pub(crate) const ROW1: [Language; 3] = [Language::EN, Language::DE, Language::EL];
-    pub(crate) const ROW2: [Language; 3] = [Language::ES, Language::FI, Language::FR];
-    pub(crate) const ROW3: [Language; 3] = [Language::IT, Language::JA, Language::KO];
-    pub(crate) const ROW4: [Language; 3] = [Language::PL, Language::PT, Language::RO];
-    pub(crate) const ROW5: [Language; 3] = [Language::RU, Language::SV, Language::TR];
-    pub(crate) const ROW6: [Language; 3] = [Language::UK, Language::UZ, Language::ZH];
+    pub(crate) const ROW1: [Language; 1] = [Language::EN];
+    pub(crate) const ROW2: [Language; 3] = [Language::DE, Language::EL, Language::ES];
+    pub(crate) const ROW3: [Language; 3] = [Language::FI, Language::FR, Language::IT];
+    pub(crate) const ROW4: [Language; 3] = [Language::JA, Language::KO, Language::PL];
+    pub(crate) const ROW5: [Language; 3] = [Language::PT, Language::PT_BR, Language::RO];
+    pub(crate) const ROW6: [Language; 3] = [Language::RU, Language::SV, Language::TR];
+    pub(crate) const ROW7: [Language; 3] = [Language::UK, Language::UZ, Language::ZH];
 
     pub fn get_radio_label(&self) -> &str {
         match self {
@@ -81,14 +82,13 @@ impl Language {
             Language::KO => "한국어",
             Language::TR => "Türkçe",
             Language::RU => "Русский",
-            Language::PT => "Português Europeu",
+            Language::PT | Language::PT_BR => "Português",
             Language::EL => "Ελληνικά",
             // Language::FA => "فارسی",
             Language::SV => "Svenska",
             Language::FI => "Suomi",
             Language::JA => "日本語",
             Language::UZ => "O'zbekcha",
-            Language::BR => "Português Brasileiro",
         }
     }
 
@@ -113,7 +113,7 @@ impl Language {
             Language::FI => FI,
             Language::JA => JP,
             Language::UZ => UZ,
-            Language::BR => BR,
+            Language::PT_BR => BR,
         })))
         .width(Length::Fixed(FLAGS_WIDTH_SMALL))
     }


### PR DESCRIPTION
# 🇧🇷 Brazilian Portuguese Translation
This PR translates Sniffnet to brazilian portuguese. 

Although european portuguese and brazilian portuguese are very similar, they differ in several ways and what "feels good" in one may not be the same in the other.