### PR TITLE
Portuguese Translation Extension - Translations_2

### DIFF
--- a/src/gui/pages/settings_language_page.rs
+++ b/src/gui/pages/settings_language_page.rs
@@ -59,7 +59,7 @@ pub fn settings_language_page(sniffer: &Sniffer) -> Container<Message, Renderer<
         .push(vertical_space(Fixed(25.0)))
         .push(col_language_radio_all);
 
-    if [Language::EL, Language::PT].contains(&sniffer.language) {
+    if sniffer.language.eq(&Language::EL) {
         content = content.push(vertical_space(Fixed(20.0))).push(
             Container::new(
                 Text::new("The selected language is not fully updated to version 1.2").font(font),

--- a/src/translations/translations_2.rs
+++ b/src/translations/translations_2.rs
@@ -23,7 +23,6 @@ pub fn new_version_available_translation(language: Language) -> &'static str {
         Language::JA => "新しいバージョンが利用可能になりました!",
         Language::UZ => "Yangi versiya mavjud!",
         Language::PT => "Uma nova versão está disponível!",
-        _ => "A newer version is available!",
     }
 }
 

--- a/src/translations/translations_2.rs
+++ b/src/translations/translations_2.rs
@@ -22,6 +22,7 @@ pub fn new_version_available_translation(language: Language) -> &'static str {
         Language::FR => "Une nouvelle version est disponible!",
         Language::JA => "新しいバージョンが利用可能になりました!",
         Language::UZ => "Yangi versiya mavjud!",
+        Language::PT => "Uma nova versão está disponível!",
         _ => "A newer version is available!",
     }
 }
@@ -45,6 +46,7 @@ pub fn inspect_translation(language: Language) -> &'static str {
         Language::RO => "Inspectați",
         Language::JA => "検査",
         Language::UZ => "Tekshirish",
+        Language::PT => "Inspecionar",
         _ => "Inspect",
     }
 }
@@ -68,6 +70,7 @@ pub fn connection_details_translation(language: Language) -> &'static str {
         Language::FR => "Détails de la connexion",
         Language::JA => "接続の詳細",
         Language::UZ => "Ulanish tafsilotlari",
+        Language::PT => "Detalhes da conexão",
         _ => "Connection details",
     }
 }
@@ -91,6 +94,7 @@ pub fn dropped_packets_translation(language: Language) -> &'static str {
         Language::FR => "Packets perdus",
         Language::JA => "ドロップしたパケット",
         Language::UZ => "Yig'ilgan paketlar",
+        Language::PT => "Pacotes perdidos",
         _ => "Dropped packets",
     }
 }
@@ -114,6 +118,7 @@ pub fn data_representation_translation(language: Language) -> &'static str {
         Language::FR => "Représentation de données",
         Language::JA => "データ表示",
         Language::UZ => "Ma'lumotlarni taqdim etish",
+        Language::PT => "Representação dos dados",
         _ => "Data representation",
     }
 }
@@ -137,6 +142,7 @@ pub fn host_translation(language: Language) -> &'static str {
         Language::FR => "Host réseaux",
         Language::JA => "ネットワーク ホスト",
         Language::UZ => "Tarmoq serveri",
+        Language::PT => "Host da rede",
         _ => "Network host",
     }
 }
@@ -160,6 +166,7 @@ pub fn only_top_30_hosts_translation(language: Language) -> &'static str {
         Language::FR => "Seuls les 30 premiers hôtes sont affichés ici",
         Language::JA => "上位 30 件のホストのみが表示されます",
         Language::UZ => "Bu erda faqat dastlabki 30 ta server ko'rsatiladi",
+        Language::PT => "Apenas os 30 melhores hosts são expostos aqui",
         _ => "Only the top 30 hosts are displayed here",
     }
 }
@@ -174,7 +181,7 @@ pub fn sort_by_translation(language: Language) -> &'static str {
         Language::DE => "Sortieren nach",
         Language::TR => "Şuna göre sırala",
         // Language::FA => "مرتب سازی بر اساس",
-        Language::ES => "Ordenar por",
+        Language::ES | Language::PT => "Ordenar por",
         Language::KO => "정렬",
         Language::ZH => "排序",
         Language::UK => "Сортувати за",
@@ -206,6 +213,7 @@ pub fn local_translation(language: Language) -> String {
         Language::FR => "Réseau local",
         Language::JA => "ローカル ネットワーク",
         Language::UZ => "Mahalliy tarmoq",
+        Language::PT => "Rede local",
         _ => "Local network",
     }
     .to_string()
@@ -230,6 +238,7 @@ pub fn unknown_translation(language: Language) -> String {
         Language::FR => "Localisation inconnue",
         Language::JA => "不明なロケーション",
         Language::UZ => "Noma'lum joylashuv",
+        Language::PT => "Localização desconhecida",
         _ => "Unknown location",
     }
     .to_string()
@@ -254,6 +263,7 @@ pub fn your_network_adapter_translation(language: Language) -> String {
         Language::FR => "Votre carte réseau",
         Language::JA => "自身のネットワーク アダプター",
         Language::UZ => "Sizning tarmoq adapteringiz",
+        Language::PT => "Seu adaptador de rede",
         _ => "Your network adapter",
     }
     .to_string()
@@ -278,6 +288,7 @@ pub fn socket_address_translation(language: Language) -> &'static str {
         Language::FR => "Adresse du socket",
         Language::JA => "ソケット アドレス",
         Language::UZ => "Soket manzili",
+        Language::PT => "Endereço da socket",
         _ => "Socket address",
     }
 }
@@ -301,6 +312,7 @@ pub fn mac_address_translation(language: Language) -> &'static str {
         Language::FR => "Adresse MAC",
         Language::JA => "MAC アドレス",
         Language::UZ => "MAC manzili",
+        Language::PT => "Endereço MAC",
         _ => "MAC address",
     }
 }
@@ -324,6 +336,7 @@ pub fn source_translation(language: Language) -> &'static str {
         Language::FR => "Source",
         Language::JA => "送信元",
         Language::UZ => "Manba",
+        Language::PT => "Fonte",
         _ => "Source",
     }
 }
@@ -337,7 +350,7 @@ pub fn destination_translation(language: Language) -> &'static str {
         Language::DE => "Ziel",
         Language::TR => "Hedef",
         // Language::FA => "مقصد",
-        Language::ES => "Destino",
+        Language::ES | Language::PT => "Destino",
         Language::KO => "목적지",
         Language::ZH => "目标",
         Language::UK => "Призначення",
@@ -368,6 +381,7 @@ pub fn fqdn_translation(language: Language) -> &'static str {
         Language::PL => "Pełna nazwa domeny",
         Language::FR => "Nom de domaine complètement qualifié",
         Language::UZ => "To'liq domen nomi",
+        Language::PT => "Nome de domínio completo",
         _ => "Fully qualified domain name",
     }
 }
@@ -391,6 +405,7 @@ pub fn administrative_entity_translation(language: Language) -> &'static str {
         Language::FR => "Nom du système autonome",
         Language::JA => "AS 名",
         Language::UZ => "Avtonom tizim nomi",
+        Language::PT => "Entidade administrativa",
         _ => "Autonomous System name",
     }
 }
@@ -414,6 +429,7 @@ pub fn transmitted_data_translation(language: Language) -> &'static str {
         Language::FR => "Données transmises",
         Language::JA => "転送データ",
         Language::UZ => "Uzatilgan ma'lumotlar",
+        Language::PT => "Dados transmitidos",
         _ => "Transmitted data",
     }
 }
@@ -428,7 +444,7 @@ pub fn country_translation(language: Language) -> &'static str {
         Language::DE => "Land",
         Language::TR => "Ülke",
         // Language::FA => "کشور",
-        Language::ES => "País",
+        Language::ES | Language::PT => "País",
         Language::KO => "국가",
         Language::ZH => "国家",
         Language::UK => "Країна",
@@ -460,6 +476,7 @@ pub fn domain_name_translation(language: Language) -> &'static str {
         Language::FR => "Nom de domaine",
         Language::JA => "ドメイン名",
         Language::UZ => "Domen nomi",
+        Language::PT => "Nome do domínio",
         _ => "Domain name",
     }
 }
@@ -483,6 +500,7 @@ pub fn only_show_favorites_translation(language: Language) -> &'static str {
         Language::FR => "Afficher uniquement les favoris",
         Language::JA => "お気に入りのみを表示する",
         Language::UZ => "Faqat sevimlilarni ko'rsatish",
+        Language::PT => "Apenas mostrar os favoritos",
         _ => "Only show favorites",
     }
 }
@@ -506,6 +524,7 @@ pub fn search_filters_translation(language: Language) -> &'static str {
         Language::FR => "Filtres de recherche",
         Language::JA => "検索フィルター",
         Language::UZ => "Qidiruv filtrlari",
+        Language::PT => "Filtros de busca",
         _ => "Search filters",
     }
 }
@@ -529,6 +548,7 @@ pub fn no_search_results_translation(language: Language) -> &'static str {
         Language::FR => "Aucun résultat disponible selon les filtres de recherche spécifiés",
         Language::JA => "指定されたフィルター条件で表示できる結果はありません",
         Language::UZ => "Belgilangan qidiruv filtrlari bo'yicha hech qanday natija mavjud emas",
+        Language::PT => "Nenhum resultado disponível de acordo com os filtros selecionados",
         _ => "No result available according to the specified search filters",
     }
 }
@@ -557,6 +577,7 @@ pub fn showing_results_translation(
         Language::FR => format!("Affichage de {start}-{end} de {total} résultats totaux"),
         Language::JA => format!("{total} 件中の {start}-{end} 件を表示"),
         Language::UZ => format!("Jami {total} natijadan {start}-{end} ko'rsatilyapti"),
+        Language::PT => format!("Mostrando {start}-{end} de {total} resultados totais"),
         _ => format!("Showing {start}-{end} of {total} total results"),
     }
 }
@@ -581,6 +602,7 @@ pub fn color_gradients_translation(language: Language) -> &'static str {
         Language::FR => "Appliquer des gradients de couleur",
         Language::JA => "グラデーションを適用する",
         Language::UZ => "Rang gradientlarini qo'llang",
+        Language::PT => "Aplicar gradientes de cor",
         _ => "Apply color gradients",
     }
 }


### PR DESCRIPTION
This PR extends the portuguese translation of sniffnet to translations_2.

This extension is based on the Brazilian variation of the portuguese language, which can be understood by any portuguese speaker.