### PR TITLE
Improve custom palettes generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All Sniffnet releases with the relative changes are documented in this file.
 - Added support for ICMP connections and messages ([#417](https://github.com/GyulyVGC/sniffnet/pull/417) — fixes [#288](https://github.com/GyulyVGC/sniffnet/issues/288))
 - Introduced new filtering capabilities to allow users specify custom values of ports and IP addresses ([#414](https://github.com/GyulyVGC/sniffnet/pull/414))
 - The size of text and widgets can now be customised by setting a proper zoom value (fixes [#202](https://github.com/GyulyVGC/sniffnet/issues/202) and [#344](https://github.com/GyulyVGC/sniffnet/issues/344))
-- Added possibility to totally customize the app's theme via styles defined in TOML files ([#286](https://github.com/GyulyVGC/sniffnet/pull/286))
+- Added possibility to totally customize the app's theme via styles defined in TOML files ([#286](https://github.com/GyulyVGC/sniffnet/pull/286) and [#419](https://github.com/GyulyVGC/sniffnet/pull/419))
 - IP addresses can now be copied to clipboard from the popup related to a given entry of the connections table, and a new search parameter has been introduced in Inspect page to allow users filter their connections based on IP address values ([#409](https://github.com/GyulyVGC/sniffnet/pull/409))
 - Added Japanese translation 🇯🇵 ([#343](https://github.com/GyulyVGC/sniffnet/pull/343))
 - Added Uzbek translation 🇺🇿 ([#385](https://github.com/GyulyVGC/sniffnet/pull/385))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -279,7 +279,7 @@ checksum = "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -780,9 +780,9 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "fdeflate"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d6dafc854908ff5da46ff3f8f473c6984119a2876a383a860246dd7841a868"
+checksum = "7caf4086251adeba90011a7ff9bd1f6d7f7595be0871867daa4dbb0fcf2ca932"
 dependencies = [
  "simd-adler32",
 ]
@@ -864,9 +864,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -879,9 +879,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -889,15 +889,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -907,32 +907,32 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-timer"
@@ -942,9 +942,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1736,9 +1736,9 @@ dependencies = [
 
 [[package]]
 name = "lyon_geom"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74df1ff0a0147282eb10699537a03baa7d31972b58984a1d44ce0624043fe8ad"
+checksum = "edecfb8d234a2b0be031ab02ebcdd9f3b9ee418fb35e265f7a540a48d197bff9"
 dependencies = [
  "arrayvec",
  "euclid",
@@ -2084,7 +2084,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -2154,9 +2154,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.1"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "memchr",
 ]
@@ -2192,9 +2192,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "openssl"
-version = "0.10.61"
+version = "0.10.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b8419dc8cc6d866deb801274bba2e6f8f6108c1bb7fcc10ee5ab864931dbb45"
+checksum = "8cde4d2d9200ad5909f8dac647e29482e07c3a35de8a13fce7c9c7747ad9f671"
 dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
@@ -2213,7 +2213,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -2224,9 +2224,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.97"
+version = "0.9.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3eaad34cdd97d81de97964fc7f29e2d104f483840d906ef56daa1912338460b"
+checksum = "c1665caf8ab2dc9aef43d1c0023bd904633a6a05cb30b0ad59bec2ae986e57a7"
 dependencies = [
  "cc",
  "libc",
@@ -2264,7 +2264,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -2296,7 +2296,7 @@ checksum = "b7db010ec5ff3d4385e4f133916faacd9dad0f6a09394c92d825b3aed310fa0a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -2404,7 +2404,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -2436,9 +2436,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
 
 [[package]]
 name = "plotters"
@@ -2526,9 +2526,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "75cb1540fadbd5b8fbccc4dddad2734eba435053f725621c070711a14bb5f4b8"
 dependencies = [
  "unicode-ident",
 ]
@@ -2817,7 +2817,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.41",
+ "syn 2.0.43",
  "unicode-ident",
 ]
 
@@ -3024,7 +3024,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -3335,9 +3335,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.41"
+version = "2.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
+checksum = "ee659fb5f3d355364e1f3e5bc10fb82068efbf824a1e9d1c9504244a6469ad53"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3398,22 +3398,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f11c217e1416d6f036b870f14e0413d480dbf28edbee1f877abaf0206af43bb7"
+checksum = "83a48fd946b02c0a526b2e9481c8e2a17755e47039164a86c4070446e3a4614d"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01742297787513b79cf8e29d1056ede1313e2420b7b3b15d0a768b4921f549df"
+checksum = "e7fbe9b594d6568a6a1443250a7e67d80b74e1e96f6d1715e1e21cc1888291d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -3863,7 +3863,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
  "wasm-bindgen-shared",
 ]
 
@@ -3897,7 +3897,7 @@ checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4645,20 +4645,20 @@ checksum = "dd15f8e0dbb966fd9245e7498c7e9e5055d9e5c8b676b95bd67091cd11a1e697"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.31"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c4061bedbb353041c12f413700357bec76df2c7e2ca8e4df8bac24c6bf68e3d"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.31"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3158,6 +3158,7 @@ dependencies = [
  "etherparse",
  "iced",
  "maxminddb",
+ "once_cell",
  "pcap",
  "plotters",
  "plotters-iced",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ serde = { version = "1.0.193", default_features = false, features = ["derive"] }
 rodio = { version = "0.17.3", default_features = false, features = ["mp3"] }
 dns-lookup = "2.0.4"
 toml = "0.8.8"
+once_cell = "1.19.0"
 
 [target.'cfg(not(target_arch = "powerpc64"))'.dependencies]
 reqwest = { version = "0.11.23", default-features = false, features = ["json", "blocking", "rustls-tls"] }

--- a/README.md
+++ b/README.md
@@ -409,22 +409,13 @@ The currently usable hotkeys are reported in the following.
 
   The TOML must follow this format:
   ```toml
-  # Colors are in RGB/RGBA hexadecimal.
-  primary = "#303446"           # Background
-  secondary = "#a6d189"         # Headers / incoming connections
-  buttons = "#414559"           # Buttons
-  outgoing = "#f4b8e4"          # Outgoing connections
-  text_headers = "#232634"      # Text headers
-  text_body = "#c6d0f5"         # Text body
-  starred = "#e5c890aa"         # Favorites
-
-  # The following parameters are in the range [0.0, 1.0].
-  round_borders_alpha = 0.4     # Borders opacity
-  round_containers_alpha = 0.25 # Containers opacity
-  chart_badge_alpha = 0.2       # Chart opacity
-
-  # Set to true if the theme is dark, false if it's light.
-  nightly = true
+  # all colors are in RGB/RGBA hexadecimal.
+  primary = "#303446"           # background color
+  secondary = "#a6d189"         # header, footer, and incoming connections color
+  outgoing = "#f4b8e4"          # outgoing connections color
+  text_body = "#c6d0f5"         # body text color 
+  text_headers = "#232634"      # header and footer text color
+  starred = "#e5c890aa"         # favorites' star color
   ```
 
   The example theme above uses colors from [Catppuccin](https://github.com/catppuccin/catppuccin).

--- a/README.md
+++ b/README.md
@@ -420,6 +420,9 @@ The currently usable hotkeys are reported in the following.
 
   The example theme above uses colors from [Catppuccin](https://github.com/catppuccin/catppuccin).
 
+  You can also check the [`resources/themes`](https://github.com/GyulyVGC/sniffnet/tree/main/resources/themes) folder,
+  which contains sample TOML files with additional themes.
+
   To use a custom theme for your instance of Sniffnet, specify the path of your TOML file in the application's 
   settings (at the bottom of the style tab).
 </details>

--- a/resources/themes/catppuccin.toml
+++ b/resources/themes/catppuccin.toml
@@ -1,16 +1,7 @@
 # Colors are in RGB/RGBA hexadecimal.
 primary = "#303446"           # Background
 secondary = "#a6d189"         # Headers / incoming connections
-buttons = "#414559"           # Buttons
 outgoing = "#f4b8e4"          # Outgoing connections
 text_headers = "#232634"      # Text headers
 text_body = "#c6d0f5"         # Text body
 starred = "#e5c890aa"         # Favorites
-
-# The following parameters are in the range [0.0, 1.0].
-round_borders_alpha = 0.4     # Borders opacity
-round_containers_alpha = 0.25 # Containers opacity
-chart_badge_alpha = 0.2       # Chart opacity
-
-# Set to true if the theme is dark, false if it's light.
-nightly = true

--- a/resources/themes/catppuccin.toml
+++ b/resources/themes/catppuccin.toml
@@ -1,7 +1,7 @@
-# Colors are in RGB/RGBA hexadecimal.
-primary = "#303446"           # Background
-secondary = "#a6d189"         # Headers / incoming connections
-outgoing = "#f4b8e4"          # Outgoing connections
-text_headers = "#232634"      # Text headers
-text_body = "#c6d0f5"         # Text body
-starred = "#e5c890aa"         # Favorites
+# all colors are in RGB/RGBA hexadecimal.
+primary = "#303446"           # background color
+secondary = "#a6d189"         # header, footer, and incoming connections color
+outgoing = "#f4b8e4"          # outgoing connections color
+text_body = "#c6d0f5"         # body text color
+text_headers = "#232634"      # header and footer text color
+starred = "#e5c890aa"         # favorites' star color

--- a/resources/themes/deep_cosmos.toml
+++ b/resources/themes/deep_cosmos.toml
@@ -1,0 +1,6 @@
+primary = "#0E0430"
+secondary = "#8C19FF"
+outgoing = "#1061EB"
+text_body = "#BEDDFF"
+text_headers = "#FFB3F2"
+starred = "#FF8000aa"

--- a/resources/themes/electric_wave.toml
+++ b/resources/themes/electric_wave.toml
@@ -1,0 +1,6 @@
+primary = "#0f0f0f"
+secondary = "#dfc020"
+outgoing = "#9966ff"
+text_body = "#eeeeee"
+text_headers = "#232634"
+starred = "#f3e00c77"

--- a/resources/themes/goleador.toml
+++ b/resources/themes/goleador.toml
@@ -1,0 +1,6 @@
+primary = "#222222"
+secondary = "#1EB300"
+outgoing = "#FF3333"
+text_body = "#eeeeee"
+text_headers = "#232634"
+starred = "#f3e00c77"

--- a/resources/themes/light_bubbles.toml
+++ b/resources/themes/light_bubbles.toml
@@ -1,0 +1,6 @@
+primary = "#CCFFFF"
+secondary = "#0080FF"
+outgoing = "#A748AE"
+text_body = "#000066"
+text_headers = "#CCFFFF"
+starred = "#FFFF66"

--- a/src/chart/types/traffic_chart.rs
+++ b/src/chart/types/traffic_chart.rs
@@ -8,14 +8,12 @@ use iced::{Element, Renderer};
 use plotters::prelude::*;
 use plotters_iced::{Chart, ChartBuilder, ChartWidget, DrawingBackend};
 
-use crate::gui::styles::style_constants::{
-    get_alpha_chart_badge, get_font_weight, CHARTS_LINE_BORDER,
-};
+use crate::gui::styles::style_constants::{CHARTS_LINE_BORDER};
 use crate::gui::styles::types::palette::to_rgb_color;
 use crate::gui::types::message::Message;
 use crate::translations::translations::{incoming_translation, outgoing_translation};
 use crate::utils::formatted_strings::get_formatted_bytes_string_with_b;
-use crate::{get_colors, ChartType, Language, StyleType};
+use crate::{ChartType, Language, StyleType};
 
 /// Struct defining the chart to be displayed in gui run page
 pub struct TrafficChart {
@@ -91,7 +89,7 @@ impl Chart<Message> for TrafficChart {
         _state: &Self::State,
         mut chart_builder: ChartBuilder<DB>,
     ) {
-        let font_weight = get_font_weight(self.style);
+        let font_weight = self.style.get_font_weight();
 
         if self.ticks == 0 {
             return;
@@ -103,7 +101,7 @@ impl Chart<Message> for TrafficChart {
         let color_incoming = to_rgb_color(colors.secondary);
         let color_outgoing = to_rgb_color(colors.outgoing);
         let color_font = to_rgb_color(colors.text_body);
-        let color_mix = get_alpha_chart_badge(self.style);
+        let color_mix = self.style.get_alpha_chart_badge();
 
         chart_builder
             .margin_right(30)

--- a/src/chart/types/traffic_chart.rs
+++ b/src/chart/types/traffic_chart.rs
@@ -101,7 +101,7 @@ impl Chart<Message> for TrafficChart {
         let color_incoming = to_rgb_color(colors.secondary);
         let color_outgoing = to_rgb_color(colors.outgoing);
         let color_font = to_rgb_color(colors.text_body);
-        let color_mix = self.style.get_palette_extension().alpha_chart_badge;
+        let color_mix = self.style.get_extension().alpha_chart_badge;
 
         chart_builder
             .margin_right(30)

--- a/src/chart/types/traffic_chart.rs
+++ b/src/chart/types/traffic_chart.rs
@@ -8,7 +8,7 @@ use iced::{Element, Renderer};
 use plotters::prelude::*;
 use plotters_iced::{Chart, ChartBuilder, ChartWidget, DrawingBackend};
 
-use crate::gui::styles::style_constants::{CHARTS_LINE_BORDER};
+use crate::gui::styles::style_constants::CHARTS_LINE_BORDER;
 use crate::gui::styles::types::palette::to_rgb_color;
 use crate::gui::types::message::Message;
 use crate::translations::translations::{incoming_translation, outgoing_translation};
@@ -97,11 +97,11 @@ impl Chart<Message> for TrafficChart {
         let tot_seconds = self.ticks - 1;
         let first_time_displayed = if self.ticks > 30 { self.ticks - 30 } else { 0 };
 
-        let colors = get_colors(self.style);
+        let colors = self.style.get_palette();
         let color_incoming = to_rgb_color(colors.secondary);
         let color_outgoing = to_rgb_color(colors.outgoing);
         let color_font = to_rgb_color(colors.text_body);
-        let color_mix = self.style.get_alpha_chart_badge();
+        let color_mix = self.style.get_palette_extension().alpha_chart_badge;
 
         chart_builder
             .margin_right(30)

--- a/src/configs/types/config_settings.rs
+++ b/src/configs/types/config_settings.rs
@@ -25,6 +25,7 @@ impl ConfigSettings {
         if let Ok(settings) = confy::load::<ConfigSettings>("sniffnet", "settings") {
             settings
         } else {
+            println!("{:?}",confy::load::<ConfigSettings>("sniffnet", "settings").err().unwrap());
             confy::store("sniffnet", "settings", ConfigSettings::default()).unwrap_or(());
             ConfigSettings::default()
         }

--- a/src/configs/types/config_settings.rs
+++ b/src/configs/types/config_settings.rs
@@ -25,7 +25,12 @@ impl ConfigSettings {
         if let Ok(settings) = confy::load::<ConfigSettings>("sniffnet", "settings") {
             settings
         } else {
-            println!("{:?}",confy::load::<ConfigSettings>("sniffnet", "settings").err().unwrap());
+            println!(
+                "{:?}",
+                confy::load::<ConfigSettings>("sniffnet", "settings")
+                    .err()
+                    .unwrap()
+            );
             confy::store("sniffnet", "settings", ConfigSettings::default()).unwrap_or(());
             ConfigSettings::default()
         }

--- a/src/configs/types/config_settings.rs
+++ b/src/configs/types/config_settings.rs
@@ -25,12 +25,6 @@ impl ConfigSettings {
         if let Ok(settings) = confy::load::<ConfigSettings>("sniffnet", "settings") {
             settings
         } else {
-            println!(
-                "{:?}",
-                confy::load::<ConfigSettings>("sniffnet", "settings")
-                    .err()
-                    .unwrap()
-            );
             confy::store("sniffnet", "settings", ConfigSettings::default()).unwrap_or(());
             ConfigSettings::default()
         }

--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -25,9 +25,7 @@ use crate::gui::pages::settings_notifications_page::settings_notifications_page;
 use crate::gui::pages::settings_style_page::settings_style_page;
 use crate::gui::pages::types::running_page::RunningPage;
 use crate::gui::pages::types::settings_page::SettingsPage;
-use crate::gui::styles::style_constants::{
-    get_font, get_font_headers, ICONS_BYTES, SARASA_MONO_BOLD_BYTES, SARASA_MONO_BYTES,
-};
+use crate::gui::styles::style_constants::{ICONS_BYTES, SARASA_MONO_BOLD_BYTES, SARASA_MONO_BYTES, };
 use crate::gui::types::message::Message;
 use crate::gui::types::sniffer::Sniffer;
 use crate::StyleType;
@@ -64,8 +62,8 @@ impl Application for Sniffer {
         let style = self.settings.style;
         let language = self.settings.language;
         let color_gradient = self.settings.color_gradient;
-        let font = get_font(style);
-        let font_headers = get_font_headers(style);
+        let font = style.get_font();
+        let font_headers = style.get_font_headers();
 
         let header = header(
             font,

--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -25,7 +25,7 @@ use crate::gui::pages::settings_notifications_page::settings_notifications_page;
 use crate::gui::pages::settings_style_page::settings_style_page;
 use crate::gui::pages::types::running_page::RunningPage;
 use crate::gui::pages::types::settings_page::SettingsPage;
-use crate::gui::styles::style_constants::{ICONS_BYTES, SARASA_MONO_BOLD_BYTES, SARASA_MONO_BYTES, };
+use crate::gui::styles::style_constants::{ICONS_BYTES, SARASA_MONO_BOLD_BYTES, SARASA_MONO_BYTES};
 use crate::gui::types::message::Message;
 use crate::gui::types::sniffer::Sniffer;
 use crate::StyleType;
@@ -62,8 +62,8 @@ impl Application for Sniffer {
         let style = self.settings.style;
         let language = self.settings.language;
         let color_gradient = self.settings.color_gradient;
-        let font = style.get_font();
-        let font_headers = style.get_font_headers();
+        let font = style.get_palette_extension().font;
+        let font_headers = style.get_palette_extension().font_headers;
 
         let header = header(
             font,

--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -62,8 +62,8 @@ impl Application for Sniffer {
         let style = self.settings.style;
         let language = self.settings.language;
         let color_gradient = self.settings.color_gradient;
-        let font = style.get_palette_extension().font;
-        let font_headers = style.get_palette_extension().font_headers;
+        let font = style.get_extension().font;
+        let font_headers = style.get_extension().font_headers;
 
         let header = header(
             font,

--- a/src/gui/pages/connection_details_page.rs
+++ b/src/gui/pages/connection_details_page.rs
@@ -13,7 +13,7 @@ use crate::countries::flags_pictures::FLAGS_WIDTH_BIG;
 use crate::gui::components::button::button_hide;
 use crate::gui::styles::container::ContainerType;
 use crate::gui::styles::scrollbar::ScrollbarType;
-use crate::gui::styles::style_constants::{get_font, get_font_headers, FONT_SIZE_TITLE};
+use crate::gui::styles::style_constants::{FONT_SIZE_TITLE};
 use crate::gui::styles::text::TextType;
 use crate::gui::styles::types::gradient_type::GradientType;
 use crate::gui::types::message::Message;
@@ -60,8 +60,8 @@ fn page_content(
     let style = sniffer.settings.style;
     let language = sniffer.settings.language;
     let color_gradient = sniffer.settings.color_gradient;
-    let font = get_font(style);
-    let font_headers = get_font_headers(style);
+    let font = style.get_font();
+    let font_headers = style.get_font_headers();
 
     let info_traffic_lock = sniffer
         .info_traffic
@@ -326,7 +326,7 @@ fn get_local_tooltip(
             TrafficDirection::Outgoing,
         ),
         language,
-        get_font(style),
+        style.get_font(),
     )
 }
 

--- a/src/gui/pages/connection_details_page.rs
+++ b/src/gui/pages/connection_details_page.rs
@@ -60,8 +60,8 @@ fn page_content(
     let style = sniffer.settings.style;
     let language = sniffer.settings.language;
     let color_gradient = sniffer.settings.color_gradient;
-    let font = style.get_palette_extension().font;
-    let font_headers = style.get_palette_extension().font_headers;
+    let font = style.get_extension().font;
+    let font_headers = style.get_extension().font_headers;
 
     let info_traffic_lock = sniffer
         .info_traffic
@@ -326,7 +326,7 @@ fn get_local_tooltip(
             TrafficDirection::Outgoing,
         ),
         language,
-        style.get_palette_extension().font,
+        style.get_extension().font,
     )
 }
 

--- a/src/gui/pages/connection_details_page.rs
+++ b/src/gui/pages/connection_details_page.rs
@@ -13,7 +13,7 @@ use crate::countries::flags_pictures::FLAGS_WIDTH_BIG;
 use crate::gui::components::button::button_hide;
 use crate::gui::styles::container::ContainerType;
 use crate::gui::styles::scrollbar::ScrollbarType;
-use crate::gui::styles::style_constants::{FONT_SIZE_TITLE};
+use crate::gui::styles::style_constants::FONT_SIZE_TITLE;
 use crate::gui::styles::text::TextType;
 use crate::gui::styles::types::gradient_type::GradientType;
 use crate::gui::types::message::Message;
@@ -60,8 +60,8 @@ fn page_content(
     let style = sniffer.settings.style;
     let language = sniffer.settings.language;
     let color_gradient = sniffer.settings.color_gradient;
-    let font = style.get_font();
-    let font_headers = style.get_font_headers();
+    let font = style.get_palette_extension().font;
+    let font_headers = style.get_palette_extension().font_headers;
 
     let info_traffic_lock = sniffer
         .info_traffic
@@ -326,7 +326,7 @@ fn get_local_tooltip(
             TrafficDirection::Outgoing,
         ),
         language,
-        style.get_font(),
+        style.get_palette_extension().font,
     )
 }
 

--- a/src/gui/pages/initial_page.rs
+++ b/src/gui/pages/initial_page.rs
@@ -19,7 +19,7 @@ use pcap::Device;
 use crate::gui::styles::button::ButtonType;
 use crate::gui::styles::container::ContainerType;
 use crate::gui::styles::scrollbar::ScrollbarType;
-use crate::gui::styles::style_constants::{get_font, FONT_SIZE_SUBTITLE, FONT_SIZE_TITLE};
+use crate::gui::styles::style_constants::{FONT_SIZE_SUBTITLE, FONT_SIZE_TITLE};
 use crate::gui::styles::text::TextType;
 use crate::gui::styles::text_input::TextInputType;
 use crate::gui::styles::types::gradient_type::GradientType;
@@ -42,7 +42,7 @@ pub fn initial_page(sniffer: &Sniffer) -> Container<Message, Renderer<StyleType>
     let style = sniffer.settings.style;
     let language = sniffer.settings.language;
     let color_gradient = sniffer.settings.color_gradient;
-    let font = get_font(style);
+    let font = style.get_font();
 
     let col_adapter = get_col_adapter(sniffer, font);
 

--- a/src/gui/pages/initial_page.rs
+++ b/src/gui/pages/initial_page.rs
@@ -42,7 +42,7 @@ pub fn initial_page(sniffer: &Sniffer) -> Container<Message, Renderer<StyleType>
     let style = sniffer.settings.style;
     let language = sniffer.settings.language;
     let color_gradient = sniffer.settings.color_gradient;
-    let font = style.get_palette_extension().font;
+    let font = style.get_extension().font;
 
     let col_adapter = get_col_adapter(sniffer, font);
 

--- a/src/gui/pages/initial_page.rs
+++ b/src/gui/pages/initial_page.rs
@@ -42,7 +42,7 @@ pub fn initial_page(sniffer: &Sniffer) -> Container<Message, Renderer<StyleType>
     let style = sniffer.settings.style;
     let language = sniffer.settings.language;
     let color_gradient = sniffer.settings.color_gradient;
-    let font = style.get_font();
+    let font = style.get_palette_extension().font;
 
     let col_adapter = get_col_adapter(sniffer, font);
 

--- a/src/gui/pages/inspect_page.rs
+++ b/src/gui/pages/inspect_page.rs
@@ -11,7 +11,7 @@ use crate::gui::components::types::my_modal::MyModal;
 use crate::gui::styles::button::ButtonType;
 use crate::gui::styles::container::ContainerType;
 use crate::gui::styles::scrollbar::ScrollbarType;
-use crate::gui::styles::style_constants::{get_font, get_font_headers, FONT_SIZE_TITLE};
+use crate::gui::styles::style_constants::{FONT_SIZE_TITLE};
 use crate::gui::styles::text::TextType;
 use crate::gui::styles::text_input::TextInputType;
 use crate::gui::types::message::Message;
@@ -31,8 +31,8 @@ use crate::{Language, ReportSortType, RunningPage, Sniffer, StyleType};
 pub fn inspect_page(sniffer: &Sniffer) -> Container<Message, Renderer<StyleType>> {
     let style = sniffer.settings.style;
     let language = sniffer.settings.language;
-    let font = get_font(style);
-    let font_headers = get_font_headers(style);
+    let font = style.get_font();
+    let font_headers = style.get_font_headers();
 
     let mut body = Column::new()
         .width(Length::Fill)
@@ -112,7 +112,7 @@ pub fn inspect_page(sniffer: &Sniffer) -> Container<Message, Renderer<StyleType>
 fn lazy_report(sniffer: &Sniffer) -> Container<'static, Message, Renderer<StyleType>> {
     let style = sniffer.settings.style;
     let language = sniffer.settings.language;
-    let font = get_font(style);
+    let font = style.get_font();
 
     let (search_results, results_number) = get_searched_entries(sniffer);
 

--- a/src/gui/pages/inspect_page.rs
+++ b/src/gui/pages/inspect_page.rs
@@ -11,7 +11,7 @@ use crate::gui::components::types::my_modal::MyModal;
 use crate::gui::styles::button::ButtonType;
 use crate::gui::styles::container::ContainerType;
 use crate::gui::styles::scrollbar::ScrollbarType;
-use crate::gui::styles::style_constants::{FONT_SIZE_TITLE};
+use crate::gui::styles::style_constants::FONT_SIZE_TITLE;
 use crate::gui::styles::text::TextType;
 use crate::gui::styles::text_input::TextInputType;
 use crate::gui::types::message::Message;
@@ -31,8 +31,8 @@ use crate::{Language, ReportSortType, RunningPage, Sniffer, StyleType};
 pub fn inspect_page(sniffer: &Sniffer) -> Container<Message, Renderer<StyleType>> {
     let style = sniffer.settings.style;
     let language = sniffer.settings.language;
-    let font = style.get_font();
-    let font_headers = style.get_font_headers();
+    let font = style.get_palette_extension().font;
+    let font_headers = style.get_palette_extension().font_headers;
 
     let mut body = Column::new()
         .width(Length::Fill)
@@ -112,7 +112,7 @@ pub fn inspect_page(sniffer: &Sniffer) -> Container<Message, Renderer<StyleType>
 fn lazy_report(sniffer: &Sniffer) -> Container<'static, Message, Renderer<StyleType>> {
     let style = sniffer.settings.style;
     let language = sniffer.settings.language;
-    let font = style.get_font();
+    let font = style.get_palette_extension().font;
 
     let (search_results, results_number) = get_searched_entries(sniffer);
 

--- a/src/gui/pages/inspect_page.rs
+++ b/src/gui/pages/inspect_page.rs
@@ -31,8 +31,8 @@ use crate::{Language, ReportSortType, RunningPage, Sniffer, StyleType};
 pub fn inspect_page(sniffer: &Sniffer) -> Container<Message, Renderer<StyleType>> {
     let style = sniffer.settings.style;
     let language = sniffer.settings.language;
-    let font = style.get_palette_extension().font;
-    let font_headers = style.get_palette_extension().font_headers;
+    let font = style.get_extension().font;
+    let font_headers = style.get_extension().font_headers;
 
     let mut body = Column::new()
         .width(Length::Fill)
@@ -112,7 +112,7 @@ pub fn inspect_page(sniffer: &Sniffer) -> Container<Message, Renderer<StyleType>
 fn lazy_report(sniffer: &Sniffer) -> Container<'static, Message, Renderer<StyleType>> {
     let style = sniffer.settings.style;
     let language = sniffer.settings.language;
-    let font = style.get_palette_extension().font;
+    let font = style.get_extension().font;
 
     let (search_results, results_number) = get_searched_entries(sniffer);
 

--- a/src/gui/pages/notifications_page.rs
+++ b/src/gui/pages/notifications_page.rs
@@ -14,7 +14,7 @@ use crate::gui::components::types::my_modal::MyModal;
 use crate::gui::pages::types::settings_page::SettingsPage;
 use crate::gui::styles::container::ContainerType;
 use crate::gui::styles::scrollbar::ScrollbarType;
-use crate::gui::styles::style_constants::{get_font, get_font_headers, FONT_SIZE_FOOTER};
+use crate::gui::styles::style_constants::{FONT_SIZE_FOOTER};
 use crate::gui::styles::text::TextType;
 use crate::gui::types::message::Message;
 use crate::notifications::types::logged_notification::{
@@ -36,8 +36,8 @@ pub fn notifications_page(sniffer: &Sniffer) -> Container<Message, Renderer<Styl
     let style = sniffer.settings.style;
     let language = sniffer.settings.language;
     let notifications = sniffer.settings.notifications;
-    let font = get_font(style);
-    let font_headers = get_font_headers(style);
+    let font = style.get_font();
+    let font_headers = style.get_font_headers();
 
     let mut tab_and_body = Column::new()
         .align_items(Alignment::Center)
@@ -398,7 +398,7 @@ fn get_button_clear_all(
 fn lazy_logged_notifications(sniffer: &Sniffer) -> Column<'static, Message, Renderer<StyleType>> {
     let style = sniffer.settings.style;
     let language = sniffer.settings.language;
-    let font = get_font(style);
+    let font = style.get_font();
     let mut ret_val = Column::new()
         .width(Length::Fixed(830.0))
         .padding(5)

--- a/src/gui/pages/notifications_page.rs
+++ b/src/gui/pages/notifications_page.rs
@@ -36,8 +36,8 @@ pub fn notifications_page(sniffer: &Sniffer) -> Container<Message, Renderer<Styl
     let style = sniffer.settings.style;
     let language = sniffer.settings.language;
     let notifications = sniffer.settings.notifications;
-    let font = style.get_palette_extension().font;
-    let font_headers = style.get_palette_extension().font_headers;
+    let font = style.get_extension().font;
+    let font_headers = style.get_extension().font_headers;
 
     let mut tab_and_body = Column::new()
         .align_items(Alignment::Center)
@@ -398,7 +398,7 @@ fn get_button_clear_all(
 fn lazy_logged_notifications(sniffer: &Sniffer) -> Column<'static, Message, Renderer<StyleType>> {
     let style = sniffer.settings.style;
     let language = sniffer.settings.language;
-    let font = style.get_palette_extension().font;
+    let font = style.get_extension().font;
     let mut ret_val = Column::new()
         .width(Length::Fixed(830.0))
         .padding(5)

--- a/src/gui/pages/notifications_page.rs
+++ b/src/gui/pages/notifications_page.rs
@@ -14,7 +14,7 @@ use crate::gui::components::types::my_modal::MyModal;
 use crate::gui::pages::types::settings_page::SettingsPage;
 use crate::gui::styles::container::ContainerType;
 use crate::gui::styles::scrollbar::ScrollbarType;
-use crate::gui::styles::style_constants::{FONT_SIZE_FOOTER};
+use crate::gui::styles::style_constants::FONT_SIZE_FOOTER;
 use crate::gui::styles::text::TextType;
 use crate::gui::types::message::Message;
 use crate::notifications::types::logged_notification::{
@@ -36,8 +36,8 @@ pub fn notifications_page(sniffer: &Sniffer) -> Container<Message, Renderer<Styl
     let style = sniffer.settings.style;
     let language = sniffer.settings.language;
     let notifications = sniffer.settings.notifications;
-    let font = style.get_font();
-    let font_headers = style.get_font_headers();
+    let font = style.get_palette_extension().font;
+    let font_headers = style.get_palette_extension().font_headers;
 
     let mut tab_and_body = Column::new()
         .align_items(Alignment::Center)
@@ -398,7 +398,7 @@ fn get_button_clear_all(
 fn lazy_logged_notifications(sniffer: &Sniffer) -> Column<'static, Message, Renderer<StyleType>> {
     let style = sniffer.settings.style;
     let language = sniffer.settings.language;
-    let font = style.get_font();
+    let font = style.get_palette_extension().font;
     let mut ret_val = Column::new()
         .width(Length::Fixed(830.0))
         .padding(5)

--- a/src/gui/pages/notifications_page.rs
+++ b/src/gui/pages/notifications_page.rs
@@ -337,7 +337,7 @@ fn favorite_notification_log(
         .height(Length::Fill)
         .push(
             Tooltip::new(
-                Icon::Star.to_text().size(80),
+                Icon::Star.to_text().size(80).style(TextType::Starred),
                 favorite_transmitted_translation(language),
                 Position::FollowCursor,
             )

--- a/src/gui/pages/overview_page.rs
+++ b/src/gui/pages/overview_page.rs
@@ -51,8 +51,8 @@ use crate::{AppProtocol, ChartType, Language, RunningPage, StyleType};
 pub fn overview_page(sniffer: &Sniffer) -> Container<Message, Renderer<StyleType>> {
     let style = sniffer.settings.style;
     let language = sniffer.settings.language;
-    let font = style.get_palette_extension().font;
-    let font_headers = style.get_palette_extension().font_headers;
+    let font = style.get_extension().font;
+    let font_headers = style.get_extension().font_headers;
 
     let mut body = Column::new();
     let mut tab_and_body = Column::new().height(Length::Fill);
@@ -242,7 +242,7 @@ fn lazy_row_report(sniffer: &Sniffer) -> Container<'static, Message, Renderer<St
 fn col_host(width: f32, sniffer: &Sniffer) -> Column<'static, Message, Renderer<StyleType>> {
     let language = sniffer.settings.language;
     let style = sniffer.settings.style;
-    let font = style.get_palette_extension().font;
+    let font = style.get_extension().font;
     let chart_type = sniffer.traffic_chart.chart_type;
 
     let mut scroll_host = Column::new()
@@ -339,7 +339,7 @@ fn col_host(width: f32, sniffer: &Sniffer) -> Column<'static, Message, Renderer<
 fn col_app(width: f32, sniffer: &Sniffer) -> Column<'static, Message, Renderer<StyleType>> {
     let style = sniffer.settings.style;
     let language = sniffer.settings.language;
-    let font = style.get_palette_extension().font;
+    let font = style.get_extension().font;
     let chart_type = sniffer.traffic_chart.chart_type;
 
     let mut col_app = Column::new()
@@ -414,7 +414,7 @@ fn lazy_col_info(
 ) -> Container<'static, Message, Renderer<StyleType>> {
     let style = sniffer.settings.style;
     let language = sniffer.settings.language;
-    let font = style.get_palette_extension().font;
+    let font = style.get_extension().font;
     let filtered_bytes =
         sniffer.runtime_data.tot_sent_bytes + sniffer.runtime_data.tot_received_bytes;
     let all_bytes = sniffer.runtime_data.all_bytes;

--- a/src/gui/pages/overview_page.rs
+++ b/src/gui/pages/overview_page.rs
@@ -20,7 +20,7 @@ use crate::gui::styles::button::ButtonType;
 use crate::gui::styles::container::ContainerType;
 use crate::gui::styles::rule::RuleType;
 use crate::gui::styles::scrollbar::ScrollbarType;
-use crate::gui::styles::style_constants::{get_font, get_font_headers, FONT_SIZE_TITLE};
+use crate::gui::styles::style_constants::{FONT_SIZE_TITLE};
 use crate::gui::styles::text::TextType;
 use crate::gui::types::message::Message;
 use crate::gui::types::sniffer::Sniffer;
@@ -51,8 +51,8 @@ use crate::{AppProtocol, ChartType, Language, RunningPage, StyleType};
 pub fn overview_page(sniffer: &Sniffer) -> Container<Message, Renderer<StyleType>> {
     let style = sniffer.settings.style;
     let language = sniffer.settings.language;
-    let font = get_font(style);
-    let font_headers = get_font_headers(style);
+    let font = style.get_font();
+    let font_headers = style.get_font_headers();
 
     let mut body = Column::new();
     let mut tab_and_body = Column::new().height(Length::Fill);
@@ -241,7 +241,7 @@ fn lazy_row_report(sniffer: &Sniffer) -> Container<'static, Message, Renderer<St
 
 fn col_host(width: f32, sniffer: &Sniffer) -> Column<'static, Message, Renderer<StyleType>> {
     let language = sniffer.settings.language;
-    let font = get_font(sniffer.settings.style);
+    let font = sniffer.settings.style.get_font();
     let chart_type = sniffer.traffic_chart.chart_type;
 
     let mut scroll_host = Column::new()
@@ -338,7 +338,7 @@ fn col_host(width: f32, sniffer: &Sniffer) -> Column<'static, Message, Renderer<
 fn col_app(width: f32, sniffer: &Sniffer) -> Column<'static, Message, Renderer<StyleType>> {
     let style = sniffer.settings.style;
     let language = sniffer.settings.language;
-    let font = get_font(style);
+    let font = style.get_font();
     let chart_type = sniffer.traffic_chart.chart_type;
 
     let mut col_app = Column::new()
@@ -413,7 +413,7 @@ fn lazy_col_info(
 ) -> Container<'static, Message, Renderer<StyleType>> {
     let style = sniffer.settings.style;
     let language = sniffer.settings.language;
-    let font = get_font(style);
+    let font = style.get_font();
     let filtered_bytes =
         sniffer.runtime_data.tot_sent_bytes + sniffer.runtime_data.tot_received_bytes;
     let all_bytes = sniffer.runtime_data.all_bytes;

--- a/src/gui/pages/overview_page.rs
+++ b/src/gui/pages/overview_page.rs
@@ -20,7 +20,7 @@ use crate::gui::styles::button::ButtonType;
 use crate::gui::styles::container::ContainerType;
 use crate::gui::styles::rule::RuleType;
 use crate::gui::styles::scrollbar::ScrollbarType;
-use crate::gui::styles::style_constants::{FONT_SIZE_TITLE};
+use crate::gui::styles::style_constants::FONT_SIZE_TITLE;
 use crate::gui::styles::text::TextType;
 use crate::gui::types::message::Message;
 use crate::gui::types::sniffer::Sniffer;
@@ -51,8 +51,8 @@ use crate::{AppProtocol, ChartType, Language, RunningPage, StyleType};
 pub fn overview_page(sniffer: &Sniffer) -> Container<Message, Renderer<StyleType>> {
     let style = sniffer.settings.style;
     let language = sniffer.settings.language;
-    let font = style.get_font();
-    let font_headers = style.get_font_headers();
+    let font = style.get_palette_extension().font;
+    let font_headers = style.get_palette_extension().font_headers;
 
     let mut body = Column::new();
     let mut tab_and_body = Column::new().height(Length::Fill);
@@ -241,7 +241,8 @@ fn lazy_row_report(sniffer: &Sniffer) -> Container<'static, Message, Renderer<St
 
 fn col_host(width: f32, sniffer: &Sniffer) -> Column<'static, Message, Renderer<StyleType>> {
     let language = sniffer.settings.language;
-    let font = sniffer.settings.style.get_font();
+    let style = sniffer.settings.style;
+    let font = style.get_palette_extension().font;
     let chart_type = sniffer.traffic_chart.chart_type;
 
     let mut scroll_host = Column::new()
@@ -338,7 +339,7 @@ fn col_host(width: f32, sniffer: &Sniffer) -> Column<'static, Message, Renderer<
 fn col_app(width: f32, sniffer: &Sniffer) -> Column<'static, Message, Renderer<StyleType>> {
     let style = sniffer.settings.style;
     let language = sniffer.settings.language;
-    let font = style.get_font();
+    let font = style.get_palette_extension().font;
     let chart_type = sniffer.traffic_chart.chart_type;
 
     let mut col_app = Column::new()
@@ -413,7 +414,7 @@ fn lazy_col_info(
 ) -> Container<'static, Message, Renderer<StyleType>> {
     let style = sniffer.settings.style;
     let language = sniffer.settings.language;
-    let font = style.get_font();
+    let font = style.get_palette_extension().font;
     let filtered_bytes =
         sniffer.runtime_data.tot_sent_bytes + sniffer.runtime_data.tot_received_bytes;
     let all_bytes = sniffer.runtime_data.all_bytes;

--- a/src/gui/pages/settings_general_page.rs
+++ b/src/gui/pages/settings_general_page.rs
@@ -14,7 +14,7 @@ use crate::gui::components::tab::get_settings_tabs;
 use crate::gui::pages::settings_notifications_page::settings_header;
 use crate::gui::pages::types::settings_page::SettingsPage;
 use crate::gui::styles::container::ContainerType;
-use crate::gui::styles::style_constants::{get_font, get_font_headers, FONT_SIZE_SUBTITLE};
+use crate::gui::styles::style_constants::{FONT_SIZE_SUBTITLE};
 use crate::gui::styles::text::TextType;
 use crate::gui::styles::text_input::TextInputType;
 use crate::gui::types::message::Message;
@@ -31,8 +31,8 @@ pub fn settings_general_page(sniffer: &Sniffer) -> Container<Message, Renderer<S
     let style = sniffer.settings.style;
     let language = sniffer.settings.language;
     let color_gradient = sniffer.settings.color_gradient;
-    let font = get_font(style);
-    let font_headers = get_font_headers(style);
+    let font = style.get_font();
+    let font_headers = style.get_font_headers();
 
     let content = Column::new()
         .align_items(Alignment::Center)

--- a/src/gui/pages/settings_general_page.rs
+++ b/src/gui/pages/settings_general_page.rs
@@ -31,8 +31,8 @@ pub fn settings_general_page(sniffer: &Sniffer) -> Container<Message, Renderer<S
     let style = sniffer.settings.style;
     let language = sniffer.settings.language;
     let color_gradient = sniffer.settings.color_gradient;
-    let font = style.get_palette_extension().font;
-    let font_headers = style.get_palette_extension().font_headers;
+    let font = style.get_extension().font;
+    let font_headers = style.get_extension().font_headers;
 
     let content = Column::new()
         .align_items(Alignment::Center)

--- a/src/gui/pages/settings_general_page.rs
+++ b/src/gui/pages/settings_general_page.rs
@@ -14,7 +14,7 @@ use crate::gui::components::tab::get_settings_tabs;
 use crate::gui::pages::settings_notifications_page::settings_header;
 use crate::gui::pages::types::settings_page::SettingsPage;
 use crate::gui::styles::container::ContainerType;
-use crate::gui::styles::style_constants::{FONT_SIZE_SUBTITLE};
+use crate::gui::styles::style_constants::FONT_SIZE_SUBTITLE;
 use crate::gui::styles::text::TextType;
 use crate::gui::styles::text_input::TextInputType;
 use crate::gui::types::message::Message;
@@ -31,8 +31,8 @@ pub fn settings_general_page(sniffer: &Sniffer) -> Container<Message, Renderer<S
     let style = sniffer.settings.style;
     let language = sniffer.settings.language;
     let color_gradient = sniffer.settings.color_gradient;
-    let font = style.get_font();
-    let font_headers = style.get_font_headers();
+    let font = style.get_palette_extension().font;
+    let font_headers = style.get_palette_extension().font_headers;
 
     let content = Column::new()
         .align_items(Alignment::Center)

--- a/src/gui/pages/settings_notifications_page.rs
+++ b/src/gui/pages/settings_notifications_page.rs
@@ -14,7 +14,7 @@ use crate::gui::styles::button::ButtonType;
 use crate::gui::styles::container::ContainerType;
 use crate::gui::styles::scrollbar::ScrollbarType;
 use crate::gui::styles::style_constants::{
-    get_font, get_font_headers, FONT_SIZE_FOOTER, FONT_SIZE_SUBTITLE, FONT_SIZE_TITLE,
+    FONT_SIZE_FOOTER, FONT_SIZE_SUBTITLE, FONT_SIZE_TITLE,
 };
 use crate::gui::styles::text::TextType;
 use crate::gui::styles::types::gradient_type::GradientType;
@@ -37,8 +37,8 @@ pub fn settings_notifications_page(sniffer: &Sniffer) -> Container<Message, Rend
     let language = sniffer.settings.language;
     let color_gradient = sniffer.settings.color_gradient;
     let notifications = sniffer.settings.notifications;
-    let font = get_font(style);
-    let font_headers = get_font_headers(style);
+    let font = style.get_font();
+    let font_headers = style.get_font_headers();
 
     let mut content = Column::new()
         .width(Length::Fill)

--- a/src/gui/pages/settings_notifications_page.rs
+++ b/src/gui/pages/settings_notifications_page.rs
@@ -35,8 +35,8 @@ pub fn settings_notifications_page(sniffer: &Sniffer) -> Container<Message, Rend
     let language = sniffer.settings.language;
     let color_gradient = sniffer.settings.color_gradient;
     let notifications = sniffer.settings.notifications;
-    let font = style.get_palette_extension().font;
-    let font_headers = style.get_palette_extension().font_headers;
+    let font = style.get_extension().font;
+    let font_headers = style.get_extension().font_headers;
 
     let mut content = Column::new()
         .width(Length::Fill)

--- a/src/gui/pages/settings_notifications_page.rs
+++ b/src/gui/pages/settings_notifications_page.rs
@@ -13,9 +13,7 @@ use crate::gui::pages::types::settings_page::SettingsPage;
 use crate::gui::styles::button::ButtonType;
 use crate::gui::styles::container::ContainerType;
 use crate::gui::styles::scrollbar::ScrollbarType;
-use crate::gui::styles::style_constants::{
-    FONT_SIZE_FOOTER, FONT_SIZE_SUBTITLE, FONT_SIZE_TITLE,
-};
+use crate::gui::styles::style_constants::{FONT_SIZE_FOOTER, FONT_SIZE_SUBTITLE, FONT_SIZE_TITLE};
 use crate::gui::styles::text::TextType;
 use crate::gui::styles::types::gradient_type::GradientType;
 use crate::gui::types::message::Message;
@@ -37,8 +35,8 @@ pub fn settings_notifications_page(sniffer: &Sniffer) -> Container<Message, Rend
     let language = sniffer.settings.language;
     let color_gradient = sniffer.settings.color_gradient;
     let notifications = sniffer.settings.notifications;
-    let font = style.get_font();
-    let font_headers = style.get_font_headers();
+    let font = style.get_palette_extension().font;
+    let font_headers = style.get_palette_extension().font_headers;
 
     let mut content = Column::new()
         .width(Length::Fill)

--- a/src/gui/pages/settings_notifications_page.rs
+++ b/src/gui/pages/settings_notifications_page.rs
@@ -63,6 +63,7 @@ pub fn settings_notifications_page(sniffer: &Sniffer) -> Container<Message, Rend
         .push(vertical_space(Fixed(5.0)));
 
     let volume_notification_col = Column::new()
+        .padding([0, 0, 5, 0])
         .align_items(Alignment::Center)
         .width(Length::Fill)
         .push(volume_slider(language, font, notifications.volume))

--- a/src/gui/pages/settings_style_page.rs
+++ b/src/gui/pages/settings_style_page.rs
@@ -15,7 +15,7 @@ use crate::gui::styles::scrollbar::ScrollbarType;
 use crate::gui::styles::style_constants::{BORDER_WIDTH, FONT_SIZE_SUBTITLE};
 use crate::gui::styles::text::TextType;
 use crate::gui::styles::text_input::TextInputType;
-use crate::gui::styles::types::custom_palette::{ExtraStyles};
+use crate::gui::styles::types::custom_palette::ExtraStyles;
 use crate::gui::styles::types::gradient_type::GradientType;
 use crate::gui::styles::types::palette::Palette;
 use crate::gui::types::message::Message;
@@ -221,25 +221,25 @@ fn get_palette_rule(
 
     Container::new(
         Row::new()
+            .push(Row::new().width(Length::Fixed(120.0)).push(
+                Rule::horizontal(height).style(RuleType::PaletteColor(palette.primary, is_custom)),
+            ))
             .push(
-                Row::new()
-                    .width(Length::Fixed(120.0))
-                    .push(Rule::horizontal(height).style(RuleType::PaletteColor(palette.primary, is_custom))),
+                Row::new().width(Length::Fixed(80.0)).push(
+                    Rule::horizontal(height)
+                        .style(RuleType::PaletteColor(palette.secondary, is_custom)),
+                ),
             )
-            .push(
-                Row::new()
-                    .width(Length::Fixed(80.0))
-                    .push(Rule::horizontal(height).style(RuleType::PaletteColor(palette.secondary, is_custom))),
-            )
-            .push(
-                Row::new()
-                    .width(Length::Fixed(60.0))
-                    .push(Rule::horizontal(height).style(RuleType::PaletteColor(palette.outgoing, is_custom))),
-            )
+            .push(Row::new().width(Length::Fixed(60.0)).push(
+                Rule::horizontal(height).style(RuleType::PaletteColor(palette.outgoing, is_custom)),
+            ))
             .push(
                 Row::new()
                     .width(Length::Fixed(40.0))
-                    .push(Rule::horizontal(height).style(RuleType::PaletteColor(palette.generate_buttons_color(), is_custom))),
+                    .push(Rule::horizontal(height).style(RuleType::PaletteColor(
+                        palette.generate_buttons_color(),
+                        is_custom,
+                    ))),
             ),
     )
     .align_x(Horizontal::Center)
@@ -300,8 +300,7 @@ fn lazy_custom_style_input(
     custom_path: &str,
     style: StyleType,
 ) -> Button<'static, Message, Renderer<StyleType>> {
-    let is_custom_toml_style_set =
-        matches!(style, StyleType::Custom(ExtraStyles::CustomToml(_)));
+    let is_custom_toml_style_set = matches!(style, StyleType::Custom(ExtraStyles::CustomToml(_)));
 
     let custom_palette = Palette::from_file(custom_path);
     let is_error = if custom_path.is_empty() {
@@ -331,10 +330,7 @@ fn lazy_custom_style_input(
     if is_custom_toml_style_set {
         content = content.push(get_palette_rule(style.get_palette(), true));
     } else if let Ok(palette) = custom_palette {
-        content = content.push(get_palette_rule(
-            palette,
-            true,
-        ));
+        content = content.push(get_palette_rule(palette, true));
     }
 
     Button::new(content)

--- a/src/gui/pages/settings_style_page.rs
+++ b/src/gui/pages/settings_style_page.rs
@@ -12,13 +12,12 @@ use crate::gui::styles::button::ButtonType;
 use crate::gui::styles::container::ContainerType;
 use crate::gui::styles::rule::RuleType;
 use crate::gui::styles::scrollbar::ScrollbarType;
-use crate::gui::styles::style_constants::{
-    BORDER_WIDTH, FONT_SIZE_SUBTITLE,
-};
+use crate::gui::styles::style_constants::{BORDER_WIDTH, FONT_SIZE_SUBTITLE};
 use crate::gui::styles::text::TextType;
 use crate::gui::styles::text_input::TextInputType;
-use crate::gui::styles::types::custom_palette::{ExtraStyles};
+use crate::gui::styles::types::custom_palette::ExtraStyles;
 use crate::gui::styles::types::gradient_type::GradientType;
+use crate::gui::styles::types::palette::Palette;
 use crate::gui::types::message::Message;
 use crate::translations::translations::{
     appearance_title_translation, deep_sea_translation, mon_amour_translation,
@@ -29,15 +28,14 @@ use crate::translations::translations_3::custom_style_translation;
 use crate::utils::types::icon::Icon;
 use crate::StyleType::{Day, DeepSea, MonAmour, Night};
 use crate::{Language, Sniffer, StyleType};
-use crate::gui::styles::types::palette::Palette;
 
 pub fn settings_style_page(sniffer: &Sniffer) -> Container<Message, Renderer<StyleType>> {
     let style = sniffer.settings.style;
     let style_path = &sniffer.settings.style_path;
     let color_gradient = sniffer.settings.color_gradient;
     let language = sniffer.settings.language;
-    let font = style.get_font();
-    let font_headers = style.get_font_headers();
+    let font = style.get_palette_extension().font;
+    let font_headers = style.get_palette_extension().font_headers;
 
     let mut content = Column::new()
         .align_items(Alignment::Center)
@@ -188,7 +186,7 @@ fn get_palette_container(
     description: String,
     on_press: StyleType,
 ) -> Button<'static, Message, Renderer<StyleType>> {
-    let font = style.get_font();
+    let font = style.get_palette_extension().font;
 
     let is_custom = matches!(on_press, StyleType::Custom(_));
 
@@ -302,7 +300,8 @@ fn lazy_custom_style_input(
     custom_path: &str,
     style: StyleType,
 ) -> Button<'static, Message, Renderer<StyleType>> {
-    let is_custom_toml_style_set = matches!(style, StyleType::Custom(ExtraStyles::CustomToml(_)));
+    let is_custom_toml_style_set =
+        matches!(style, StyleType::Custom(ExtraStyles::CustomToml(_, _)));
 
     let custom_palette = Palette::from_file(custom_path);
     let is_error = if custom_path.is_empty() {
@@ -333,7 +332,7 @@ fn lazy_custom_style_input(
         content = content.push(get_palette(style, true));
     } else if let Ok(palette) = custom_palette {
         content = content.push(get_palette(
-            StyleType::Custom(ExtraStyles::CustomToml(palette)),
+            StyleType::Custom(ExtraStyles::CustomToml(palette, palette.generate_palette_extension())),
             true,
         ));
     }

--- a/src/gui/pages/settings_style_page.rs
+++ b/src/gui/pages/settings_style_page.rs
@@ -15,7 +15,7 @@ use crate::gui::styles::scrollbar::ScrollbarType;
 use crate::gui::styles::style_constants::{BORDER_WIDTH, FONT_SIZE_SUBTITLE};
 use crate::gui::styles::text::TextType;
 use crate::gui::styles::text_input::TextInputType;
-use crate::gui::styles::types::custom_palette::{CustomPalette, ExtraStyles};
+use crate::gui::styles::types::custom_palette::{ExtraStyles};
 use crate::gui::styles::types::gradient_type::GradientType;
 use crate::gui::styles::types::palette::Palette;
 use crate::gui::types::message::Message;
@@ -195,7 +195,7 @@ fn get_palette_container(
         .align_items(Alignment::Center)
         .spacing(5)
         .push(Text::new(name).font(font))
-        .push(get_palette(on_press, is_custom));
+        .push(get_palette_rule(on_press.get_palette(), is_custom));
 
     if !is_custom {
         content = content.push(Text::new(description).font(font));
@@ -213,8 +213,8 @@ fn get_palette_container(
         .on_press(Message::Style(on_press))
 }
 
-fn get_palette(
-    style: StyleType,
+fn get_palette_rule(
+    palette: Palette,
     is_custom: bool,
 ) -> Container<'static, Message, Renderer<StyleType>> {
     let height = if is_custom { 25.0 } else { 40.0 };
@@ -224,22 +224,22 @@ fn get_palette(
             .push(
                 Row::new()
                     .width(Length::Fixed(120.0))
-                    .push(Rule::horizontal(height).style(RuleType::PalettePrimary(style))),
+                    .push(Rule::horizontal(height).style(RuleType::PaletteColor(palette.primary, is_custom))),
             )
             .push(
                 Row::new()
                     .width(Length::Fixed(80.0))
-                    .push(Rule::horizontal(height).style(RuleType::PaletteSecondary(style))),
+                    .push(Rule::horizontal(height).style(RuleType::PaletteColor(palette.secondary, is_custom))),
             )
             .push(
                 Row::new()
                     .width(Length::Fixed(60.0))
-                    .push(Rule::horizontal(height).style(RuleType::PaletteOutgoing(style))),
+                    .push(Rule::horizontal(height).style(RuleType::PaletteColor(palette.outgoing, is_custom))),
             )
             .push(
                 Row::new()
                     .width(Length::Fixed(40.0))
-                    .push(Rule::horizontal(height).style(RuleType::PaletteButtons(style))),
+                    .push(Rule::horizontal(height).style(RuleType::PaletteColor(palette.generate_buttons_color(), is_custom))),
             ),
     )
     .align_x(Horizontal::Center)
@@ -329,12 +329,10 @@ fn lazy_custom_style_input(
         .push(input);
 
     if is_custom_toml_style_set {
-        content = content.push(get_palette(style, true));
+        content = content.push(get_palette_rule(style.get_palette(), true));
     } else if let Ok(palette) = custom_palette {
-        content = content.push(get_palette(
-            StyleType::Custom(ExtraStyles::CustomToml(
-                CustomPalette::from_palette(palette)
-            )),
+        content = content.push(get_palette_rule(
+            palette,
             true,
         ));
     }

--- a/src/gui/pages/settings_style_page.rs
+++ b/src/gui/pages/settings_style_page.rs
@@ -34,8 +34,8 @@ pub fn settings_style_page(sniffer: &Sniffer) -> Container<Message, Renderer<Sty
     let style_path = &sniffer.settings.style_path;
     let color_gradient = sniffer.settings.color_gradient;
     let language = sniffer.settings.language;
-    let font = style.get_palette_extension().font;
-    let font_headers = style.get_palette_extension().font_headers;
+    let font = style.get_extension().font;
+    let font_headers = style.get_extension().font_headers;
 
     let mut content = Column::new()
         .align_items(Alignment::Center)
@@ -186,7 +186,7 @@ fn get_palette_container(
     description: String,
     on_press: StyleType,
 ) -> Button<'static, Message, Renderer<StyleType>> {
-    let font = style.get_palette_extension().font;
+    let font = style.get_extension().font;
 
     let is_custom = matches!(on_press, StyleType::Custom(_));
 

--- a/src/gui/pages/settings_style_page.rs
+++ b/src/gui/pages/settings_style_page.rs
@@ -332,7 +332,10 @@ fn lazy_custom_style_input(
         content = content.push(get_palette(style, true));
     } else if let Ok(palette) = custom_palette {
         content = content.push(get_palette(
-            StyleType::Custom(ExtraStyles::CustomToml(palette, palette.generate_palette_extension())),
+            StyleType::Custom(ExtraStyles::CustomToml(
+                palette,
+                palette.generate_palette_extension(),
+            )),
             true,
         ));
     }

--- a/src/gui/pages/settings_style_page.rs
+++ b/src/gui/pages/settings_style_page.rs
@@ -38,6 +38,7 @@ pub fn settings_style_page(sniffer: &Sniffer) -> Container<Message, Renderer<Sty
     let font_headers = style.get_extension().font_headers;
 
     let mut content = Column::new()
+        .padding([0, 0, 5, 0])
         .align_items(Alignment::Center)
         .width(Length::Fill)
         .push(settings_header(

--- a/src/gui/pages/settings_style_page.rs
+++ b/src/gui/pages/settings_style_page.rs
@@ -3,7 +3,7 @@ use iced::widget::scrollable::Direction;
 use iced::widget::{button, horizontal_space, lazy, vertical_space, Rule, TextInput};
 use iced::widget::{Button, Column, Container, Row, Scrollable, Space, Text};
 use iced::Length::Fixed;
-use iced::{Alignment, Element, Font, Length, Renderer};
+use iced::{Alignment, Color, Element, Font, Length, Renderer};
 
 use crate::gui::components::tab::get_settings_tabs;
 use crate::gui::pages::settings_notifications_page::settings_header;
@@ -195,7 +195,11 @@ fn get_palette_container(
         .align_items(Alignment::Center)
         .spacing(5)
         .push(Text::new(name).font(font))
-        .push(get_palette_rule(on_press.get_palette(), is_custom));
+        .push(get_palette_rule(
+            on_press.get_palette(),
+            on_press.get_extension().buttons_color,
+            is_custom,
+        ));
 
     if !is_custom {
         content = content.push(Text::new(description).font(font));
@@ -215,37 +219,30 @@ fn get_palette_container(
 
 fn get_palette_rule(
     palette: Palette,
+    buttons_color: Color,
     is_custom: bool,
 ) -> Container<'static, Message, Renderer<StyleType>> {
-    let height = if is_custom { 25.0 } else { 40.0 };
+    let height = if is_custom { 25 } else { 40 };
 
     Container::new(
         Row::new()
             .push(Row::new().width(Length::Fixed(120.0)).push(
-                Rule::horizontal(height).style(RuleType::PaletteColor(palette.primary, is_custom)),
+                Rule::horizontal(height).style(RuleType::PaletteColor(palette.primary, height)),
             ))
-            .push(
-                Row::new().width(Length::Fixed(80.0)).push(
-                    Rule::horizontal(height)
-                        .style(RuleType::PaletteColor(palette.secondary, is_custom)),
-                ),
-            )
+            .push(Row::new().width(Length::Fixed(80.0)).push(
+                Rule::horizontal(height).style(RuleType::PaletteColor(palette.secondary, height)),
+            ))
             .push(Row::new().width(Length::Fixed(60.0)).push(
-                Rule::horizontal(height).style(RuleType::PaletteColor(palette.outgoing, is_custom)),
+                Rule::horizontal(height).style(RuleType::PaletteColor(palette.outgoing, height)),
             ))
-            .push(
-                Row::new()
-                    .width(Length::Fixed(40.0))
-                    .push(Rule::horizontal(height).style(RuleType::PaletteColor(
-                        palette.generate_buttons_color(),
-                        is_custom,
-                    ))),
-            ),
+            .push(Row::new().width(Length::Fixed(40.0)).push(
+                Rule::horizontal(height).style(RuleType::PaletteColor(buttons_color, height)),
+            )),
     )
     .align_x(Horizontal::Center)
     .align_y(Vertical::Center)
     .width(300.0 + 2.0 * BORDER_WIDTH)
-    .height(height + 1.7 * BORDER_WIDTH)
+    .height(f32::from(height) + 1.7 * BORDER_WIDTH)
     .style(ContainerType::Palette)
 }
 
@@ -328,9 +325,17 @@ fn lazy_custom_style_input(
         .push(input);
 
     if is_custom_toml_style_set {
-        content = content.push(get_palette_rule(style.get_palette(), true));
+        content = content.push(get_palette_rule(
+            style.get_palette(),
+            style.get_extension().buttons_color,
+            true,
+        ));
     } else if let Ok(palette) = custom_palette {
-        content = content.push(get_palette_rule(palette, true));
+        content = content.push(get_palette_rule(
+            palette,
+            palette.generate_buttons_color(),
+            true,
+        ));
     }
 
     Button::new(content)

--- a/src/gui/pages/settings_style_page.rs
+++ b/src/gui/pages/settings_style_page.rs
@@ -13,11 +13,11 @@ use crate::gui::styles::container::ContainerType;
 use crate::gui::styles::rule::RuleType;
 use crate::gui::styles::scrollbar::ScrollbarType;
 use crate::gui::styles::style_constants::{
-    get_font, get_font_headers, BORDER_WIDTH, FONT_SIZE_SUBTITLE,
+    BORDER_WIDTH, FONT_SIZE_SUBTITLE,
 };
 use crate::gui::styles::text::TextType;
 use crate::gui::styles::text_input::TextInputType;
-use crate::gui::styles::types::custom_palette::{CustomPalette, ExtraStyles};
+use crate::gui::styles::types::custom_palette::{ExtraStyles};
 use crate::gui::styles::types::gradient_type::GradientType;
 use crate::gui::types::message::Message;
 use crate::translations::translations::{
@@ -29,14 +29,15 @@ use crate::translations::translations_3::custom_style_translation;
 use crate::utils::types::icon::Icon;
 use crate::StyleType::{Day, DeepSea, MonAmour, Night};
 use crate::{Language, Sniffer, StyleType};
+use crate::gui::styles::types::palette::Palette;
 
 pub fn settings_style_page(sniffer: &Sniffer) -> Container<Message, Renderer<StyleType>> {
     let style = sniffer.settings.style;
     let style_path = &sniffer.settings.style_path;
     let color_gradient = sniffer.settings.color_gradient;
     let language = sniffer.settings.language;
-    let font = get_font(style);
-    let font_headers = get_font_headers(style);
+    let font = style.get_font();
+    let font_headers = style.get_font_headers();
 
     let mut content = Column::new()
         .align_items(Alignment::Center)
@@ -187,7 +188,7 @@ fn get_palette_container(
     description: String,
     on_press: StyleType,
 ) -> Button<'static, Message, Renderer<StyleType>> {
-    let font = get_font(style);
+    let font = style.get_font();
 
     let is_custom = matches!(on_press, StyleType::Custom(_));
 
@@ -303,7 +304,7 @@ fn lazy_custom_style_input(
 ) -> Button<'static, Message, Renderer<StyleType>> {
     let is_custom_toml_style_set = matches!(style, StyleType::Custom(ExtraStyles::CustomToml(_)));
 
-    let custom_palette = CustomPalette::from_file(custom_path);
+    let custom_palette = Palette::from_file(custom_path);
     let is_error = if custom_path.is_empty() {
         false
     } else {

--- a/src/gui/pages/settings_style_page.rs
+++ b/src/gui/pages/settings_style_page.rs
@@ -15,7 +15,7 @@ use crate::gui::styles::scrollbar::ScrollbarType;
 use crate::gui::styles::style_constants::{BORDER_WIDTH, FONT_SIZE_SUBTITLE};
 use crate::gui::styles::text::TextType;
 use crate::gui::styles::text_input::TextInputType;
-use crate::gui::styles::types::custom_palette::ExtraStyles;
+use crate::gui::styles::types::custom_palette::{CustomPalette, ExtraStyles};
 use crate::gui::styles::types::gradient_type::GradientType;
 use crate::gui::styles::types::palette::Palette;
 use crate::gui::types::message::Message;
@@ -301,7 +301,7 @@ fn lazy_custom_style_input(
     style: StyleType,
 ) -> Button<'static, Message, Renderer<StyleType>> {
     let is_custom_toml_style_set =
-        matches!(style, StyleType::Custom(ExtraStyles::CustomToml(_, _)));
+        matches!(style, StyleType::Custom(ExtraStyles::CustomToml(_)));
 
     let custom_palette = Palette::from_file(custom_path);
     let is_error = if custom_path.is_empty() {
@@ -333,8 +333,7 @@ fn lazy_custom_style_input(
     } else if let Ok(palette) = custom_palette {
         content = content.push(get_palette(
             StyleType::Custom(ExtraStyles::CustomToml(
-                palette,
-                palette.generate_palette_extension(),
+                CustomPalette::from_palette(palette)
             )),
             true,
         ));

--- a/src/gui/styles/button.rs
+++ b/src/gui/styles/button.rs
@@ -11,7 +11,7 @@ use crate::gui::styles::types::gradient_type::{
     get_gradient_buttons, get_gradient_hovered_buttons, GradientType,
 };
 use crate::gui::styles::types::palette::mix_colors;
-use crate::{StyleType};
+use crate::StyleType;
 
 #[derive(Clone, Copy, Default)]
 pub enum ButtonType {
@@ -33,17 +33,17 @@ impl button::StyleSheet for StyleType {
     type Style = ButtonType;
 
     fn active(&self, style: &Self::Style) -> button::Appearance {
-        let colors = get_colors(*self);
-        let color_buttons = self.get_buttons_color();
+        let colors = self.get_palette();
+        let ext = self.get_palette_extension();
         button::Appearance {
             background: Some(match style {
                 ButtonType::TabActive | ButtonType::BorderedRoundSelected => {
-                    Background::Color(mix_colors(colors.primary, color_buttons))
+                    Background::Color(mix_colors(colors.primary, ext.buttons_color))
                 }
                 ButtonType::Starred => Background::Color(colors.starred),
                 ButtonType::BorderedRound => Background::Color(Color {
-                    a: self.get_alpha_round_containers(),
-                    ..color_buttons
+                    a: ext.alpha_round_containers,
+                    ..ext.buttons_color
                 }),
                 ButtonType::Neutral | ButtonType::NotStarred => {
                     Background::Color(Color::TRANSPARENT)
@@ -54,10 +54,10 @@ impl button::StyleSheet for StyleType {
                 ButtonType::Gradient(gradient_type) => Background::Gradient(get_gradient_buttons(
                     &colors,
                     *gradient_type,
-                    self.is_nightly(),
+                    ext.is_nightly,
                     1.0,
                 )),
-                _ => Background::Color(color_buttons),
+                _ => Background::Color(ext.buttons_color),
             }),
             border_radius: match style {
                 ButtonType::Neutral => 0.0.into(),
@@ -88,8 +88,8 @@ impl button::StyleSheet for StyleType {
             border_color: match style {
                 ButtonType::Alert => Color::new(0.8, 0.15, 0.15, 1.0),
                 ButtonType::BorderedRound => Color {
-                    a: self.get_alpha_round_borders(),
-                    ..color_buttons
+                    a: ext.alpha_round_borders,
+                    ..ext.buttons_color
                 },
                 _ => colors.secondary,
             },
@@ -97,8 +97,8 @@ impl button::StyleSheet for StyleType {
     }
 
     fn hovered(&self, style: &Self::Style) -> button::Appearance {
-        let colors = get_colors(*self);
-        let color_buttons = self.get_buttons_color();
+        let colors = self.get_palette();
+        let ext = self.get_palette_extension();
         button::Appearance {
             shadow_offset: match style {
                 ButtonType::Neutral => Vector::default(),
@@ -107,14 +107,17 @@ impl button::StyleSheet for StyleType {
             },
             background: Some(match style {
                 ButtonType::Starred => Background::Color(colors.starred),
-                ButtonType::Neutral => Background::Color(Color{a: get_alpha_round_borders(*self), ..color_buttons}),
+                ButtonType::Neutral => Background::Color(Color {
+                    a: ext.alpha_round_borders,
+                    ..ext.buttons_color
+                }),
                 ButtonType::Gradient(GradientType::None) => {
                     Background::Color(mix_colors(colors.primary, colors.secondary))
                 }
                 ButtonType::Gradient(gradient_type) => Background::Gradient(
-                    get_gradient_hovered_buttons(&colors, *gradient_type, self.is_nightly()),
+                    get_gradient_hovered_buttons(&colors, *gradient_type, ext.is_nightly),
                 ),
-                _ => Background::Color(mix_colors(colors.primary, color_buttons)),
+                _ => Background::Color(mix_colors(colors.primary, ext.buttons_color)),
             }),
             border_radius: match style {
                 ButtonType::Neutral => 0.0.into(),
@@ -133,10 +136,10 @@ impl button::StyleSheet for StyleType {
             border_color: match style {
                 ButtonType::Alert => Color::new(0.8, 0.15, 0.15, 1.0),
                 ButtonType::BorderedRound | ButtonType::NotStarred => Color {
-                    a: get_alpha_round_borders(*self),
-                    ..color_buttons
+                    a: ext.alpha_round_borders,
+                    ..ext.buttons_color
                 },
-                ButtonType::Neutral => color_buttons,
+                ButtonType::Neutral => ext.buttons_color,
                 _ => colors.secondary,
             },
             text_color: match style {
@@ -150,30 +153,30 @@ impl button::StyleSheet for StyleType {
     fn disabled(&self, style: &Self::Style) -> Appearance {
         match style {
             ButtonType::Gradient(_) => {
-                let colors = get_colors(*self);
-                let color_buttons = get_buttons_color(*self);
+                let colors = self.get_palette();
+                let ext = self.get_palette_extension();
                 button::Appearance {
                     background: Some(match style {
                         ButtonType::Gradient(GradientType::None) => Background::Color(Color {
-                            a: get_alpha_round_containers(*self),
+                            a: ext.alpha_round_containers,
                             ..colors.secondary
                         }),
                         ButtonType::Gradient(gradient_type) => {
                             Background::Gradient(get_gradient_buttons(
                                 &colors,
                                 *gradient_type,
-                                self.is_nightly(),
-                                get_alpha_round_containers(*self),
+                                ext.is_nightly,
+                                ext.alpha_round_containers,
                             ))
                         }
-                        _ => Background::Color(color_buttons),
+                        _ => Background::Color(ext.buttons_color),
                     }),
                     border_radius: BORDER_BUTTON_RADIUS.into(),
                     border_width: BORDER_WIDTH,
                     shadow_offset: Vector::new(0.0, 0.0),
                     text_color: colors.text_headers,
                     border_color: Color {
-                        a: get_alpha_round_borders(*self),
+                        a: ext.alpha_round_borders,
                         ..colors.secondary
                     },
                 }

--- a/src/gui/styles/button.rs
+++ b/src/gui/styles/button.rs
@@ -6,15 +6,12 @@ use iced::widget::button;
 use iced::widget::button::Appearance;
 use iced::{Background, Color, Vector};
 
-use crate::gui::styles::style_constants::{
-    get_alpha_round_borders, get_alpha_round_containers, get_starred_color, BORDER_BUTTON_RADIUS,
-    BORDER_WIDTH,
-};
+use crate::gui::styles::style_constants::{BORDER_BUTTON_RADIUS, BORDER_WIDTH};
 use crate::gui::styles::types::gradient_type::{
     get_gradient_buttons, get_gradient_hovered_buttons, GradientType,
 };
 use crate::gui::styles::types::palette::mix_colors;
-use crate::{get_colors, StyleType};
+use crate::{StyleType};
 
 #[derive(Clone, Copy, Default)]
 pub enum ButtonType {
@@ -37,15 +34,16 @@ impl button::StyleSheet for StyleType {
 
     fn active(&self, style: &Self::Style) -> button::Appearance {
         let colors = get_colors(*self);
+        let color_buttons = self.get_buttons_color();
         button::Appearance {
             background: Some(match style {
                 ButtonType::TabActive | ButtonType::BorderedRoundSelected => {
-                    Background::Color(mix_colors(colors.primary, colors.buttons))
+                    Background::Color(mix_colors(colors.primary, color_buttons))
                 }
-                ButtonType::Starred => Background::Color(get_starred_color(*self)),
+                ButtonType::Starred => Background::Color(colors.starred),
                 ButtonType::BorderedRound => Background::Color(Color {
-                    a: get_alpha_round_containers(*self),
-                    ..colors.buttons
+                    a: self.get_alpha_round_containers(),
+                    ..color_buttons
                 }),
                 ButtonType::Neutral | ButtonType::NotStarred => {
                     Background::Color(Color::TRANSPARENT)
@@ -59,7 +57,7 @@ impl button::StyleSheet for StyleType {
                     self.is_nightly(),
                     1.0,
                 )),
-                _ => Background::Color(colors.buttons),
+                _ => Background::Color(color_buttons),
             }),
             border_radius: match style {
                 ButtonType::Neutral => 0.0.into(),
@@ -90,8 +88,8 @@ impl button::StyleSheet for StyleType {
             border_color: match style {
                 ButtonType::Alert => Color::new(0.8, 0.15, 0.15, 1.0),
                 ButtonType::BorderedRound => Color {
-                    a: get_alpha_round_borders(*self),
-                    ..colors.buttons
+                    a: self.get_alpha_round_borders(),
+                    ..color_buttons
                 },
                 _ => colors.secondary,
             },
@@ -100,6 +98,7 @@ impl button::StyleSheet for StyleType {
 
     fn hovered(&self, style: &Self::Style) -> button::Appearance {
         let colors = get_colors(*self);
+        let color_buttons = self.get_buttons_color();
         button::Appearance {
             shadow_offset: match style {
                 ButtonType::Neutral => Vector::default(),
@@ -107,14 +106,15 @@ impl button::StyleSheet for StyleType {
                 _ => Vector::new(0.0, 2.0),
             },
             background: Some(match style {
-                ButtonType::Starred => Background::Color(get_starred_color(*self)),
+                ButtonType::Starred => Background::Color(colors.starred),
+                ButtonType::Neutral => Background::Color(Color{a: get_alpha_round_borders(*self), ..color_buttons}),
                 ButtonType::Gradient(GradientType::None) => {
                     Background::Color(mix_colors(colors.primary, colors.secondary))
                 }
                 ButtonType::Gradient(gradient_type) => Background::Gradient(
                     get_gradient_hovered_buttons(&colors, *gradient_type, self.is_nightly()),
                 ),
-                _ => Background::Color(mix_colors(colors.primary, colors.buttons)),
+                _ => Background::Color(mix_colors(colors.primary, color_buttons)),
             }),
             border_radius: match style {
                 ButtonType::Neutral => 0.0.into(),
@@ -132,10 +132,11 @@ impl button::StyleSheet for StyleType {
             },
             border_color: match style {
                 ButtonType::Alert => Color::new(0.8, 0.15, 0.15, 1.0),
-                ButtonType::BorderedRound | ButtonType::Neutral | ButtonType::NotStarred => Color {
+                ButtonType::BorderedRound | ButtonType::NotStarred => Color {
                     a: get_alpha_round_borders(*self),
-                    ..colors.buttons
+                    ..color_buttons
                 },
+                ButtonType::Neutral => color_buttons,
                 _ => colors.secondary,
             },
             text_color: match style {
@@ -150,6 +151,7 @@ impl button::StyleSheet for StyleType {
         match style {
             ButtonType::Gradient(_) => {
                 let colors = get_colors(*self);
+                let color_buttons = get_buttons_color(*self);
                 button::Appearance {
                     background: Some(match style {
                         ButtonType::Gradient(GradientType::None) => Background::Color(Color {
@@ -164,7 +166,7 @@ impl button::StyleSheet for StyleType {
                                 get_alpha_round_containers(*self),
                             ))
                         }
-                        _ => Background::Color(colors.buttons),
+                        _ => Background::Color(color_buttons),
                     }),
                     border_radius: BORDER_BUTTON_RADIUS.into(),
                     border_width: BORDER_WIDTH,

--- a/src/gui/styles/button.rs
+++ b/src/gui/styles/button.rs
@@ -34,7 +34,7 @@ impl button::StyleSheet for StyleType {
 
     fn active(&self, style: &Self::Style) -> button::Appearance {
         let colors = self.get_palette();
-        let ext = self.get_palette_extension();
+        let ext = self.get_extension();
         button::Appearance {
             background: Some(match style {
                 ButtonType::TabActive | ButtonType::BorderedRoundSelected => {
@@ -98,7 +98,7 @@ impl button::StyleSheet for StyleType {
 
     fn hovered(&self, style: &Self::Style) -> button::Appearance {
         let colors = self.get_palette();
-        let ext = self.get_palette_extension();
+        let ext = self.get_extension();
         button::Appearance {
             shadow_offset: match style {
                 ButtonType::Neutral => Vector::default(),
@@ -154,7 +154,7 @@ impl button::StyleSheet for StyleType {
         match style {
             ButtonType::Gradient(_) => {
                 let colors = self.get_palette();
-                let ext = self.get_palette_extension();
+                let ext = self.get_extension();
                 button::Appearance {
                     background: Some(match style {
                         ButtonType::Gradient(GradientType::None) => Background::Color(Color {

--- a/src/gui/styles/checkbox.rs
+++ b/src/gui/styles/checkbox.rs
@@ -5,7 +5,7 @@
 use iced::widget::checkbox::Appearance;
 use iced::Background;
 
-use crate::{get_colors, StyleType};
+use crate::{ StyleType};
 
 #[derive(Clone, Copy, Default)]
 pub enum CheckboxType {
@@ -18,8 +18,9 @@ impl iced::widget::checkbox::StyleSheet for StyleType {
 
     fn active(&self, _: &Self::Style, is_checked: bool) -> Appearance {
         let colors = get_colors(*self);
+        let color_buttons = get_buttons_color(*self);
         Appearance {
-            background: Background::Color(colors.buttons),
+            background: Background::Color(color_buttons),
             icon_color: colors.text_body,
             border_radius: 0.0.into(),
             border_width: if is_checked { 1.0 } else { 0.0 },
@@ -30,8 +31,9 @@ impl iced::widget::checkbox::StyleSheet for StyleType {
 
     fn hovered(&self, _: &Self::Style, _is_checked: bool) -> Appearance {
         let colors = get_colors(*self);
+        let color_buttons = get_buttons_color(*self);
         Appearance {
-            background: Background::Color(colors.buttons),
+            background: Background::Color(color_buttons),
             icon_color: colors.text_body,
             border_radius: 0.0.into(),
             border_width: 1.0,

--- a/src/gui/styles/checkbox.rs
+++ b/src/gui/styles/checkbox.rs
@@ -5,7 +5,7 @@
 use iced::widget::checkbox::Appearance;
 use iced::Background;
 
-use crate::{ StyleType};
+use crate::StyleType;
 
 #[derive(Clone, Copy, Default)]
 pub enum CheckboxType {
@@ -17,10 +17,10 @@ impl iced::widget::checkbox::StyleSheet for StyleType {
     type Style = CheckboxType;
 
     fn active(&self, _: &Self::Style, is_checked: bool) -> Appearance {
-        let colors = get_colors(*self);
-        let color_buttons = get_buttons_color(*self);
+        let colors = self.get_palette();
+        let ext = self.get_palette_extension();
         Appearance {
-            background: Background::Color(color_buttons),
+            background: Background::Color(ext.buttons_color),
             icon_color: colors.text_body,
             border_radius: 0.0.into(),
             border_width: if is_checked { 1.0 } else { 0.0 },
@@ -30,10 +30,10 @@ impl iced::widget::checkbox::StyleSheet for StyleType {
     }
 
     fn hovered(&self, _: &Self::Style, _is_checked: bool) -> Appearance {
-        let colors = get_colors(*self);
-        let color_buttons = get_buttons_color(*self);
+        let colors = self.get_palette();
+        let ext = self.get_palette_extension();
         Appearance {
-            background: Background::Color(color_buttons),
+            background: Background::Color(ext.buttons_color),
             icon_color: colors.text_body,
             border_radius: 0.0.into(),
             border_width: 1.0,

--- a/src/gui/styles/checkbox.rs
+++ b/src/gui/styles/checkbox.rs
@@ -18,7 +18,7 @@ impl iced::widget::checkbox::StyleSheet for StyleType {
 
     fn active(&self, _: &Self::Style, is_checked: bool) -> Appearance {
         let colors = self.get_palette();
-        let ext = self.get_palette_extension();
+        let ext = self.get_extension();
         Appearance {
             background: Background::Color(ext.buttons_color),
             icon_color: colors.text_body,
@@ -31,7 +31,7 @@ impl iced::widget::checkbox::StyleSheet for StyleType {
 
     fn hovered(&self, _: &Self::Style, _is_checked: bool) -> Appearance {
         let colors = self.get_palette();
-        let ext = self.get_palette_extension();
+        let ext = self.get_extension();
         Appearance {
             background: Background::Color(ext.buttons_color),
             icon_color: colors.text_body,

--- a/src/gui/styles/container.rs
+++ b/src/gui/styles/container.rs
@@ -27,7 +27,7 @@ impl iced::widget::container::StyleSheet for StyleType {
 
     fn appearance(&self, style: &Self::Style) -> Appearance {
         let colors = self.get_palette();
-        let ext = self.get_palette_extension();
+        let ext = self.get_extension();
         Appearance {
             text_color: Some(match style {
                 ContainerType::Gradient(_) => colors.text_headers,

--- a/src/gui/styles/container.rs
+++ b/src/gui/styles/container.rs
@@ -7,7 +7,7 @@ use iced::{Background, Color};
 
 use crate::gui::styles::style_constants::{BORDER_ROUNDED_RADIUS, BORDER_WIDTH};
 use crate::gui::styles::types::gradient_type::{get_gradient_headers, GradientType};
-use crate::{ StyleType};
+use crate::StyleType;
 
 #[derive(Clone, Copy, Default)]
 pub enum ContainerType {
@@ -26,8 +26,8 @@ impl iced::widget::container::StyleSheet for StyleType {
     type Style = ContainerType;
 
     fn appearance(&self, style: &Self::Style) -> Appearance {
-        let colors = get_colors(*self);
-        let color_buttons = get_buttons_color(*self);
+        let colors = self.get_palette();
+        let ext = self.get_palette_extension();
         Appearance {
             text_color: Some(match style {
                 ContainerType::Gradient(_) => colors.text_headers,
@@ -35,20 +35,20 @@ impl iced::widget::container::StyleSheet for StyleType {
             }),
             background: Some(match style {
                 ContainerType::Gradient(GradientType::None) => Background::Color(colors.secondary),
-                ContainerType::Tooltip => Background::Color(color_buttons),
+                ContainerType::Tooltip => Background::Color(ext.buttons_color),
                 ContainerType::BorderedRound => Background::Color(Color {
-                    a: get_alpha_round_containers(*self),
-                    ..color_buttons
+                    a: ext.alpha_round_containers,
+                    ..ext.buttons_color
                 }),
                 ContainerType::Neutral | ContainerType::Palette => {
                     Background::Color(Color::TRANSPARENT)
                 }
                 ContainerType::Badge => Background::Color(Color {
-                    a: get_alpha_chart_badge(*self),
+                    a: ext.alpha_chart_badge,
                     ..colors.secondary
                 }),
                 ContainerType::Gradient(gradient_type) => Background::Gradient(
-                    get_gradient_headers(&colors, *gradient_type, self.is_nightly()),
+                    get_gradient_headers(&colors, *gradient_type, ext.is_nightly),
                 ),
                 ContainerType::Modal => Background::Color(colors.primary),
                 ContainerType::Standard => Background::Color(Color::TRANSPARENT),
@@ -74,8 +74,8 @@ impl iced::widget::container::StyleSheet for StyleType {
             border_color: match style {
                 ContainerType::Palette => Color::BLACK,
                 _ => Color {
-                    a: get_alpha_round_borders(*self),
-                    ..color_buttons
+                    a: ext.alpha_round_borders,
+                    ..ext.buttons_color
                 },
             },
         }

--- a/src/gui/styles/container.rs
+++ b/src/gui/styles/container.rs
@@ -5,12 +5,9 @@
 use iced::widget::container::Appearance;
 use iced::{Background, Color};
 
-use crate::gui::styles::style_constants::{
-    get_alpha_chart_badge, get_alpha_round_borders, get_alpha_round_containers,
-    BORDER_ROUNDED_RADIUS, BORDER_WIDTH,
-};
+use crate::gui::styles::style_constants::{BORDER_ROUNDED_RADIUS, BORDER_WIDTH};
 use crate::gui::styles::types::gradient_type::{get_gradient_headers, GradientType};
-use crate::{get_colors, StyleType};
+use crate::{ StyleType};
 
 #[derive(Clone, Copy, Default)]
 pub enum ContainerType {
@@ -30,6 +27,7 @@ impl iced::widget::container::StyleSheet for StyleType {
 
     fn appearance(&self, style: &Self::Style) -> Appearance {
         let colors = get_colors(*self);
+        let color_buttons = get_buttons_color(*self);
         Appearance {
             text_color: Some(match style {
                 ContainerType::Gradient(_) => colors.text_headers,
@@ -37,10 +35,10 @@ impl iced::widget::container::StyleSheet for StyleType {
             }),
             background: Some(match style {
                 ContainerType::Gradient(GradientType::None) => Background::Color(colors.secondary),
-                ContainerType::Tooltip => Background::Color(colors.buttons),
+                ContainerType::Tooltip => Background::Color(color_buttons),
                 ContainerType::BorderedRound => Background::Color(Color {
                     a: get_alpha_round_containers(*self),
-                    ..colors.buttons
+                    ..color_buttons
                 }),
                 ContainerType::Neutral | ContainerType::Palette => {
                     Background::Color(Color::TRANSPARENT)
@@ -77,7 +75,7 @@ impl iced::widget::container::StyleSheet for StyleType {
                 ContainerType::Palette => Color::BLACK,
                 _ => Color {
                     a: get_alpha_round_borders(*self),
-                    ..colors.buttons
+                    ..color_buttons
                 },
             },
         }

--- a/src/gui/styles/custom_themes/dracula.rs
+++ b/src/gui/styles/custom_themes/dracula.rs
@@ -22,14 +22,14 @@ pub static DRACULA_DARK_PALETTE_EXTENSION: Lazy<PaletteExtension> =
     Lazy::new(|| DRACULA_DARK_PALETTE.generate_palette_extension());
 
 // Light Darker variant
-pub const DRACULA_LIGHT_PALETTE: Palette = Palette {
+pub const DRACULA_LIGHT_PALETTE: Lazy<Palette> = Lazy::new(|| Palette {
     primary: color!(0xf8f8f2),
     secondary: color!(0x9f1670),
     outgoing: color!(0x005d6f),
     starred: color!(0xffb86c, 0.8),
     text_headers: color!(0xf8f8f2),
     text_body: color!(0x282a36),
-};
+});
 
 pub static DRACULA_LIGHT_PALETTE_EXTENSION: Lazy<PaletteExtension> =
     Lazy::new(|| DRACULA_LIGHT_PALETTE.generate_palette_extension());

--- a/src/gui/styles/custom_themes/dracula.rs
+++ b/src/gui/styles/custom_themes/dracula.rs
@@ -5,46 +5,27 @@
 //! Light style from: <https://github.com/AshGrowem/Dracula.min/>
 use iced::color;
 
-use crate::gui::styles::types::custom_palette::{CustomPalette, PaletteExtension};
 use crate::gui::styles::types::palette::Palette;
 
-pub(in crate::gui::styles) fn dracula_dark() -> CustomPalette {
-    CustomPalette {
-        palette: Palette {
-            primary: color!(0x282a36),      // Background
-            secondary: color!(0xff79c6),    // Pink
-            outgoing: color!(0x8be9fd),     // Cyan
-            buttons: color!(0x6272a4),      // Comments
-            text_headers: color!(0x282a36), // Background
-            text_body: color!(0xf8f8f2),    // Foreground
-        },
-        extension: PaletteExtension {
-            starred: color!(0xf1fa8c, 0.7),
-            round_borders_alpha: 0.1,
-            round_containers_alpha: 0.04,
-            chart_badge_alpha: 0.15,
-            nightly: true,
-        },
+pub(in crate::gui::styles) fn dracula_dark() -> Palette {
+    Palette {
+        primary: color!(0x282a36),   // Background
+        secondary: color!(0xff79c6), // Pink
+        outgoing: color!(0x8be9fd),  // Cyan
+        starred: color!(0xf1fa8c, 0.7),
+        text_headers: color!(0x282a36), // Background
+        text_body: color!(0xf8f8f2),    // Foreground
     }
 }
 
 // Light Darker variant
-pub(in crate::gui::styles) fn dracula_light() -> CustomPalette {
-    CustomPalette {
-        palette: Palette {
-            primary: color!(0xf8f8f2),
-            secondary: color!(0x9f1670),
-            outgoing: color!(0x005d6f),
-            buttons: color!(0xc5c8de),
-            text_headers: color!(0xf8f8f2),
-            text_body: color!(0x282a36),
-        },
-        extension: PaletteExtension {
-            starred: color!(0xffb86c, 0.8),
-            chart_badge_alpha: 0.75,
-            round_borders_alpha: 0.45,
-            round_containers_alpha: 0.25,
-            nightly: false,
-        },
+pub(in crate::gui::styles) fn dracula_light() -> Palette {
+    Palette {
+        primary: color!(0xf8f8f2),
+        secondary: color!(0x9f1670),
+        outgoing: color!(0x005d6f),
+        starred: color!(0xffb86c, 0.8),
+        text_headers: color!(0xf8f8f2),
+        text_body: color!(0x282a36),
     }
 }

--- a/src/gui/styles/custom_themes/dracula.rs
+++ b/src/gui/styles/custom_themes/dracula.rs
@@ -4,28 +4,32 @@
 //! <https://draculatheme.com/>
 //! Light style from: <https://github.com/AshGrowem/Dracula.min/>
 use iced::color;
+use once_cell::sync::Lazy;
 
 use crate::gui::styles::types::palette::Palette;
+use crate::gui::styles::types::palette_extension::PaletteExtension;
 
-pub(in crate::gui::styles) fn dracula_dark() -> Palette {
-    Palette {
-        primary: color!(0x282a36),   // Background
-        secondary: color!(0xff79c6), // Pink
-        outgoing: color!(0x8be9fd),  // Cyan
-        starred: color!(0xf1fa8c, 0.7),
-        text_headers: color!(0x282a36), // Background
-        text_body: color!(0xf8f8f2),    // Foreground
-    }
-}
+pub static DRACULA_DARK_PALETTE: Lazy<Palette> = Lazy::new(|| Palette {
+    primary: color!(0x282a36),   // Background
+    secondary: color!(0xff79c6), // Pink
+    outgoing: color!(0x8be9fd),  // Cyan
+    starred: color!(0xf1fa8c, 0.7),
+    text_headers: color!(0x282a36), // Background
+    text_body: color!(0xf8f8f2),    // Foreground
+});
+
+pub static DRACULA_DARK_PALETTE_EXTENSION: Lazy<PaletteExtension> =
+    Lazy::new(|| DRACULA_DARK_PALETTE.generate_palette_extension());
 
 // Light Darker variant
-pub(in crate::gui::styles) fn dracula_light() -> Palette {
-    Palette {
-        primary: color!(0xf8f8f2),
-        secondary: color!(0x9f1670),
-        outgoing: color!(0x005d6f),
-        starred: color!(0xffb86c, 0.8),
-        text_headers: color!(0xf8f8f2),
-        text_body: color!(0x282a36),
-    }
-}
+pub const DRACULA_LIGHT_PALETTE: Palette = Palette {
+    primary: color!(0xf8f8f2),
+    secondary: color!(0x9f1670),
+    outgoing: color!(0x005d6f),
+    starred: color!(0xffb86c, 0.8),
+    text_headers: color!(0xf8f8f2),
+    text_body: color!(0x282a36),
+};
+
+pub static DRACULA_LIGHT_PALETTE_EXTENSION: Lazy<PaletteExtension> =
+    Lazy::new(|| DRACULA_LIGHT_PALETTE.generate_palette_extension());

--- a/src/gui/styles/custom_themes/dracula.rs
+++ b/src/gui/styles/custom_themes/dracula.rs
@@ -22,7 +22,7 @@ pub static DRACULA_DARK_PALETTE_EXTENSION: Lazy<PaletteExtension> =
     Lazy::new(|| DRACULA_DARK_PALETTE.generate_palette_extension());
 
 // Light Darker variant
-pub const DRACULA_LIGHT_PALETTE: Lazy<Palette> = Lazy::new(|| Palette {
+pub static DRACULA_LIGHT_PALETTE: Lazy<Palette> = Lazy::new(|| Palette {
     primary: color!(0xf8f8f2),
     secondary: color!(0x9f1670),
     outgoing: color!(0x005d6f),

--- a/src/gui/styles/custom_themes/gruvbox.rs
+++ b/src/gui/styles/custom_themes/gruvbox.rs
@@ -10,7 +10,7 @@ use crate::gui::styles::types::palette::Palette;
 use crate::gui::styles::types::palette_extension::PaletteExtension;
 
 /// Gruvbox (night style)
-pub const GRUVBOX_DARK_PALETTE: Lazy<Palette> = Lazy::new(|| Palette {
+pub static GRUVBOX_DARK_PALETTE: Lazy<Palette> = Lazy::new(|| Palette {
     primary: color!(0x282828),   // bg
     secondary: color!(0xfe8019), // orange
     outgoing: color!(0x8ec07c),  // aqua
@@ -23,7 +23,7 @@ pub static GRUVBOX_DARK_PALETTE_EXTENSION: Lazy<PaletteExtension> =
     Lazy::new(|| GRUVBOX_DARK_PALETTE.generate_palette_extension());
 
 /// Gruvbox (day style)
-pub const GRUVBOX_LIGHT_PALETTE: Lazy<Palette> = Lazy::new(|| Palette {
+pub static GRUVBOX_LIGHT_PALETTE: Lazy<Palette> = Lazy::new(|| Palette {
     primary: color!(0xfbf1c7),      // bg
     secondary: color!(0xd65d0e),    // orange
     outgoing: color!(0x689d6a),     // aqua

--- a/src/gui/styles/custom_themes/gruvbox.rs
+++ b/src/gui/styles/custom_themes/gruvbox.rs
@@ -5,47 +5,28 @@
 
 use iced::color;
 
-use crate::gui::styles::types::custom_palette::{CustomPalette, PaletteExtension};
 use crate::gui::styles::types::palette::Palette;
 
 /// Gruvbox (night style)
-pub(in crate::gui::styles) fn gruvbox_dark() -> CustomPalette {
-    CustomPalette {
-        palette: Palette {
-            primary: color!(0x282828),      // bg
-            secondary: color!(0xfe8019),    // orange
-            outgoing: color!(0x8ec07c),     // aqua
-            buttons: color!(0x7c6f64),      // bg4
-            text_headers: color!(0x1d2021), // bg0_h
-            text_body: color!(0xebdbb2),    // fg
-        },
-        extension: PaletteExtension {
-            starred: color!(0xd79921, 0.8),
-            chart_badge_alpha: 0.15,
-            round_borders_alpha: 0.12,
-            round_containers_alpha: 0.05,
-            nightly: true,
-        },
+pub(in crate::gui::styles) fn gruvbox_dark() -> Palette {
+    Palette {
+        primary: color!(0x282828),   // bg
+        secondary: color!(0xfe8019), // orange
+        outgoing: color!(0x8ec07c),  // aqua
+        starred: color!(0xd79921, 0.8),
+        text_headers: color!(0x1d2021), // bg0_h
+        text_body: color!(0xebdbb2),    // fg
     }
 }
 
 /// Gruvbox (day style)
-pub(in crate::gui::styles) fn gruvbox_light() -> CustomPalette {
-    CustomPalette {
-        palette: Palette {
-            primary: color!(0xfbf1c7),      // bg
-            secondary: color!(0xd65d0e),    // orange
-            outgoing: color!(0x689d6a),     // aqua
-            buttons: color!(0xd5c4a1),      // bg2
-            text_headers: color!(0xf9f5d7), // bg0_h
-            text_body: color!(0x282828),    // fg
-        },
-        extension: PaletteExtension {
-            starred: color!(0xd79921, 0.8), // yellow
-            chart_badge_alpha: 0.75,
-            round_borders_alpha: 0.45,
-            round_containers_alpha: 0.2,
-            nightly: false,
-        },
+pub(in crate::gui::styles) fn gruvbox_light() -> Palette {
+    Palette {
+        primary: color!(0xfbf1c7),      // bg
+        secondary: color!(0xd65d0e),    // orange
+        outgoing: color!(0x689d6a),     // aqua
+        starred: color!(0xd79921, 0.8), // yellow
+        text_headers: color!(0xf9f5d7), // bg0_h
+        text_body: color!(0x282828),    // fg
     }
 }

--- a/src/gui/styles/custom_themes/gruvbox.rs
+++ b/src/gui/styles/custom_themes/gruvbox.rs
@@ -10,27 +10,27 @@ use crate::gui::styles::types::palette::Palette;
 use crate::gui::styles::types::palette_extension::PaletteExtension;
 
 /// Gruvbox (night style)
-pub const GRUVBOX_DARK_PALETTE: Palette = Palette {
+pub const GRUVBOX_DARK_PALETTE: Lazy<Palette> = Lazy::new(|| Palette {
     primary: color!(0x282828),   // bg
     secondary: color!(0xfe8019), // orange
     outgoing: color!(0x8ec07c),  // aqua
     starred: color!(0xd79921, 0.8),
     text_headers: color!(0x1d2021), // bg0_h
     text_body: color!(0xebdbb2),    // fg
-};
+});
 
 pub static GRUVBOX_DARK_PALETTE_EXTENSION: Lazy<PaletteExtension> =
     Lazy::new(|| GRUVBOX_DARK_PALETTE.generate_palette_extension());
 
 /// Gruvbox (day style)
-pub const GRUVBOX_LIGHT_PALETTE: Palette = Palette {
+pub const GRUVBOX_LIGHT_PALETTE: Lazy<Palette> = Lazy::new(|| Palette {
     primary: color!(0xfbf1c7),      // bg
     secondary: color!(0xd65d0e),    // orange
     outgoing: color!(0x689d6a),     // aqua
     starred: color!(0xd79921, 0.8), // yellow
     text_headers: color!(0xf9f5d7), // bg0_h
     text_body: color!(0x282828),    // fg
-};
+});
 
 pub static GRUVBOX_LIGHT_PALETTE_EXTENSION: Lazy<PaletteExtension> =
     Lazy::new(|| GRUVBOX_LIGHT_PALETTE.generate_palette_extension());

--- a/src/gui/styles/custom_themes/gruvbox.rs
+++ b/src/gui/styles/custom_themes/gruvbox.rs
@@ -4,29 +4,33 @@
 //! <https://github.com/morhetz/gruvbox>
 
 use iced::color;
+use once_cell::sync::Lazy;
 
 use crate::gui::styles::types::palette::Palette;
+use crate::gui::styles::types::palette_extension::PaletteExtension;
 
 /// Gruvbox (night style)
-pub(in crate::gui::styles) fn gruvbox_dark() -> Palette {
-    Palette {
-        primary: color!(0x282828),   // bg
-        secondary: color!(0xfe8019), // orange
-        outgoing: color!(0x8ec07c),  // aqua
-        starred: color!(0xd79921, 0.8),
-        text_headers: color!(0x1d2021), // bg0_h
-        text_body: color!(0xebdbb2),    // fg
-    }
-}
+pub const GRUVBOX_DARK_PALETTE: Palette = Palette {
+    primary: color!(0x282828),   // bg
+    secondary: color!(0xfe8019), // orange
+    outgoing: color!(0x8ec07c),  // aqua
+    starred: color!(0xd79921, 0.8),
+    text_headers: color!(0x1d2021), // bg0_h
+    text_body: color!(0xebdbb2),    // fg
+};
+
+pub static GRUVBOX_DARK_PALETTE_EXTENSION: Lazy<PaletteExtension> =
+    Lazy::new(|| GRUVBOX_DARK_PALETTE.generate_palette_extension());
 
 /// Gruvbox (day style)
-pub(in crate::gui::styles) fn gruvbox_light() -> Palette {
-    Palette {
-        primary: color!(0xfbf1c7),      // bg
-        secondary: color!(0xd65d0e),    // orange
-        outgoing: color!(0x689d6a),     // aqua
-        starred: color!(0xd79921, 0.8), // yellow
-        text_headers: color!(0xf9f5d7), // bg0_h
-        text_body: color!(0x282828),    // fg
-    }
-}
+pub const GRUVBOX_LIGHT_PALETTE: Palette = Palette {
+    primary: color!(0xfbf1c7),      // bg
+    secondary: color!(0xd65d0e),    // orange
+    outgoing: color!(0x689d6a),     // aqua
+    starred: color!(0xd79921, 0.8), // yellow
+    text_headers: color!(0xf9f5d7), // bg0_h
+    text_body: color!(0x282828),    // fg
+};
+
+pub static GRUVBOX_LIGHT_PALETTE_EXTENSION: Lazy<PaletteExtension> =
+    Lazy::new(|| GRUVBOX_LIGHT_PALETTE.generate_palette_extension());

--- a/src/gui/styles/custom_themes/nord.rs
+++ b/src/gui/styles/custom_themes/nord.rs
@@ -8,7 +8,7 @@ use once_cell::sync::Lazy;
 use crate::gui::styles::types::palette::Palette;
 use crate::gui::styles::types::palette_extension::PaletteExtension;
 
-pub const NORD_DARK_PALETTE: Lazy<Palette> = Lazy::new(|| Palette {
+pub static NORD_DARK_PALETTE: Lazy<Palette> = Lazy::new(|| Palette {
     primary: color!(0x2e3440),      // nord0
     secondary: color!(0x88c0d0),    // nord8
     outgoing: color!(0xB48EAD),     // nord15
@@ -20,7 +20,7 @@ pub const NORD_DARK_PALETTE: Lazy<Palette> = Lazy::new(|| Palette {
 pub static NORD_DARK_PALETTE_EXTENSION: Lazy<PaletteExtension> =
     Lazy::new(|| NORD_DARK_PALETTE.generate_palette_extension());
 
-pub const NORD_LIGHT_PALETTE: Lazy<Palette> = Lazy::new(|| Palette {
+pub static NORD_LIGHT_PALETTE: Lazy<Palette> = Lazy::new(|| Palette {
     primary: color!(0xeceff4),      // nord6
     secondary: color!(0x05e81ac),   // nord10
     outgoing: color!(0xb48ead),     // nord15

--- a/src/gui/styles/custom_themes/nord.rs
+++ b/src/gui/styles/custom_themes/nord.rs
@@ -4,45 +4,26 @@
 //! <https://www.nordtheme.com/docs/colors-and-palettes>
 use iced::color;
 
-use crate::gui::styles::types::custom_palette::{CustomPalette, PaletteExtension};
 use crate::gui::styles::types::palette::Palette;
 
-pub(in crate::gui::styles) fn nord_dark() -> CustomPalette {
-    CustomPalette {
-        palette: Palette {
-            primary: color!(0x2e3440),      // nord0
-            secondary: color!(0x88c0d0),    // nord8
-            outgoing: color!(0xB48EAD),     // nord15
-            buttons: color!(0x4C566A),      // nord3
-            text_headers: color!(0x2e3440), // nord0
-            text_body: color!(0xd8dee9),    // nord4
-        },
-        extension: PaletteExtension {
-            starred: color!(0xebcb8b), // nord13
-            chart_badge_alpha: 0.2,
-            round_borders_alpha: 0.35,
-            round_containers_alpha: 0.15,
-            nightly: true,
-        },
+pub(in crate::gui::styles) fn nord_dark() -> Palette {
+    Palette {
+        primary: color!(0x2e3440),      // nord0
+        secondary: color!(0x88c0d0),    // nord8
+        outgoing: color!(0xB48EAD),     // nord15
+        starred: color!(0xebcb8b),      // nord13
+        text_headers: color!(0x2e3440), // nord0
+        text_body: color!(0xd8dee9),    // nord4
     }
 }
 
-pub(in crate::gui::styles) fn nord_light() -> CustomPalette {
-    CustomPalette {
-        palette: Palette {
-            primary: color!(0xeceff4),      // nord6
-            secondary: color!(0x05e81ac),   // nord10
-            outgoing: color!(0xb48ead),     // nord15
-            buttons: color!(0x8FBCBB),      // nord7
-            text_headers: color!(0xeceff4), // nord6
-            text_body: color!(0x2e3440),    // nord0
-        },
-        extension: PaletteExtension {
-            starred: color!(0xebcb8b), // nord13
-            chart_badge_alpha: 0.6,
-            round_borders_alpha: 0.35,
-            round_containers_alpha: 0.15,
-            nightly: false,
-        },
+pub(in crate::gui::styles) fn nord_light() -> Palette {
+    Palette {
+        primary: color!(0xeceff4),      // nord6
+        secondary: color!(0x05e81ac),   // nord10
+        outgoing: color!(0xb48ead),     // nord15
+        starred: color!(0xebcb8b),      // nord13
+        text_headers: color!(0xeceff4), // nord6
+        text_body: color!(0x2e3440),    // nord0
     }
 }

--- a/src/gui/styles/custom_themes/nord.rs
+++ b/src/gui/styles/custom_themes/nord.rs
@@ -3,27 +3,31 @@
 //! Nord theme
 //! <https://www.nordtheme.com/docs/colors-and-palettes>
 use iced::color;
+use once_cell::sync::Lazy;
 
 use crate::gui::styles::types::palette::Palette;
+use crate::gui::styles::types::palette_extension::PaletteExtension;
 
-pub(in crate::gui::styles) fn nord_dark() -> Palette {
-    Palette {
-        primary: color!(0x2e3440),      // nord0
-        secondary: color!(0x88c0d0),    // nord8
-        outgoing: color!(0xB48EAD),     // nord15
-        starred: color!(0xebcb8b),      // nord13
-        text_headers: color!(0x2e3440), // nord0
-        text_body: color!(0xd8dee9),    // nord4
-    }
-}
+pub const NORD_DARK_PALETTE: Palette = Palette {
+    primary: color!(0x2e3440),      // nord0
+    secondary: color!(0x88c0d0),    // nord8
+    outgoing: color!(0xB48EAD),     // nord15
+    starred: color!(0xebcb8b),      // nord13
+    text_headers: color!(0x2e3440), // nord0
+    text_body: color!(0xd8dee9),    // nord4
+};
 
-pub(in crate::gui::styles) fn nord_light() -> Palette {
-    Palette {
-        primary: color!(0xeceff4),      // nord6
-        secondary: color!(0x05e81ac),   // nord10
-        outgoing: color!(0xb48ead),     // nord15
-        starred: color!(0xebcb8b),      // nord13
-        text_headers: color!(0xeceff4), // nord6
-        text_body: color!(0x2e3440),    // nord0
-    }
-}
+pub static NORD_DARK_PALETTE_EXTENSION: Lazy<PaletteExtension> =
+    Lazy::new(|| NORD_DARK_PALETTE.generate_palette_extension());
+
+pub const NORD_LIGHT_PALETTE: Palette = Palette {
+    primary: color!(0xeceff4),      // nord6
+    secondary: color!(0x05e81ac),   // nord10
+    outgoing: color!(0xb48ead),     // nord15
+    starred: color!(0xebcb8b),      // nord13
+    text_headers: color!(0xeceff4), // nord6
+    text_body: color!(0x2e3440),    // nord0
+};
+
+pub static NORD_LIGHT_PALETTE_EXTENSION: Lazy<PaletteExtension> =
+    Lazy::new(|| NORD_LIGHT_PALETTE.generate_palette_extension());

--- a/src/gui/styles/custom_themes/nord.rs
+++ b/src/gui/styles/custom_themes/nord.rs
@@ -8,26 +8,26 @@ use once_cell::sync::Lazy;
 use crate::gui::styles::types::palette::Palette;
 use crate::gui::styles::types::palette_extension::PaletteExtension;
 
-pub const NORD_DARK_PALETTE: Palette = Palette {
+pub const NORD_DARK_PALETTE: Lazy<Palette> = Lazy::new(|| Palette {
     primary: color!(0x2e3440),      // nord0
     secondary: color!(0x88c0d0),    // nord8
     outgoing: color!(0xB48EAD),     // nord15
     starred: color!(0xebcb8b),      // nord13
     text_headers: color!(0x2e3440), // nord0
     text_body: color!(0xd8dee9),    // nord4
-};
+});
 
 pub static NORD_DARK_PALETTE_EXTENSION: Lazy<PaletteExtension> =
     Lazy::new(|| NORD_DARK_PALETTE.generate_palette_extension());
 
-pub const NORD_LIGHT_PALETTE: Palette = Palette {
+pub const NORD_LIGHT_PALETTE: Lazy<Palette> = Lazy::new(|| Palette {
     primary: color!(0xeceff4),      // nord6
     secondary: color!(0x05e81ac),   // nord10
     outgoing: color!(0xb48ead),     // nord15
     starred: color!(0xebcb8b),      // nord13
     text_headers: color!(0xeceff4), // nord6
     text_body: color!(0x2e3440),    // nord0
-};
+});
 
 pub static NORD_LIGHT_PALETTE_EXTENSION: Lazy<PaletteExtension> =
     Lazy::new(|| NORD_LIGHT_PALETTE.generate_palette_extension());

--- a/src/gui/styles/custom_themes/solarized.rs
+++ b/src/gui/styles/custom_themes/solarized.rs
@@ -9,7 +9,7 @@ use crate::gui::styles::types::palette::Palette;
 use crate::gui::styles::types::palette_extension::PaletteExtension;
 
 /// Solarized light (Day style)
-pub const SOLARIZED_LIGHT_PALETTE: Lazy<Palette> = Lazy::new(|| Palette {
+pub static SOLARIZED_LIGHT_PALETTE: Lazy<Palette> = Lazy::new(|| Palette {
     primary: color!(0xfdf6e3),      // base3
     secondary: color!(0x859900),    // green
     outgoing: color!(0x268bd2),     // blue
@@ -22,7 +22,7 @@ pub static SOLARIZED_LIGHT_PALETTE_EXTENSION: Lazy<PaletteExtension> =
     Lazy::new(|| SOLARIZED_LIGHT_PALETTE.generate_palette_extension());
 
 /// Solarized dark (Night style)
-pub const SOLARIZED_DARK_PALETTE: Lazy<Palette> = Lazy::new(|| Palette {
+pub static SOLARIZED_DARK_PALETTE: Lazy<Palette> = Lazy::new(|| Palette {
     primary: color!(0x002b36),      // base03
     secondary: color!(0x859900),    // green
     outgoing: color!(0x268bd2),     // blue

--- a/src/gui/styles/custom_themes/solarized.rs
+++ b/src/gui/styles/custom_themes/solarized.rs
@@ -4,47 +4,28 @@
 //! <https://ethanschoonover.com/solarized/>
 use iced::color;
 
-use crate::gui::styles::types::custom_palette::{CustomPalette, PaletteExtension};
 use crate::gui::styles::types::palette::Palette;
 
 /// Solarized light (Day style)
-pub(in crate::gui::styles) fn solarized_light() -> CustomPalette {
-    CustomPalette {
-        palette: Palette {
-            primary: color!(0xfdf6e3),      // base3
-            secondary: color!(0x859900),    // green
-            outgoing: color!(0x268bd2),     // blue
-            buttons: color!(0x93a1a1),      // base1
-            text_headers: color!(0xfdf6e3), // base3
-            text_body: color!(0x002b36),    // base03
-        },
-        extension: PaletteExtension {
-            starred: color!(0xb58900, 0.9), // yellow
-            chart_badge_alpha: 0.75,
-            round_borders_alpha: 0.35,
-            round_containers_alpha: 0.15,
-            nightly: false,
-        },
+pub(in crate::gui::styles) fn solarized_light() -> Palette {
+    Palette {
+        primary: color!(0xfdf6e3),      // base3
+        secondary: color!(0x859900),    // green
+        outgoing: color!(0x268bd2),     // blue
+        starred: color!(0xb58900, 0.9), // yellow
+        text_headers: color!(0xfdf6e3), // base3
+        text_body: color!(0x002b36),    // base03
     }
 }
 
 /// Solarized dark (Night style)
-pub(in crate::gui::styles) fn solarized_dark() -> CustomPalette {
-    CustomPalette {
-        palette: Palette {
-            primary: color!(0x002b36),      // base03
-            secondary: color!(0x859900),    // green
-            outgoing: color!(0x268bd2),     // blue
-            buttons: color!(0x586e75),      // base01
-            text_headers: color!(0x002b36), // base03
-            text_body: color!(0xeee8d5),    // base2
-        },
-        extension: PaletteExtension {
-            starred: color!(0xb58900), // yellow
-            chart_badge_alpha: 0.25,
-            round_borders_alpha: 0.15,
-            round_containers_alpha: 0.08,
-            nightly: true,
-        },
+pub(in crate::gui::styles) fn solarized_dark() -> Palette {
+    Palette {
+        primary: color!(0x002b36),      // base03
+        secondary: color!(0x859900),    // green
+        outgoing: color!(0x268bd2),     // blue
+        starred: color!(0xb58900),      // yellow
+        text_headers: color!(0x002b36), // base03
+        text_body: color!(0xeee8d5),    // base2
     }
 }

--- a/src/gui/styles/custom_themes/solarized.rs
+++ b/src/gui/styles/custom_themes/solarized.rs
@@ -3,29 +3,33 @@
 //! Solarized
 //! <https://ethanschoonover.com/solarized/>
 use iced::color;
+use once_cell::sync::Lazy;
 
 use crate::gui::styles::types::palette::Palette;
+use crate::gui::styles::types::palette_extension::PaletteExtension;
 
 /// Solarized light (Day style)
-pub(in crate::gui::styles) fn solarized_light() -> Palette {
-    Palette {
-        primary: color!(0xfdf6e3),      // base3
-        secondary: color!(0x859900),    // green
-        outgoing: color!(0x268bd2),     // blue
-        starred: color!(0xb58900, 0.9), // yellow
-        text_headers: color!(0xfdf6e3), // base3
-        text_body: color!(0x002b36),    // base03
-    }
-}
+pub const SOLARIZED_LIGHT_PALETTE: Palette = Palette {
+    primary: color!(0xfdf6e3),      // base3
+    secondary: color!(0x859900),    // green
+    outgoing: color!(0x268bd2),     // blue
+    starred: color!(0xb58900, 0.9), // yellow
+    text_headers: color!(0xfdf6e3), // base3
+    text_body: color!(0x002b36),    // base03
+};
+
+pub static SOLARIZED_LIGHT_PALETTE_EXTENSION: Lazy<PaletteExtension> =
+    Lazy::new(|| SOLARIZED_LIGHT_PALETTE.generate_palette_extension());
 
 /// Solarized dark (Night style)
-pub(in crate::gui::styles) fn solarized_dark() -> Palette {
-    Palette {
-        primary: color!(0x002b36),      // base03
-        secondary: color!(0x859900),    // green
-        outgoing: color!(0x268bd2),     // blue
-        starred: color!(0xb58900),      // yellow
-        text_headers: color!(0x002b36), // base03
-        text_body: color!(0xeee8d5),    // base2
-    }
-}
+pub const SOLARIZED_DARK_PALETTE: Palette = Palette {
+    primary: color!(0x002b36),      // base03
+    secondary: color!(0x859900),    // green
+    outgoing: color!(0x268bd2),     // blue
+    starred: color!(0xb58900),      // yellow
+    text_headers: color!(0x002b36), // base03
+    text_body: color!(0xeee8d5),    // base2
+};
+
+pub static SOLARIZED_DARK_PALETTE_EXTENSION: Lazy<PaletteExtension> =
+    Lazy::new(|| SOLARIZED_DARK_PALETTE.generate_palette_extension());

--- a/src/gui/styles/custom_themes/solarized.rs
+++ b/src/gui/styles/custom_themes/solarized.rs
@@ -9,27 +9,27 @@ use crate::gui::styles::types::palette::Palette;
 use crate::gui::styles::types::palette_extension::PaletteExtension;
 
 /// Solarized light (Day style)
-pub const SOLARIZED_LIGHT_PALETTE: Palette = Palette {
+pub const SOLARIZED_LIGHT_PALETTE: Lazy<Palette> = Lazy::new(|| Palette {
     primary: color!(0xfdf6e3),      // base3
     secondary: color!(0x859900),    // green
     outgoing: color!(0x268bd2),     // blue
     starred: color!(0xb58900, 0.9), // yellow
     text_headers: color!(0xfdf6e3), // base3
     text_body: color!(0x002b36),    // base03
-};
+});
 
 pub static SOLARIZED_LIGHT_PALETTE_EXTENSION: Lazy<PaletteExtension> =
     Lazy::new(|| SOLARIZED_LIGHT_PALETTE.generate_palette_extension());
 
 /// Solarized dark (Night style)
-pub const SOLARIZED_DARK_PALETTE: Palette = Palette {
+pub const SOLARIZED_DARK_PALETTE: Lazy<Palette> = Lazy::new(|| Palette {
     primary: color!(0x002b36),      // base03
     secondary: color!(0x859900),    // green
     outgoing: color!(0x268bd2),     // blue
     starred: color!(0xb58900),      // yellow
     text_headers: color!(0x002b36), // base03
     text_body: color!(0xeee8d5),    // base2
-};
+});
 
 pub static SOLARIZED_DARK_PALETTE_EXTENSION: Lazy<PaletteExtension> =
     Lazy::new(|| SOLARIZED_DARK_PALETTE.generate_palette_extension());

--- a/src/gui/styles/picklist.rs
+++ b/src/gui/styles/picklist.rs
@@ -19,7 +19,7 @@ impl iced::overlay::menu::StyleSheet for StyleType {
 
     fn appearance(&self, _: &Self::Style) -> iced::overlay::menu::Appearance {
         let colors = self.get_palette();
-        let ext = self.get_palette_extension();
+        let ext = self.get_extension();
         iced::overlay::menu::Appearance {
             text_color: colors.text_body,
             background: Background::Color(ext.buttons_color),
@@ -37,7 +37,7 @@ impl pick_list::StyleSheet for StyleType {
 
     fn active(&self, _: &Self::Style) -> pick_list::Appearance {
         let colors = self.get_palette();
-        let ext = self.get_palette_extension();
+        let ext = self.get_extension();
         pick_list::Appearance {
             text_color: colors.text_body,
             placeholder_color: colors.text_body,
@@ -54,7 +54,7 @@ impl pick_list::StyleSheet for StyleType {
 
     fn hovered(&self, _: &Self::Style) -> pick_list::Appearance {
         let colors = self.get_palette();
-        let ext = self.get_palette_extension();
+        let ext = self.get_extension();
         pick_list::Appearance {
             text_color: colors.text_body,
             placeholder_color: colors.text_body,

--- a/src/gui/styles/picklist.rs
+++ b/src/gui/styles/picklist.rs
@@ -5,9 +5,8 @@
 use iced::widget::pick_list;
 use iced::{Background, Color};
 
-use crate::gui::styles::style_constants::get_alpha_round_borders;
 use crate::gui::styles::types::palette::mix_colors;
-use crate::{get_colors, StyleType};
+use crate::{ StyleType};
 
 #[derive(Clone, Copy, Default)]
 pub enum PicklistType {
@@ -20,14 +19,15 @@ impl iced::overlay::menu::StyleSheet for StyleType {
 
     fn appearance(&self, _: &Self::Style) -> iced::overlay::menu::Appearance {
         let colors = get_colors(*self);
+        let color_buttons = get_buttons_color(*self);
         iced::overlay::menu::Appearance {
             text_color: colors.text_body,
-            background: Background::Color(colors.buttons),
+            background: Background::Color(color_buttons),
             border_width: 1.0,
             border_radius: 0.0.into(),
             border_color: colors.secondary,
             selected_text_color: colors.text_body,
-            selected_background: Background::Color(mix_colors(colors.buttons, colors.primary)),
+            selected_background: Background::Color(mix_colors(color_buttons, colors.primary)),
         }
     }
 }
@@ -37,27 +37,29 @@ impl pick_list::StyleSheet for StyleType {
 
     fn active(&self, _: &Self::Style) -> pick_list::Appearance {
         let colors = get_colors(*self);
+        let color_buttons = get_buttons_color(*self);
         pick_list::Appearance {
             text_color: colors.text_body,
             placeholder_color: colors.text_body,
             handle_color: colors.text_body,
-            background: Background::Color(colors.buttons),
+            background: Background::Color(color_buttons),
             border_radius: 0.0.into(),
             border_width: 1.0,
             border_color: Color {
                 a: get_alpha_round_borders(*self),
-                ..colors.buttons
+                ..color_buttons
             },
         }
     }
 
     fn hovered(&self, _: &Self::Style) -> pick_list::Appearance {
         let colors = get_colors(*self);
+        let color_buttons = get_buttons_color(*self);
         pick_list::Appearance {
             text_color: colors.text_body,
             placeholder_color: colors.text_body,
             handle_color: colors.text_body,
-            background: Background::Color(mix_colors(colors.buttons, colors.primary)),
+            background: Background::Color(mix_colors(color_buttons, colors.primary)),
             border_radius: 0.0.into(),
             border_width: 1.0,
             border_color: colors.secondary,

--- a/src/gui/styles/picklist.rs
+++ b/src/gui/styles/picklist.rs
@@ -6,7 +6,7 @@ use iced::widget::pick_list;
 use iced::{Background, Color};
 
 use crate::gui::styles::types::palette::mix_colors;
-use crate::{ StyleType};
+use crate::StyleType;
 
 #[derive(Clone, Copy, Default)]
 pub enum PicklistType {
@@ -18,16 +18,16 @@ impl iced::overlay::menu::StyleSheet for StyleType {
     type Style = PicklistType;
 
     fn appearance(&self, _: &Self::Style) -> iced::overlay::menu::Appearance {
-        let colors = get_colors(*self);
-        let color_buttons = get_buttons_color(*self);
+        let colors = self.get_palette();
+        let ext = self.get_palette_extension();
         iced::overlay::menu::Appearance {
             text_color: colors.text_body,
-            background: Background::Color(color_buttons),
+            background: Background::Color(ext.buttons_color),
             border_width: 1.0,
             border_radius: 0.0.into(),
             border_color: colors.secondary,
             selected_text_color: colors.text_body,
-            selected_background: Background::Color(mix_colors(color_buttons, colors.primary)),
+            selected_background: Background::Color(mix_colors(ext.buttons_color, colors.primary)),
         }
     }
 }
@@ -36,30 +36,30 @@ impl pick_list::StyleSheet for StyleType {
     type Style = PicklistType;
 
     fn active(&self, _: &Self::Style) -> pick_list::Appearance {
-        let colors = get_colors(*self);
-        let color_buttons = get_buttons_color(*self);
+        let colors = self.get_palette();
+        let ext = self.get_palette_extension();
         pick_list::Appearance {
             text_color: colors.text_body,
             placeholder_color: colors.text_body,
             handle_color: colors.text_body,
-            background: Background::Color(color_buttons),
+            background: Background::Color(ext.buttons_color),
             border_radius: 0.0.into(),
             border_width: 1.0,
             border_color: Color {
-                a: get_alpha_round_borders(*self),
-                ..color_buttons
+                a: ext.alpha_round_borders,
+                ..ext.buttons_color
             },
         }
     }
 
     fn hovered(&self, _: &Self::Style) -> pick_list::Appearance {
-        let colors = get_colors(*self);
-        let color_buttons = get_buttons_color(*self);
+        let colors = self.get_palette();
+        let ext = self.get_palette_extension();
         pick_list::Appearance {
             text_color: colors.text_body,
             placeholder_color: colors.text_body,
             handle_color: colors.text_body,
-            background: Background::Color(mix_colors(color_buttons, colors.primary)),
+            background: Background::Color(mix_colors(ext.buttons_color, colors.primary)),
             border_radius: 0.0.into(),
             border_width: 1.0,
             border_color: colors.secondary,

--- a/src/gui/styles/radio.rs
+++ b/src/gui/styles/radio.rs
@@ -4,8 +4,8 @@
 
 use iced::Background;
 
-use crate::gui::styles::style_constants::BORDER_WIDTH;
-use crate::{get_colors, StyleType};
+use crate::gui::styles::style_constants::{BORDER_WIDTH};
+use crate::{ StyleType};
 
 #[derive(Clone, Copy, Default)]
 pub enum RadioType {
@@ -18,8 +18,9 @@ impl iced::widget::radio::StyleSheet for StyleType {
 
     fn active(&self, _: &Self::Style, is_selected: bool) -> iced::widget::radio::Appearance {
         let colors = get_colors(*self);
+        let color_buttons = get_buttons_color(*self);
         iced::widget::radio::Appearance {
-            background: Background::Color(colors.buttons),
+            background: Background::Color(color_buttons),
             dot_color: colors.secondary,
             border_width: if is_selected { BORDER_WIDTH } else { 0.0 },
             border_color: colors.secondary,
@@ -29,8 +30,9 @@ impl iced::widget::radio::StyleSheet for StyleType {
 
     fn hovered(&self, _: &Self::Style, _is_selected: bool) -> iced::widget::radio::Appearance {
         let colors = get_colors(*self);
+        let color_buttons = get_buttons_color(*self);
         iced::widget::radio::Appearance {
-            background: Background::Color(colors.buttons),
+            background: Background::Color(color_buttons),
             dot_color: colors.secondary,
             border_width: BORDER_WIDTH,
             border_color: colors.secondary,

--- a/src/gui/styles/radio.rs
+++ b/src/gui/styles/radio.rs
@@ -18,7 +18,7 @@ impl iced::widget::radio::StyleSheet for StyleType {
 
     fn active(&self, _: &Self::Style, is_selected: bool) -> iced::widget::radio::Appearance {
         let colors = self.get_palette();
-        let ext = self.get_palette_extension();
+        let ext = self.get_extension();
         iced::widget::radio::Appearance {
             background: Background::Color(ext.buttons_color),
             dot_color: colors.secondary,
@@ -30,7 +30,7 @@ impl iced::widget::radio::StyleSheet for StyleType {
 
     fn hovered(&self, _: &Self::Style, _is_selected: bool) -> iced::widget::radio::Appearance {
         let colors = self.get_palette();
-        let ext = self.get_palette_extension();
+        let ext = self.get_extension();
         iced::widget::radio::Appearance {
             background: Background::Color(ext.buttons_color),
             dot_color: colors.secondary,

--- a/src/gui/styles/radio.rs
+++ b/src/gui/styles/radio.rs
@@ -4,8 +4,8 @@
 
 use iced::Background;
 
-use crate::gui::styles::style_constants::{BORDER_WIDTH};
-use crate::{ StyleType};
+use crate::gui::styles::style_constants::BORDER_WIDTH;
+use crate::StyleType;
 
 #[derive(Clone, Copy, Default)]
 pub enum RadioType {
@@ -17,10 +17,10 @@ impl iced::widget::radio::StyleSheet for StyleType {
     type Style = RadioType;
 
     fn active(&self, _: &Self::Style, is_selected: bool) -> iced::widget::radio::Appearance {
-        let colors = get_colors(*self);
-        let color_buttons = get_buttons_color(*self);
+        let colors = self.get_palette();
+        let ext = self.get_palette_extension();
         iced::widget::radio::Appearance {
-            background: Background::Color(color_buttons),
+            background: Background::Color(ext.buttons_color),
             dot_color: colors.secondary,
             border_width: if is_selected { BORDER_WIDTH } else { 0.0 },
             border_color: colors.secondary,
@@ -29,10 +29,10 @@ impl iced::widget::radio::StyleSheet for StyleType {
     }
 
     fn hovered(&self, _: &Self::Style, _is_selected: bool) -> iced::widget::radio::Appearance {
-        let colors = get_colors(*self);
-        let color_buttons = get_buttons_color(*self);
+        let colors = self.get_palette();
+        let ext = self.get_palette_extension();
         iced::widget::radio::Appearance {
-            background: Background::Color(color_buttons),
+            background: Background::Color(ext.buttons_color),
             dot_color: colors.secondary,
             border_width: BORDER_WIDTH,
             border_color: colors.secondary,

--- a/src/gui/styles/rule.rs
+++ b/src/gui/styles/rule.rs
@@ -35,7 +35,13 @@ impl rule::StyleSheet for StyleType {
             },
             width: match style {
                 RuleType::Incoming | RuleType::Outgoing => 5,
-                RuleType::PaletteColor(_, is_custom) => if *is_custom {25} else { 40 },
+                RuleType::PaletteColor(_, is_custom) => {
+                    if *is_custom {
+                        25
+                    } else {
+                        40
+                    }
+                }
                 RuleType::Standard => 3,
             },
             radius: 0.0.into(),

--- a/src/gui/styles/rule.rs
+++ b/src/gui/styles/rule.rs
@@ -6,7 +6,7 @@ use iced::widget::rule;
 use iced::widget::rule::FillMode;
 use iced::Color;
 
-use crate::{ StyleType};
+use crate::StyleType;
 
 #[derive(Clone, Copy, Default)]
 pub enum RuleType {
@@ -24,19 +24,19 @@ impl rule::StyleSheet for StyleType {
     type Style = RuleType;
 
     fn appearance(&self, style: &Self::Style) -> iced::widget::rule::Appearance {
-        let colors = get_colors(*self);
-        let color_buttons = get_buttons_color(*self);
+        let colors = self.get_palette();
+        let ext = self.get_palette_extension();
         iced::widget::rule::Appearance {
             color: match style {
                 RuleType::Incoming => colors.secondary,
                 RuleType::Outgoing => colors.outgoing,
-                RuleType::PalettePrimary(style) => get_colors(*style).primary,
-                RuleType::PaletteSecondary(style) => get_colors(*style).secondary,
-                RuleType::PaletteOutgoing(style) => get_colors(*style).outgoing,
-                RuleType::PaletteButtons(style) => get_buttons_color(*style),
+                RuleType::PalettePrimary(style) => style.get_palette().primary,
+                RuleType::PaletteSecondary(style) => style.get_palette().secondary,
+                RuleType::PaletteOutgoing(style) => style.get_palette().outgoing,
+                RuleType::PaletteButtons(style) => style.get_palette_extension().buttons_color,
                 RuleType::Standard => Color {
-                    a: get_alpha_round_borders(*self),
-                    ..color_buttons
+                    a: ext.alpha_round_borders,
+                    ..ext.buttons_color
                 },
             },
             width: match style {

--- a/src/gui/styles/rule.rs
+++ b/src/gui/styles/rule.rs
@@ -6,8 +6,7 @@ use iced::widget::rule;
 use iced::widget::rule::FillMode;
 use iced::Color;
 
-use crate::gui::styles::style_constants::get_alpha_round_borders;
-use crate::{get_colors, StyleType};
+use crate::{ StyleType};
 
 #[derive(Clone, Copy, Default)]
 pub enum RuleType {
@@ -26,6 +25,7 @@ impl rule::StyleSheet for StyleType {
 
     fn appearance(&self, style: &Self::Style) -> iced::widget::rule::Appearance {
         let colors = get_colors(*self);
+        let color_buttons = get_buttons_color(*self);
         iced::widget::rule::Appearance {
             color: match style {
                 RuleType::Incoming => colors.secondary,
@@ -33,10 +33,10 @@ impl rule::StyleSheet for StyleType {
                 RuleType::PalettePrimary(style) => get_colors(*style).primary,
                 RuleType::PaletteSecondary(style) => get_colors(*style).secondary,
                 RuleType::PaletteOutgoing(style) => get_colors(*style).outgoing,
-                RuleType::PaletteButtons(style) => get_colors(*style).buttons,
+                RuleType::PaletteButtons(style) => get_buttons_color(*style),
                 RuleType::Standard => Color {
                     a: get_alpha_round_borders(*self),
-                    ..colors.buttons
+                    ..color_buttons
                 },
             },
             width: match style {

--- a/src/gui/styles/rule.rs
+++ b/src/gui/styles/rule.rs
@@ -12,10 +12,7 @@ use crate::StyleType;
 pub enum RuleType {
     #[default]
     Standard,
-    PalettePrimary(StyleType),
-    PaletteSecondary(StyleType),
-    PaletteOutgoing(StyleType),
-    PaletteButtons(StyleType),
+    PaletteColor(Color, bool),
     Incoming,
     Outgoing,
 }
@@ -30,10 +27,7 @@ impl rule::StyleSheet for StyleType {
             color: match style {
                 RuleType::Incoming => colors.secondary,
                 RuleType::Outgoing => colors.outgoing,
-                RuleType::PalettePrimary(style) => style.get_palette().primary,
-                RuleType::PaletteSecondary(style) => style.get_palette().secondary,
-                RuleType::PaletteOutgoing(style) => style.get_palette().outgoing,
-                RuleType::PaletteButtons(style) => style.get_palette_extension().buttons_color,
+                RuleType::PaletteColor(color, _) => *color,
                 RuleType::Standard => Color {
                     a: ext.alpha_round_borders,
                     ..ext.buttons_color
@@ -41,13 +35,7 @@ impl rule::StyleSheet for StyleType {
             },
             width: match style {
                 RuleType::Incoming | RuleType::Outgoing => 5,
-                RuleType::PalettePrimary(style)
-                | RuleType::PaletteSecondary(style)
-                | RuleType::PaletteOutgoing(style)
-                | RuleType::PaletteButtons(style) => match style {
-                    StyleType::Custom(_) => 25,
-                    _ => 40,
-                },
+                RuleType::PaletteColor(_, is_custom) => if *is_custom {25} else { 40 },
                 RuleType::Standard => 3,
             },
             radius: 0.0.into(),

--- a/src/gui/styles/rule.rs
+++ b/src/gui/styles/rule.rs
@@ -12,7 +12,7 @@ use crate::StyleType;
 pub enum RuleType {
     #[default]
     Standard,
-    PaletteColor(Color, bool),
+    PaletteColor(Color, u16),
     Incoming,
     Outgoing,
 }
@@ -35,13 +35,7 @@ impl rule::StyleSheet for StyleType {
             },
             width: match style {
                 RuleType::Incoming | RuleType::Outgoing => 5,
-                RuleType::PaletteColor(_, is_custom) => {
-                    if *is_custom {
-                        25
-                    } else {
-                        40
-                    }
-                }
+                RuleType::PaletteColor(_, width) => *width,
                 RuleType::Standard => 3,
             },
             radius: 0.0.into(),

--- a/src/gui/styles/rule.rs
+++ b/src/gui/styles/rule.rs
@@ -22,7 +22,7 @@ impl rule::StyleSheet for StyleType {
 
     fn appearance(&self, style: &Self::Style) -> iced::widget::rule::Appearance {
         let colors = self.get_palette();
-        let ext = self.get_palette_extension();
+        let ext = self.get_extension();
         iced::widget::rule::Appearance {
             color: match style {
                 RuleType::Incoming => colors.secondary,

--- a/src/gui/styles/scrollbar.rs
+++ b/src/gui/styles/scrollbar.rs
@@ -6,9 +6,9 @@ use iced::widget::scrollable::Properties;
 use iced::widget::scrollable::{Scrollbar, Scroller};
 use iced::{Background, Color};
 
-use crate::gui::styles::style_constants::{get_alpha_round_borders, BORDER_ROUNDED_RADIUS};
+use crate::gui::styles::style_constants::{BORDER_ROUNDED_RADIUS};
 use crate::gui::styles::types::palette::mix_colors;
-use crate::{get_colors, StyleType};
+use crate::{ StyleType};
 
 #[derive(Clone, Copy, Default)]
 pub enum ScrollbarType {
@@ -26,19 +26,19 @@ impl iced::widget::scrollable::StyleSheet for StyleType {
     type Style = ScrollbarType;
 
     fn active(&self, _: &Self::Style) -> Scrollbar {
-        let colors = get_colors(*self);
+        let color_buttons = get_buttons_color(*self);
         Scrollbar {
             background: Some(Background::Color(Color::TRANSPARENT)),
             border_radius: BORDER_ROUNDED_RADIUS.into(),
             border_width: 0.0,
             border_color: Color {
                 a: get_alpha_round_borders(*self),
-                ..colors.buttons
+                ..color_buttons
             },
             scroller: Scroller {
                 color: Color {
                     a: get_alpha_round_borders(*self),
-                    ..colors.buttons
+                    ..color_buttons
                 },
                 border_radius: BORDER_ROUNDED_RADIUS.into(),
                 border_width: 0.0,
@@ -49,22 +49,23 @@ impl iced::widget::scrollable::StyleSheet for StyleType {
 
     fn hovered(&self, _: &Self::Style, is_mouse_over_scrollbar: bool) -> Scrollbar {
         let colors = get_colors(*self);
+        let color_buttons = get_buttons_color(*self);
         Scrollbar {
             background: Some(Background::Color(Color {
                 a: get_alpha_round_borders(*self),
-                ..colors.buttons
+                ..color_buttons
             })),
             border_radius: BORDER_ROUNDED_RADIUS.into(),
             border_width: 0.0,
             border_color: Color {
                 a: get_alpha_round_borders(*self),
-                ..colors.buttons
+                ..color_buttons
             },
             scroller: Scroller {
                 color: if is_mouse_over_scrollbar {
                     colors.secondary
                 } else {
-                    mix_colors(colors.secondary, colors.buttons)
+                    mix_colors(colors.secondary, color_buttons)
                 },
                 border_radius: BORDER_ROUNDED_RADIUS.into(),
                 border_width: 0.0,

--- a/src/gui/styles/scrollbar.rs
+++ b/src/gui/styles/scrollbar.rs
@@ -6,9 +6,9 @@ use iced::widget::scrollable::Properties;
 use iced::widget::scrollable::{Scrollbar, Scroller};
 use iced::{Background, Color};
 
-use crate::gui::styles::style_constants::{BORDER_ROUNDED_RADIUS};
+use crate::gui::styles::style_constants::BORDER_ROUNDED_RADIUS;
 use crate::gui::styles::types::palette::mix_colors;
-use crate::{ StyleType};
+use crate::StyleType;
 
 #[derive(Clone, Copy, Default)]
 pub enum ScrollbarType {
@@ -26,19 +26,19 @@ impl iced::widget::scrollable::StyleSheet for StyleType {
     type Style = ScrollbarType;
 
     fn active(&self, _: &Self::Style) -> Scrollbar {
-        let color_buttons = get_buttons_color(*self);
+        let ext = self.get_palette_extension();
         Scrollbar {
             background: Some(Background::Color(Color::TRANSPARENT)),
             border_radius: BORDER_ROUNDED_RADIUS.into(),
             border_width: 0.0,
             border_color: Color {
-                a: get_alpha_round_borders(*self),
-                ..color_buttons
+                a: ext.alpha_round_borders,
+                ..ext.buttons_color
             },
             scroller: Scroller {
                 color: Color {
-                    a: get_alpha_round_borders(*self),
-                    ..color_buttons
+                    a: ext.alpha_round_borders,
+                    ..ext.buttons_color
                 },
                 border_radius: BORDER_ROUNDED_RADIUS.into(),
                 border_width: 0.0,
@@ -48,24 +48,24 @@ impl iced::widget::scrollable::StyleSheet for StyleType {
     }
 
     fn hovered(&self, _: &Self::Style, is_mouse_over_scrollbar: bool) -> Scrollbar {
-        let colors = get_colors(*self);
-        let color_buttons = get_buttons_color(*self);
+        let colors = self.get_palette();
+        let ext = self.get_palette_extension();
         Scrollbar {
             background: Some(Background::Color(Color {
-                a: get_alpha_round_borders(*self),
-                ..color_buttons
+                a: ext.alpha_round_borders,
+                ..ext.buttons_color
             })),
             border_radius: BORDER_ROUNDED_RADIUS.into(),
             border_width: 0.0,
             border_color: Color {
-                a: get_alpha_round_borders(*self),
-                ..color_buttons
+                a: ext.alpha_round_borders,
+                ..ext.buttons_color
             },
             scroller: Scroller {
                 color: if is_mouse_over_scrollbar {
                     colors.secondary
                 } else {
-                    mix_colors(colors.secondary, color_buttons)
+                    mix_colors(colors.secondary, ext.buttons_color)
                 },
                 border_radius: BORDER_ROUNDED_RADIUS.into(),
                 border_width: 0.0,

--- a/src/gui/styles/scrollbar.rs
+++ b/src/gui/styles/scrollbar.rs
@@ -26,7 +26,7 @@ impl iced::widget::scrollable::StyleSheet for StyleType {
     type Style = ScrollbarType;
 
     fn active(&self, _: &Self::Style) -> Scrollbar {
-        let ext = self.get_palette_extension();
+        let ext = self.get_extension();
         Scrollbar {
             background: Some(Background::Color(Color::TRANSPARENT)),
             border_radius: BORDER_ROUNDED_RADIUS.into(),
@@ -49,7 +49,7 @@ impl iced::widget::scrollable::StyleSheet for StyleType {
 
     fn hovered(&self, _: &Self::Style, is_mouse_over_scrollbar: bool) -> Scrollbar {
         let colors = self.get_palette();
-        let ext = self.get_palette_extension();
+        let ext = self.get_extension();
         Scrollbar {
             background: Some(Background::Color(Color {
                 a: ext.alpha_round_borders,

--- a/src/gui/styles/slider.rs
+++ b/src/gui/styles/slider.rs
@@ -7,7 +7,7 @@ use iced::widget::slider::{Handle, HandleShape, Rail};
 
 use crate::gui::styles::style_constants::{BORDER_ROUNDED_RADIUS, BORDER_WIDTH};
 use crate::gui::styles::types::palette::mix_colors;
-use crate::{ StyleType};
+use crate::StyleType;
 
 #[derive(Clone, Copy, Default)]
 pub enum SliderType {
@@ -19,17 +19,20 @@ impl iced::widget::slider::StyleSheet for StyleType {
     type Style = SliderType;
 
     fn active(&self, _: &Self::Style) -> Appearance {
-        let colors = get_colors(*self);
-        let color_buttons = get_buttons_color(*self);
+        let colors = self.get_palette();
+        let ext = self.get_palette_extension();
         Appearance {
             rail: Rail {
-                colors: (mix_colors(colors.secondary, color_buttons), color_buttons),
+                colors: (
+                    mix_colors(colors.secondary, ext.buttons_color),
+                    ext.buttons_color,
+                ),
                 width: 3.0,
                 border_radius: BORDER_ROUNDED_RADIUS.into(),
             },
             handle: Handle {
                 shape: HandleShape::Circle { radius: 5.5 },
-                color: mix_colors(colors.secondary, color_buttons),
+                color: mix_colors(colors.secondary, ext.buttons_color),
                 border_width: 0.0,
                 border_color: colors.secondary,
             },
@@ -37,11 +40,11 @@ impl iced::widget::slider::StyleSheet for StyleType {
     }
 
     fn hovered(&self, _: &Self::Style) -> Appearance {
-        let colors = get_colors(*self);
-        let color_buttons = get_buttons_color(*self);
+        let colors = self.get_palette();
+        let ext = self.get_palette_extension();
         Appearance {
             rail: Rail {
-                colors: (colors.secondary, color_buttons),
+                colors: (colors.secondary, ext.buttons_color),
                 width: 3.0,
                 border_radius: BORDER_ROUNDED_RADIUS.into(),
             },
@@ -55,11 +58,11 @@ impl iced::widget::slider::StyleSheet for StyleType {
     }
 
     fn dragging(&self, _: &Self::Style) -> Appearance {
-        let colors = get_colors(*self);
-        let color_buttons = get_buttons_color(*self);
+        let colors = self.get_palette();
+        let ext = self.get_palette_extension();
         Appearance {
             rail: Rail {
-                colors: (colors.secondary, color_buttons),
+                colors: (colors.secondary, ext.buttons_color),
                 width: 3.0,
                 border_radius: BORDER_ROUNDED_RADIUS.into(),
             },
@@ -67,7 +70,7 @@ impl iced::widget::slider::StyleSheet for StyleType {
                 shape: HandleShape::Circle { radius: 8.0 },
                 color: colors.secondary,
                 border_width: BORDER_WIDTH,
-                border_color: mix_colors(colors.secondary, color_buttons),
+                border_color: mix_colors(colors.secondary, ext.buttons_color),
             },
         }
     }

--- a/src/gui/styles/slider.rs
+++ b/src/gui/styles/slider.rs
@@ -20,7 +20,7 @@ impl iced::widget::slider::StyleSheet for StyleType {
 
     fn active(&self, _: &Self::Style) -> Appearance {
         let colors = self.get_palette();
-        let ext = self.get_palette_extension();
+        let ext = self.get_extension();
         Appearance {
             rail: Rail {
                 colors: (
@@ -41,7 +41,7 @@ impl iced::widget::slider::StyleSheet for StyleType {
 
     fn hovered(&self, _: &Self::Style) -> Appearance {
         let colors = self.get_palette();
-        let ext = self.get_palette_extension();
+        let ext = self.get_extension();
         Appearance {
             rail: Rail {
                 colors: (colors.secondary, ext.buttons_color),
@@ -59,7 +59,7 @@ impl iced::widget::slider::StyleSheet for StyleType {
 
     fn dragging(&self, _: &Self::Style) -> Appearance {
         let colors = self.get_palette();
-        let ext = self.get_palette_extension();
+        let ext = self.get_extension();
         Appearance {
             rail: Rail {
                 colors: (colors.secondary, ext.buttons_color),

--- a/src/gui/styles/slider.rs
+++ b/src/gui/styles/slider.rs
@@ -7,7 +7,7 @@ use iced::widget::slider::{Handle, HandleShape, Rail};
 
 use crate::gui::styles::style_constants::{BORDER_ROUNDED_RADIUS, BORDER_WIDTH};
 use crate::gui::styles::types::palette::mix_colors;
-use crate::{get_colors, StyleType};
+use crate::{ StyleType};
 
 #[derive(Clone, Copy, Default)]
 pub enum SliderType {
@@ -20,15 +20,16 @@ impl iced::widget::slider::StyleSheet for StyleType {
 
     fn active(&self, _: &Self::Style) -> Appearance {
         let colors = get_colors(*self);
+        let color_buttons = get_buttons_color(*self);
         Appearance {
             rail: Rail {
-                colors: (mix_colors(colors.secondary, colors.buttons), colors.buttons),
+                colors: (mix_colors(colors.secondary, color_buttons), color_buttons),
                 width: 3.0,
                 border_radius: BORDER_ROUNDED_RADIUS.into(),
             },
             handle: Handle {
                 shape: HandleShape::Circle { radius: 5.5 },
-                color: mix_colors(colors.secondary, colors.buttons),
+                color: mix_colors(colors.secondary, color_buttons),
                 border_width: 0.0,
                 border_color: colors.secondary,
             },
@@ -37,9 +38,10 @@ impl iced::widget::slider::StyleSheet for StyleType {
 
     fn hovered(&self, _: &Self::Style) -> Appearance {
         let colors = get_colors(*self);
+        let color_buttons = get_buttons_color(*self);
         Appearance {
             rail: Rail {
-                colors: (colors.secondary, colors.buttons),
+                colors: (colors.secondary, color_buttons),
                 width: 3.0,
                 border_radius: BORDER_ROUNDED_RADIUS.into(),
             },
@@ -54,9 +56,10 @@ impl iced::widget::slider::StyleSheet for StyleType {
 
     fn dragging(&self, _: &Self::Style) -> Appearance {
         let colors = get_colors(*self);
+        let color_buttons = get_buttons_color(*self);
         Appearance {
             rail: Rail {
-                colors: (colors.secondary, colors.buttons),
+                colors: (colors.secondary, color_buttons),
                 width: 3.0,
                 border_radius: BORDER_ROUNDED_RADIUS.into(),
             },
@@ -64,7 +67,7 @@ impl iced::widget::slider::StyleSheet for StyleType {
                 shape: HandleShape::Circle { radius: 8.0 },
                 color: colors.secondary,
                 border_width: BORDER_WIDTH,
-                border_color: mix_colors(colors.secondary, colors.buttons),
+                border_color: mix_colors(colors.secondary, color_buttons),
             },
         }
     }

--- a/src/gui/styles/style_constants.rs
+++ b/src/gui/styles/style_constants.rs
@@ -33,7 +33,7 @@ pub const NIGHT_PALETTE: Palette = Palette {
     text_body: Color::WHITE,
 };
 
-const BUTTONS_NIGHT: Color = Color {
+pub const BUTTONS_NIGHT: Color = Color {
     r: 0.1,
     g: 0.1,
     b: 0.1,
@@ -72,7 +72,7 @@ pub const DAY_PALETTE: Palette = Palette {
     text_body: Color::BLACK,
 };
 
-const BUTTONS_DAY: Color = Color {
+pub const BUTTONS_DAY: Color = Color {
     r: 0.8,
     g: 0.8,
     b: 0.8,
@@ -122,7 +122,7 @@ pub const DEEP_SEA_PALETTE: Palette = Palette {
     text_body: Color::WHITE,
 };
 
-const BUTTONS_DEEP_SEA: Color = Color {
+pub const BUTTONS_DEEP_SEA: Color = Color {
     r: 48.0 / 255.0,
     g: 71.0 / 255.0,
     b: 94.0 / 255.0,
@@ -172,7 +172,7 @@ pub const MON_AMOUR_PALETTE: Palette = Palette {
     text_body: Color::BLACK,
 };
 
-const BUTTONS_MON_AMOUR: Color = Color {
+pub const BUTTONS_MON_AMOUR: Color = Color {
     r: 242.0 / 255.0,
     g: 190.0 / 255.0,
     b: 209.0 / 255.0,

--- a/src/gui/styles/style_constants.rs
+++ b/src/gui/styles/style_constants.rs
@@ -2,10 +2,8 @@
 
 use iced::font::{Family, Stretch, Weight};
 use iced::{Color, Font};
-use plotters::prelude::FontStyle;
 
 use crate::gui::styles::types::palette::Palette;
-use crate::StyleType;
 
 // night theme
 const PRIMARY_NIGHT: Color = Color {
@@ -20,16 +18,15 @@ const SECONDARY_NIGHT: Color = Color {
     b: 0.0,
     a: 1.0,
 };
-const BUTTONS_NIGHT: Color = Color {
-    r: 0.1,
-    g: 0.1,
-    b: 0.1,
-    a: 1.0,
-};
 pub const NIGHT_STYLE: Palette = Palette {
     primary: PRIMARY_NIGHT,
     secondary: SECONDARY_NIGHT,
-    buttons: BUTTONS_NIGHT,
+    starred: Color {
+        r: 245.0 / 255.0,
+        g: 193.0 / 255.0,
+        b: 39.0 / 255.0,
+        a: 0.5,
+    },
     outgoing: SECONDARY_DAY,
     text_headers: Color::BLACK,
     text_body: Color::WHITE,
@@ -43,17 +40,16 @@ const SECONDARY_DAY: Color = Color {
     b: 0.7,
     a: 1.0,
 };
-const BUTTONS_DAY: Color = Color {
-    r: 0.8,
-    g: 0.8,
-    b: 0.8,
-    a: 1.0,
-};
 pub const DAY_STYLE: Palette = Palette {
     primary: PRIMARY_DAY,
     secondary: SECONDARY_DAY,
-    buttons: BUTTONS_DAY,
     outgoing: SECONDARY_NIGHT,
+    starred: Color {
+        r: 245.0 / 255.0,
+        g: 193.0 / 255.0,
+        b: 39.0 / 255.0,
+        a: 0.8,
+    },
     text_headers: Color::WHITE,
     text_body: Color::BLACK,
 };
@@ -71,12 +67,6 @@ const SECONDARY_DEEP_SEA: Color = Color {
     b: 149.0 / 255.0,
     a: 1.0,
 };
-const BUTTONS_DEEP_SEA: Color = Color {
-    r: 48.0 / 255.0,
-    g: 71.0 / 255.0,
-    b: 94.0 / 255.0,
-    a: 1.0,
-};
 const OUTGOING_DEEP_SEA: Color = Color {
     r: 254.0 / 255.0,
     g: 254.0 / 255.0,
@@ -86,7 +76,12 @@ const OUTGOING_DEEP_SEA: Color = Color {
 pub const DEEP_SEA_STYLE: Palette = Palette {
     primary: PRIMARY_DEEP_SEA,
     secondary: SECONDARY_DEEP_SEA,
-    buttons: BUTTONS_DEEP_SEA,
+    starred: Color {
+        r: 245.0 / 255.0,
+        g: 193.0 / 255.0,
+        b: 39.0 / 255.0,
+        a: 0.5,
+    },
     outgoing: OUTGOING_DEEP_SEA,
     text_headers: Color::BLACK,
     text_body: Color::WHITE,
@@ -105,12 +100,6 @@ const PRIMARY_MON_AMOUR: Color = Color {
     b: 220.0 / 255.0,
     a: 1.0,
 };
-const BUTTONS_MON_AMOUR: Color = Color {
-    r: 242.0 / 255.0,
-    g: 190.0 / 255.0,
-    b: 209.0 / 255.0,
-    a: 1.0,
-};
 const OUTGOING_MON_AMOUR: Color = Color {
     r: 58.0 / 255.0,
     g: 166.0 / 255.0,
@@ -120,7 +109,12 @@ const OUTGOING_MON_AMOUR: Color = Color {
 pub const MON_AMOUR_STYLE: Palette = Palette {
     primary: PRIMARY_MON_AMOUR,
     secondary: SECONDARY_MON_AMOUR,
-    buttons: BUTTONS_MON_AMOUR,
+    starred: Color {
+        r: 245.0 / 255.0,
+        g: 193.0 / 255.0,
+        b: 39.0 / 255.0,
+        a: 0.8,
+    },
     outgoing: OUTGOING_MON_AMOUR,
     text_headers: Color::WHITE,
     text_body: Color::BLACK,
@@ -144,30 +138,6 @@ pub const SARASA_MONO: Font = Font {
     monospaced: true,
 };
 
-pub fn get_font(style: StyleType) -> Font {
-    if style.is_nightly() {
-        SARASA_MONO
-    } else {
-        SARASA_MONO_BOLD
-    }
-}
-
-pub fn get_font_weight(style: StyleType) -> FontStyle {
-    if style.is_nightly() {
-        FontStyle::Normal
-    } else {
-        FontStyle::Bold
-    }
-}
-
-pub fn get_font_headers(style: StyleType) -> Font {
-    if style.is_nightly() {
-        SARASA_MONO_BOLD
-    } else {
-        SARASA_MONO
-    }
-}
-
 //font to display icons
 pub const ICONS_BYTES: &[u8] = include_bytes!("../../../resources/fonts/subset/icons.ttf");
 pub const ICONS: Font = Font::with_name("Glyphter");
@@ -183,48 +153,3 @@ pub const BORDER_WIDTH: f32 = 2.0;
 pub const CHARTS_LINE_BORDER: u32 = 1;
 pub const BORDER_ROUNDED_RADIUS: f32 = 15.0;
 pub const BORDER_BUTTON_RADIUS: f32 = 180.0;
-
-/// Yellow color used in favorites star
-pub fn get_starred_color(style: StyleType) -> Color {
-    match style {
-        StyleType::Night | StyleType::DeepSea => Color {
-            r: 245.0 / 255.0,
-            g: 193.0 / 255.0,
-            b: 39.0 / 255.0,
-            a: 0.5,
-        },
-        StyleType::Day | StyleType::MonAmour => Color {
-            r: 245.0 / 255.0,
-            g: 193.0 / 255.0,
-            b: 39.0 / 255.0,
-            a: 0.8,
-        },
-        StyleType::Custom(style) => style.to_ext().starred,
-    }
-}
-
-pub fn get_alpha_chart_badge(style: StyleType) -> f32 {
-    match style {
-        StyleType::Night | StyleType::DeepSea => 0.2,
-        StyleType::Day | StyleType::MonAmour => 0.8,
-        StyleType::Custom(style) => style.to_ext().chart_badge_alpha,
-    }
-}
-
-pub fn get_alpha_round_borders(style: StyleType) -> f32 {
-    match style {
-        StyleType::Night | StyleType::DeepSea => 0.35,
-        StyleType::Day => 0.45,
-        StyleType::MonAmour => 0.5,
-        StyleType::Custom(style) => style.to_ext().round_borders_alpha,
-    }
-}
-
-pub fn get_alpha_round_containers(style: StyleType) -> f32 {
-    match style {
-        StyleType::Night | StyleType::MonAmour => 0.25,
-        StyleType::Day => 0.2,
-        StyleType::DeepSea => 0.15,
-        StyleType::Custom(style) => style.to_ext().round_containers_alpha,
-    }
-}

--- a/src/gui/styles/style_constants.rs
+++ b/src/gui/styles/style_constants.rs
@@ -4,6 +4,7 @@ use iced::font::{Family, Stretch, Weight};
 use iced::{Color, Font};
 
 use crate::gui::styles::types::palette::Palette;
+use crate::gui::styles::types::palette_extension::PaletteExtension;
 
 // night theme
 const PRIMARY_NIGHT: Color = Color {
@@ -18,7 +19,7 @@ const SECONDARY_NIGHT: Color = Color {
     b: 0.0,
     a: 1.0,
 };
-pub const NIGHT_STYLE: Palette = Palette {
+pub const NIGHT_PALETTE: Palette = Palette {
     primary: PRIMARY_NIGHT,
     secondary: SECONDARY_NIGHT,
     starred: Color {
@@ -32,6 +33,23 @@ pub const NIGHT_STYLE: Palette = Palette {
     text_body: Color::WHITE,
 };
 
+const BUTTONS_NIGHT: Color = Color {
+    r: 0.1,
+    g: 0.1,
+    b: 0.1,
+    a: 1.0,
+};
+
+pub const NIGHT_PALETTE_EXTENSION: PaletteExtension = PaletteExtension {
+    is_nightly: true,
+    font: SARASA_MONO,
+    font_headers: SARASA_MONO_BOLD,
+    alpha_chart_badge: 0.15,
+    alpha_round_borders: 0.35,
+    alpha_round_containers: 0.25,
+    buttons_color: BUTTONS_NIGHT,
+};
+
 // day theme
 const PRIMARY_DAY: Color = Color::WHITE;
 const SECONDARY_DAY: Color = Color {
@@ -40,7 +58,7 @@ const SECONDARY_DAY: Color = Color {
     b: 0.7,
     a: 1.0,
 };
-pub const DAY_STYLE: Palette = Palette {
+pub const DAY_PALETTE: Palette = Palette {
     primary: PRIMARY_DAY,
     secondary: SECONDARY_DAY,
     outgoing: SECONDARY_NIGHT,
@@ -52,6 +70,23 @@ pub const DAY_STYLE: Palette = Palette {
     },
     text_headers: Color::WHITE,
     text_body: Color::BLACK,
+};
+
+const BUTTONS_DAY: Color = Color {
+    r: 0.8,
+    g: 0.8,
+    b: 0.8,
+    a: 1.0,
+};
+
+pub const DAY_PALETTE_EXTENSION: PaletteExtension = PaletteExtension {
+    is_nightly: false,
+    font: SARASA_MONO_BOLD,
+    font_headers: SARASA_MONO,
+    alpha_chart_badge: 0.75,
+    alpha_round_borders: 0.45,
+    alpha_round_containers: 0.2,
+    buttons_color: BUTTONS_DAY,
 };
 
 // deep sea theme
@@ -73,7 +108,7 @@ const OUTGOING_DEEP_SEA: Color = Color {
     b: 134.0 / 255.0,
     a: 1.0,
 };
-pub const DEEP_SEA_STYLE: Palette = Palette {
+pub const DEEP_SEA_PALETTE: Palette = Palette {
     primary: PRIMARY_DEEP_SEA,
     secondary: SECONDARY_DEEP_SEA,
     starred: Color {
@@ -85,6 +120,23 @@ pub const DEEP_SEA_STYLE: Palette = Palette {
     outgoing: OUTGOING_DEEP_SEA,
     text_headers: Color::BLACK,
     text_body: Color::WHITE,
+};
+
+const BUTTONS_DEEP_SEA: Color = Color {
+    r: 48.0 / 255.0,
+    g: 71.0 / 255.0,
+    b: 94.0 / 255.0,
+    a: 1.0,
+};
+
+pub const DEEP_SEA_PALETTE_EXTENSION: PaletteExtension = PaletteExtension {
+    is_nightly: true,
+    font: SARASA_MONO,
+    font_headers: SARASA_MONO_BOLD,
+    alpha_chart_badge: 0.15,
+    alpha_round_borders: 0.35,
+    alpha_round_containers: 0.15,
+    buttons_color: BUTTONS_DEEP_SEA,
 };
 
 // mon amour theme
@@ -106,7 +158,7 @@ const OUTGOING_MON_AMOUR: Color = Color {
     b: 185.0 / 255.0,
     a: 1.0,
 };
-pub const MON_AMOUR_STYLE: Palette = Palette {
+pub const MON_AMOUR_PALETTE: Palette = Palette {
     primary: PRIMARY_MON_AMOUR,
     secondary: SECONDARY_MON_AMOUR,
     starred: Color {
@@ -118,6 +170,23 @@ pub const MON_AMOUR_STYLE: Palette = Palette {
     outgoing: OUTGOING_MON_AMOUR,
     text_headers: Color::WHITE,
     text_body: Color::BLACK,
+};
+
+const BUTTONS_MON_AMOUR: Color = Color {
+    r: 242.0 / 255.0,
+    g: 190.0 / 255.0,
+    b: 209.0 / 255.0,
+    a: 1.0,
+};
+
+pub const MON_AMOUR_PALETTE_EXTENSION: PaletteExtension = PaletteExtension {
+    is_nightly: false,
+    font: SARASA_MONO_BOLD,
+    font_headers: SARASA_MONO,
+    alpha_chart_badge: 0.75,
+    alpha_round_borders: 0.5,
+    alpha_round_containers: 0.25,
+    buttons_color: BUTTONS_MON_AMOUR,
 };
 
 pub const SARASA_MONO_BOLD_BYTES: &[u8] =

--- a/src/gui/styles/svg.rs
+++ b/src/gui/styles/svg.rs
@@ -4,7 +4,7 @@
 
 use iced::widget::svg::Appearance;
 
-use crate::{ StyleType};
+use crate::StyleType;
 
 #[derive(Clone, Copy, Default)]
 pub enum SvgType {
@@ -19,7 +19,7 @@ impl iced::widget::svg::StyleSheet for StyleType {
     fn appearance(&self, style: &Self::Style) -> Appearance {
         Appearance {
             color: match style {
-                SvgType::AdaptColor => Some(get_colors(*self).text_body),
+                SvgType::AdaptColor => Some(self.get_palette().text_body),
                 SvgType::Standard => None,
             },
         }

--- a/src/gui/styles/svg.rs
+++ b/src/gui/styles/svg.rs
@@ -4,7 +4,7 @@
 
 use iced::widget::svg::Appearance;
 
-use crate::{get_colors, StyleType};
+use crate::{ StyleType};
 
 #[derive(Clone, Copy, Default)]
 pub enum SvgType {

--- a/src/gui/styles/text.rs
+++ b/src/gui/styles/text.rs
@@ -7,7 +7,7 @@ use iced::widget::{Column, Text};
 use iced::{Color, Font, Renderer};
 
 use crate::gui::types::message::Message;
-use crate::{get_colors, StyleType};
+use crate::{ StyleType};
 
 #[derive(Clone, Copy, Default, PartialEq)]
 pub enum TextType {
@@ -52,7 +52,6 @@ impl iced::widget::text::StyleSheet for StyleType {
     }
 }
 
-/// Returns the weighted average of two colors; color intensity is fixed to 100%
 pub fn highlight(style: StyleType, element: TextType) -> Color {
     let colors = get_colors(style);
     let color = colors.secondary;

--- a/src/gui/styles/text.rs
+++ b/src/gui/styles/text.rs
@@ -55,7 +55,7 @@ impl iced::widget::text::StyleSheet for StyleType {
 pub fn highlight(style: StyleType, element: TextType) -> Color {
     let colors = style.get_palette();
     let color = colors.secondary;
-    let is_nightly = style.get_palette_extension().is_nightly;
+    let is_nightly = style.get_extension().is_nightly;
     match element {
         TextType::Title => {
             let (p1, c) = if is_nightly { (0.6, 1.0) } else { (0.9, 0.7) };

--- a/src/gui/styles/text.rs
+++ b/src/gui/styles/text.rs
@@ -19,6 +19,7 @@ pub enum TextType {
     Subtitle,
     Danger,
     Sponsor,
+    Starred,
 }
 
 /// Returns a formatted caption followed by subtitle, new line, tab, and desc
@@ -54,24 +55,24 @@ impl iced::widget::text::StyleSheet for StyleType {
 
 pub fn highlight(style: StyleType, element: TextType) -> Color {
     let colors = style.get_palette();
-    let color = colors.secondary;
+    let secondary = colors.secondary;
     let is_nightly = style.get_extension().is_nightly;
     match element {
         TextType::Title => {
             let (p1, c) = if is_nightly { (0.6, 1.0) } else { (0.9, 0.7) };
             Color {
-                r: c * (1.0 - p1) + color.r * p1,
-                g: c * (1.0 - p1) + color.g * p1,
-                b: c * (1.0 - p1) + color.b * p1,
+                r: c * (1.0 - p1) + secondary.r * p1,
+                g: c * (1.0 - p1) + secondary.g * p1,
+                b: c * (1.0 - p1) + secondary.b * p1,
                 a: 1.0,
             }
         }
         TextType::Subtitle => {
             let (p1, c) = if is_nightly { (0.4, 1.0) } else { (0.6, 0.7) };
             Color {
-                r: c * (1.0 - p1) + color.r * p1,
-                g: c * (1.0 - p1) + color.g * p1,
-                b: c * (1.0 - p1) + color.b * p1,
+                r: c * (1.0 - p1) + secondary.r * p1,
+                g: c * (1.0 - p1) + secondary.g * p1,
+                b: c * (1.0 - p1) + secondary.b * p1,
                 a: 1.0,
             }
         }
@@ -80,5 +81,6 @@ pub fn highlight(style: StyleType, element: TextType) -> Color {
         TextType::Danger => Color::from_rgb(0.8, 0.15, 0.15),
         TextType::Sponsor => Color::from_rgb(1.0, 0.3, 0.5),
         TextType::Standard => colors.text_body,
+        TextType::Starred => colors.starred,
     }
 }

--- a/src/gui/styles/text.rs
+++ b/src/gui/styles/text.rs
@@ -7,7 +7,7 @@ use iced::widget::{Column, Text};
 use iced::{Color, Font, Renderer};
 
 use crate::gui::types::message::Message;
-use crate::{ StyleType};
+use crate::StyleType;
 
 #[derive(Clone, Copy, Default, PartialEq)]
 pub enum TextType {
@@ -53,9 +53,9 @@ impl iced::widget::text::StyleSheet for StyleType {
 }
 
 pub fn highlight(style: StyleType, element: TextType) -> Color {
-    let colors = get_colors(style);
+    let colors = style.get_palette();
     let color = colors.secondary;
-    let is_nightly = style.is_nightly();
+    let is_nightly = style.get_palette_extension().is_nightly;
     match element {
         TextType::Title => {
             let (p1, c) = if is_nightly { (0.6, 1.0) } else { (0.9, 0.7) };

--- a/src/gui/styles/text_input.rs
+++ b/src/gui/styles/text_input.rs
@@ -5,8 +5,7 @@
 use iced::widget::text_input::Appearance;
 use iced::{Background, Color};
 
-use crate::gui::styles::style_constants::{get_alpha_round_borders, get_alpha_round_containers};
-use crate::{get_colors, StyleType};
+use crate::{ StyleType};
 
 #[derive(Clone, Copy, Default)]
 pub enum TextInputType {
@@ -21,19 +20,17 @@ impl iced::widget::text_input::StyleSheet for StyleType {
 
     fn active(&self, style: &Self::Style) -> iced::widget::text_input::Appearance {
         let colors = get_colors(*self);
+        let color_buttons = get_buttons_color(*self);
         Appearance {
             background: Background::Color(match style {
                 TextInputType::Badge => Color::TRANSPARENT,
-                _ => colors.buttons,
+                _ => Color{a: get_alpha_round_borders(*self), ..color_buttons},
             }),
             border_radius: 0.0.into(),
             border_width: 1.5,
             border_color: match style {
                 TextInputType::Badge => Color::TRANSPARENT,
-                TextInputType::Standard => Color {
-                    a: get_alpha_round_borders(*self),
-                    ..colors.buttons
-                },
+                TextInputType::Standard => color_buttons,
                 TextInputType::Error => Color::new(0.8, 0.15, 0.15, 1.0),
             },
             icon_color: colors.text_body,
@@ -57,7 +54,7 @@ impl iced::widget::text_input::StyleSheet for StyleType {
     fn placeholder_color(&self, _: &Self::Style) -> Color {
         let color = get_colors(*self).text_body;
         Color {
-            a: if self.is_nightly() { 0.2 } else { 0.7 },
+            a: if self.is_text_body_dark() { 0.7 } else { 0.2 },
             ..color
         }
     }
@@ -69,7 +66,7 @@ impl iced::widget::text_input::StyleSheet for StyleType {
     fn disabled_color(&self, _style: &Self::Style) -> Color {
         let color = get_colors(*self).text_body;
         Color {
-            a: if self.is_nightly() { 0.2 } else { 0.7 },
+            a: if self.is_text_body_dark() { 0.7 } else { 0.2 },
             ..color
         }
     }
@@ -77,17 +74,18 @@ impl iced::widget::text_input::StyleSheet for StyleType {
     fn selection_color(&self, _: &Self::Style) -> Color {
         let color = get_colors(*self).text_body;
         Color {
-            a: if self.is_nightly() { 0.05 } else { 0.4 },
+            a: if self.is_text_body_dark() { 0.4 } else { 0.05 },
             ..color
         }
     }
 
     fn hovered(&self, style: &Self::Style) -> iced::widget::text_input::Appearance {
         let colors = get_colors(*self);
+        let color_buttons = get_buttons_color(*self);
         Appearance {
             background: Background::Color(match style {
                 TextInputType::Badge => Color::TRANSPARENT,
-                _ => colors.buttons,
+                _ => color_buttons,
             }),
             border_radius: 0.0.into(),
             border_width: 1.5,
@@ -101,12 +99,13 @@ impl iced::widget::text_input::StyleSheet for StyleType {
 
     fn disabled(&self, style: &Self::Style) -> Appearance {
         let colors = get_colors(*self);
+        let color_buttons = get_buttons_color(*self);
         Appearance {
             background: Background::Color(match style {
                 TextInputType::Badge => Color::TRANSPARENT,
                 _ => Color {
                     a: get_alpha_round_containers(*self),
-                    ..colors.buttons
+                    ..color_buttons
                 },
             }),
             border_radius: 0.0.into(),
@@ -115,7 +114,7 @@ impl iced::widget::text_input::StyleSheet for StyleType {
                 TextInputType::Badge => Color::TRANSPARENT,
                 TextInputType::Standard => Color {
                     a: get_alpha_round_borders(*self),
-                    ..colors.buttons
+                    ..color_buttons
                 },
                 TextInputType::Error => Color::new(0.8, 0.15, 0.15, get_alpha_round_borders(*self)),
             },

--- a/src/gui/styles/text_input.rs
+++ b/src/gui/styles/text_input.rs
@@ -58,7 +58,7 @@ impl iced::widget::text_input::StyleSheet for StyleType {
         let color = self.get_palette().text_body;
         let is_nightly = self.get_palette_extension().is_nightly;
         Color {
-            a: if is_nightly { 0.7 } else { 0.2 },
+            a: if is_nightly { 0.2 } else { 0.7 },
             ..color
         }
     }
@@ -71,7 +71,7 @@ impl iced::widget::text_input::StyleSheet for StyleType {
         let color = self.get_palette().text_body;
         let is_nightly = self.get_palette_extension().is_nightly;
         Color {
-            a: if is_nightly { 0.7 } else { 0.2 },
+            a: if is_nightly { 0.2 } else { 0.7 },
             ..color
         }
     }
@@ -80,7 +80,7 @@ impl iced::widget::text_input::StyleSheet for StyleType {
         let color = self.get_palette().text_body;
         let is_nightly = self.get_palette_extension().is_nightly;
         Color {
-            a: if is_nightly { 0.4 } else { 0.05 },
+            a: if is_nightly { 0.05 } else { 0.4 },
             ..color
         }
     }

--- a/src/gui/styles/text_input.rs
+++ b/src/gui/styles/text_input.rs
@@ -5,7 +5,7 @@
 use iced::widget::text_input::Appearance;
 use iced::{Background, Color};
 
-use crate::{ StyleType};
+use crate::StyleType;
 
 #[derive(Clone, Copy, Default)]
 pub enum TextInputType {
@@ -19,18 +19,21 @@ impl iced::widget::text_input::StyleSheet for StyleType {
     type Style = TextInputType;
 
     fn active(&self, style: &Self::Style) -> iced::widget::text_input::Appearance {
-        let colors = get_colors(*self);
-        let color_buttons = get_buttons_color(*self);
+        let colors = self.get_palette();
+        let ext = self.get_palette_extension();
         Appearance {
             background: Background::Color(match style {
                 TextInputType::Badge => Color::TRANSPARENT,
-                _ => Color{a: get_alpha_round_borders(*self), ..color_buttons},
+                _ => Color {
+                    a: ext.alpha_round_borders,
+                    ..ext.buttons_color
+                },
             }),
             border_radius: 0.0.into(),
             border_width: 1.5,
             border_color: match style {
                 TextInputType::Badge => Color::TRANSPARENT,
-                TextInputType::Standard => color_buttons,
+                TextInputType::Standard => ext.buttons_color,
                 TextInputType::Error => Color::new(0.8, 0.15, 0.15, 1.0),
             },
             icon_color: colors.text_body,
@@ -38,7 +41,7 @@ impl iced::widget::text_input::StyleSheet for StyleType {
     }
 
     fn focused(&self, style: &Self::Style) -> iced::widget::text_input::Appearance {
-        let colors = get_colors(*self);
+        let colors = self.get_palette();
         Appearance {
             background: Background::Color(colors.primary),
             border_radius: 0.0.into(),
@@ -52,40 +55,43 @@ impl iced::widget::text_input::StyleSheet for StyleType {
     }
 
     fn placeholder_color(&self, _: &Self::Style) -> Color {
-        let color = get_colors(*self).text_body;
+        let color = self.get_palette().text_body;
+        let is_nightly = self.get_palette_extension().is_nightly;
         Color {
-            a: if self.is_text_body_dark() { 0.7 } else { 0.2 },
+            a: if is_nightly { 0.7 } else { 0.2 },
             ..color
         }
     }
 
     fn value_color(&self, _: &Self::Style) -> Color {
-        get_colors(*self).text_body
+        self.get_palette().text_body
     }
 
     fn disabled_color(&self, _style: &Self::Style) -> Color {
-        let color = get_colors(*self).text_body;
+        let color = self.get_palette().text_body;
+        let is_nightly = self.get_palette_extension().is_nightly;
         Color {
-            a: if self.is_text_body_dark() { 0.7 } else { 0.2 },
+            a: if is_nightly { 0.7 } else { 0.2 },
             ..color
         }
     }
 
     fn selection_color(&self, _: &Self::Style) -> Color {
-        let color = get_colors(*self).text_body;
+        let color = self.get_palette().text_body;
+        let is_nightly = self.get_palette_extension().is_nightly;
         Color {
-            a: if self.is_text_body_dark() { 0.4 } else { 0.05 },
+            a: if is_nightly { 0.4 } else { 0.05 },
             ..color
         }
     }
 
     fn hovered(&self, style: &Self::Style) -> iced::widget::text_input::Appearance {
-        let colors = get_colors(*self);
-        let color_buttons = get_buttons_color(*self);
+        let colors = self.get_palette();
+        let ext = self.get_palette_extension();
         Appearance {
             background: Background::Color(match style {
                 TextInputType::Badge => Color::TRANSPARENT,
-                _ => color_buttons,
+                _ => ext.buttons_color,
             }),
             border_radius: 0.0.into(),
             border_width: 1.5,
@@ -98,14 +104,14 @@ impl iced::widget::text_input::StyleSheet for StyleType {
     }
 
     fn disabled(&self, style: &Self::Style) -> Appearance {
-        let colors = get_colors(*self);
-        let color_buttons = get_buttons_color(*self);
+        let colors = self.get_palette();
+        let ext = self.get_palette_extension();
         Appearance {
             background: Background::Color(match style {
                 TextInputType::Badge => Color::TRANSPARENT,
                 _ => Color {
-                    a: get_alpha_round_containers(*self),
-                    ..color_buttons
+                    a: ext.alpha_round_containers,
+                    ..ext.buttons_color
                 },
             }),
             border_radius: 0.0.into(),
@@ -113,10 +119,10 @@ impl iced::widget::text_input::StyleSheet for StyleType {
             border_color: match style {
                 TextInputType::Badge => Color::TRANSPARENT,
                 TextInputType::Standard => Color {
-                    a: get_alpha_round_borders(*self),
-                    ..color_buttons
+                    a: ext.alpha_round_borders,
+                    ..ext.buttons_color
                 },
-                TextInputType::Error => Color::new(0.8, 0.15, 0.15, get_alpha_round_borders(*self)),
+                TextInputType::Error => Color::new(0.8, 0.15, 0.15, ext.alpha_round_borders),
             },
             icon_color: colors.text_body,
         }

--- a/src/gui/styles/text_input.rs
+++ b/src/gui/styles/text_input.rs
@@ -20,7 +20,7 @@ impl iced::widget::text_input::StyleSheet for StyleType {
 
     fn active(&self, style: &Self::Style) -> iced::widget::text_input::Appearance {
         let colors = self.get_palette();
-        let ext = self.get_palette_extension();
+        let ext = self.get_extension();
         Appearance {
             background: Background::Color(match style {
                 TextInputType::Badge => Color::TRANSPARENT,
@@ -56,7 +56,7 @@ impl iced::widget::text_input::StyleSheet for StyleType {
 
     fn placeholder_color(&self, _: &Self::Style) -> Color {
         let color = self.get_palette().text_body;
-        let is_nightly = self.get_palette_extension().is_nightly;
+        let is_nightly = self.get_extension().is_nightly;
         Color {
             a: if is_nightly { 0.2 } else { 0.7 },
             ..color
@@ -69,7 +69,7 @@ impl iced::widget::text_input::StyleSheet for StyleType {
 
     fn disabled_color(&self, _style: &Self::Style) -> Color {
         let color = self.get_palette().text_body;
-        let is_nightly = self.get_palette_extension().is_nightly;
+        let is_nightly = self.get_extension().is_nightly;
         Color {
             a: if is_nightly { 0.2 } else { 0.7 },
             ..color
@@ -78,7 +78,7 @@ impl iced::widget::text_input::StyleSheet for StyleType {
 
     fn selection_color(&self, _: &Self::Style) -> Color {
         let color = self.get_palette().text_body;
-        let is_nightly = self.get_palette_extension().is_nightly;
+        let is_nightly = self.get_extension().is_nightly;
         Color {
             a: if is_nightly { 0.05 } else { 0.4 },
             ..color
@@ -87,7 +87,7 @@ impl iced::widget::text_input::StyleSheet for StyleType {
 
     fn hovered(&self, style: &Self::Style) -> iced::widget::text_input::Appearance {
         let colors = self.get_palette();
-        let ext = self.get_palette_extension();
+        let ext = self.get_extension();
         Appearance {
             background: Background::Color(match style {
                 TextInputType::Badge => Color::TRANSPARENT,
@@ -105,7 +105,7 @@ impl iced::widget::text_input::StyleSheet for StyleType {
 
     fn disabled(&self, style: &Self::Style) -> Appearance {
         let colors = self.get_palette();
-        let ext = self.get_palette_extension();
+        let ext = self.get_extension();
         Appearance {
             background: Background::Color(match style {
                 TextInputType::Badge => Color::TRANSPARENT,

--- a/src/gui/styles/types/custom_palette.rs
+++ b/src/gui/styles/types/custom_palette.rs
@@ -25,9 +25,9 @@ use crate::gui::styles::types::palette_extension::PaletteExtension;
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Serialize, Deserialize)]
 pub struct CustomPalette {
     #[serde(flatten)]
-    palette: Palette,
+    pub(crate) palette: Palette,
     #[serde(flatten)]
-    extension: PaletteExtension,
+    pub(crate) extension: PaletteExtension,
 }
 
 impl CustomPalette {

--- a/src/gui/styles/types/custom_palette.rs
+++ b/src/gui/styles/types/custom_palette.rs
@@ -1,10 +1,7 @@
 use std::fmt;
-use std::fs::File;
 use std::hash::Hash;
-use std::io::{BufReader, Read};
-use std::path::Path;
 
-use serde::{de::Error as DeErrorTrait, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use crate::gui::styles::custom_themes::dracula::{
     DRACULA_DARK_PALETTE, DRACULA_DARK_PALETTE_EXTENSION, DRACULA_LIGHT_PALETTE,
@@ -39,30 +36,6 @@ impl CustomPalette {
             palette,
             extension: palette.generate_palette_extension(),
         }
-    }
-}
-
-impl Palette {
-    /// Deserialize [`Palette`] from `path`.
-    ///
-    /// # Arguments
-    /// * `path` - Path to a UTF-8 encoded file containing a custom style as TOML.
-    pub fn from_file<P>(path: P) -> Result<Self, toml::de::Error>
-    where
-        P: AsRef<Path>,
-    {
-        // Try to open the file at `path`
-        let mut toml_reader = File::open(path)
-            .map_err(DeErrorTrait::custom)
-            .map(BufReader::new)?;
-
-        // Read the ostensible TOML
-        let mut style_toml = String::new();
-        toml_reader
-            .read_to_string(&mut style_toml)
-            .map_err(DeErrorTrait::custom)?;
-
-        toml::de::from_str(&style_toml)
     }
 }
 

--- a/src/gui/styles/types/custom_palette.rs
+++ b/src/gui/styles/types/custom_palette.rs
@@ -56,7 +56,7 @@ pub enum ExtraStyles {
 
 impl ExtraStyles {
     /// [`Palette`] of the [`ExtraStyles`] variant
-    pub fn to_palette(self) -> Palette {
+    pub fn get_palette(self) -> Palette {
         match self {
             ExtraStyles::DraculaDark => *DRACULA_DARK_PALETTE,
             ExtraStyles::DraculaLight => *DRACULA_LIGHT_PALETTE,
@@ -71,7 +71,7 @@ impl ExtraStyles {
     }
 
     /// [`PaletteExtension`] of the [`ExtraStyles`] variant
-    pub fn to_palette_extension(self) -> PaletteExtension {
+    pub fn get_extension(self) -> PaletteExtension {
         match self {
             ExtraStyles::DraculaDark => *DRACULA_DARK_PALETTE_EXTENSION,
             ExtraStyles::DraculaLight => *DRACULA_LIGHT_PALETTE_EXTENSION,
@@ -114,41 +114,5 @@ impl fmt::Display for ExtraStyles {
             // Custom style names aren't used anywhere so this shouldn't be reached
             ExtraStyles::CustomToml(_) => unreachable!(),
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use iced::color;
-
-    use super::Palette;
-
-    fn style_path(name: &str) -> String {
-        format!(
-            "{}/resources/themes/{}.toml",
-            env!("CARGO_MANIFEST_DIR"),
-            name
-        )
-    }
-
-    // NOTE: This has to be updated if `resources/themes/catppuccin.toml` changes
-    fn catppuccin_style() -> Palette {
-        Palette {
-            primary: color!(0x30, 0x34, 0x46),
-            secondary: color!(0xa6, 0xd1, 0x89),
-            outgoing: color!(0xf4, 0xb8, 0xe4),
-            starred: color!(0xe5, 0xc8, 0x90, 0.6666667),
-            text_headers: color!(0x23, 0x26, 0x34),
-            text_body: color!(0xc6, 0xd0, 0xf5),
-        }
-    }
-
-    #[test]
-    fn custompalette_from_file_de() -> Result<(), toml::de::Error> {
-        let style = catppuccin_style();
-        let style_de = Palette::from_file(style_path("catppuccin"))?;
-
-        assert_eq!(style, style_de);
-        Ok(())
     }
 }

--- a/src/gui/styles/types/custom_palette.rs
+++ b/src/gui/styles/types/custom_palette.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 use std::fs::File;
-use std::hash::{Hash, Hasher};
+use std::hash::Hash;
 use std::io::{BufReader, Read};
 use std::path::Path;
 
@@ -69,13 +69,13 @@ impl ExtraStyles {
     pub fn to_palette(self) -> Palette {
         match self {
             ExtraStyles::DraculaDark => *DRACULA_DARK_PALETTE,
-            ExtraStyles::DraculaLight => DRACULA_LIGHT_PALETTE,
-            ExtraStyles::GruvboxDark => GRUVBOX_DARK_PALETTE,
-            ExtraStyles::GruvboxLight => GRUVBOX_LIGHT_PALETTE,
-            ExtraStyles::NordDark => NORD_DARK_PALETTE,
-            ExtraStyles::NordLight => NORD_LIGHT_PALETTE,
-            ExtraStyles::SolarizedDark => SOLARIZED_DARK_PALETTE,
-            ExtraStyles::SolarizedLight => SOLARIZED_LIGHT_PALETTE,
+            ExtraStyles::DraculaLight => *DRACULA_LIGHT_PALETTE,
+            ExtraStyles::GruvboxDark => *GRUVBOX_DARK_PALETTE,
+            ExtraStyles::GruvboxLight => *GRUVBOX_LIGHT_PALETTE,
+            ExtraStyles::NordDark => *NORD_DARK_PALETTE,
+            ExtraStyles::NordLight => *NORD_LIGHT_PALETTE,
+            ExtraStyles::SolarizedDark => *SOLARIZED_DARK_PALETTE,
+            ExtraStyles::SolarizedLight => *SOLARIZED_LIGHT_PALETTE,
             ExtraStyles::CustomToml(palette, _) => palette,
         }
     }

--- a/src/gui/styles/types/custom_palette.rs
+++ b/src/gui/styles/types/custom_palette.rs
@@ -30,14 +30,14 @@ pub struct CustomPalette {
     #[serde(flatten)]
     palette: Palette,
     #[serde(flatten)]
-    extension: PaletteExtension
+    extension: PaletteExtension,
 }
 
 impl CustomPalette {
     pub fn from_palette(palette: Palette) -> Self {
         Self {
             palette,
-            extension: palette.generate_palette_extension()
+            extension: palette.generate_palette_extension(),
         }
     }
 }
@@ -148,7 +148,7 @@ impl fmt::Display for ExtraStyles {
 mod tests {
     use iced::color;
 
-    use super::{Palette};
+    use super::Palette;
 
     fn style_path(name: &str) -> String {
         format!(
@@ -161,13 +161,13 @@ mod tests {
     // NOTE: This has to be updated if `resources/themes/catppuccin.toml` changes
     fn catppuccin_style() -> Palette {
         Palette {
-                primary: color!(0x30, 0x34, 0x46),
-                secondary: color!(0xa6, 0xd1, 0x89),
-                outgoing: color!(0xf4, 0xb8, 0xe4),
-                starred: color!(0xe5, 0xc8, 0x90, 0.6666667),
-                text_headers: color!(0x23, 0x26, 0x34),
-                text_body: color!(0xc6, 0xd0, 0xf5),
-            }
+            primary: color!(0x30, 0x34, 0x46),
+            secondary: color!(0xa6, 0xd1, 0x89),
+            outgoing: color!(0xf4, 0xb8, 0xe4),
+            starred: color!(0xe5, 0xc8, 0x90, 0.6666667),
+            text_headers: color!(0x23, 0x26, 0x34),
+            text_body: color!(0xc6, 0xd0, 0xf5),
+        }
     }
 
     #[test]

--- a/src/gui/styles/types/custom_palette.rs
+++ b/src/gui/styles/types/custom_palette.rs
@@ -6,10 +6,24 @@ use std::path::Path;
 
 use serde::{de::Error as DeErrorTrait, Deserialize, Serialize};
 
-use crate::gui::styles::custom_themes::{dracula, gruvbox, nord, solarized};
+use crate::gui::styles::custom_themes::dracula::{
+    DRACULA_DARK_PALETTE, DRACULA_DARK_PALETTE_EXTENSION, DRACULA_LIGHT_PALETTE,
+    DRACULA_LIGHT_PALETTE_EXTENSION,
+};
+use crate::gui::styles::custom_themes::gruvbox::{
+    GRUVBOX_DARK_PALETTE, GRUVBOX_DARK_PALETTE_EXTENSION, GRUVBOX_LIGHT_PALETTE,
+    GRUVBOX_LIGHT_PALETTE_EXTENSION,
+};
+use crate::gui::styles::custom_themes::nord::{
+    NORD_DARK_PALETTE, NORD_DARK_PALETTE_EXTENSION, NORD_LIGHT_PALETTE,
+    NORD_LIGHT_PALETTE_EXTENSION,
+};
+use crate::gui::styles::custom_themes::solarized::{
+    SOLARIZED_DARK_PALETTE, SOLARIZED_DARK_PALETTE_EXTENSION, SOLARIZED_LIGHT_PALETTE,
+    SOLARIZED_LIGHT_PALETTE_EXTENSION,
+};
 use crate::gui::styles::types::palette::Palette;
-
-use super::color_remote::{color_hash};
+use crate::gui::styles::types::palette_extension::PaletteExtension;
 
 impl Palette {
     /// Deserialize [`CustomPalette`] from `path`.
@@ -35,29 +49,9 @@ impl Palette {
     }
 }
 
-impl Hash for Palette {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        let Palette {
-            primary,
-            secondary,
-            outgoing,
-            starred,
-            text_headers,
-            text_body,
-        } = self;
-
-        color_hash(*primary, state);
-        color_hash(*secondary, state);
-        color_hash(*outgoing, state);
-        color_hash(*starred, state);
-        color_hash(*text_headers, state);
-        color_hash(*text_body, state);
-    }
-}
-
 /// Built in extra styles
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Serialize, Deserialize)]
-#[serde(tag = "custom")]
+// #[serde(tag = "custom")]
 pub enum ExtraStyles {
     DraculaDark,
     DraculaLight,
@@ -67,22 +61,37 @@ pub enum ExtraStyles {
     NordLight,
     SolarizedDark,
     SolarizedLight,
-    CustomToml(Palette),
+    CustomToml(Palette, PaletteExtension),
 }
 
 impl ExtraStyles {
     /// [`Palette`] of the [`ExtraStyles`] variant
     pub fn to_palette(self) -> Palette {
         match self {
-            ExtraStyles::DraculaLight => dracula::dracula_light(),
-            ExtraStyles::DraculaDark => dracula::dracula_dark(),
-            ExtraStyles::GruvboxDark => gruvbox::gruvbox_dark(),
-            ExtraStyles::GruvboxLight => gruvbox::gruvbox_light(),
-            ExtraStyles::NordLight => nord::nord_light(),
-            ExtraStyles::NordDark => nord::nord_dark(),
-            ExtraStyles::SolarizedDark => solarized::solarized_dark(),
-            ExtraStyles::SolarizedLight => solarized::solarized_light(),
-            ExtraStyles::CustomToml(user) => user,
+            ExtraStyles::DraculaDark => *DRACULA_DARK_PALETTE,
+            ExtraStyles::DraculaLight => DRACULA_LIGHT_PALETTE,
+            ExtraStyles::GruvboxDark => GRUVBOX_DARK_PALETTE,
+            ExtraStyles::GruvboxLight => GRUVBOX_LIGHT_PALETTE,
+            ExtraStyles::NordDark => NORD_DARK_PALETTE,
+            ExtraStyles::NordLight => NORD_LIGHT_PALETTE,
+            ExtraStyles::SolarizedDark => SOLARIZED_DARK_PALETTE,
+            ExtraStyles::SolarizedLight => SOLARIZED_LIGHT_PALETTE,
+            ExtraStyles::CustomToml(palette, _) => palette,
+        }
+    }
+
+    /// [`PaletteExtension`] of the [`ExtraStyles`] variant
+    pub fn to_palette_extension(self) -> PaletteExtension {
+        match self {
+            ExtraStyles::DraculaDark => *DRACULA_DARK_PALETTE_EXTENSION,
+            ExtraStyles::DraculaLight => *DRACULA_LIGHT_PALETTE_EXTENSION,
+            ExtraStyles::GruvboxDark => *GRUVBOX_DARK_PALETTE_EXTENSION,
+            ExtraStyles::GruvboxLight => *GRUVBOX_LIGHT_PALETTE_EXTENSION,
+            ExtraStyles::NordDark => *NORD_DARK_PALETTE_EXTENSION,
+            ExtraStyles::NordLight => *NORD_LIGHT_PALETTE_EXTENSION,
+            ExtraStyles::SolarizedDark => *SOLARIZED_DARK_PALETTE_EXTENSION,
+            ExtraStyles::SolarizedLight => *SOLARIZED_LIGHT_PALETTE_EXTENSION,
+            ExtraStyles::CustomToml(_, palette_extension) => palette_extension,
         }
     }
 
@@ -113,7 +122,7 @@ impl fmt::Display for ExtraStyles {
             ExtraStyles::SolarizedLight => write!(f, "Solarized (Day)"),
             ExtraStyles::SolarizedDark => write!(f, "Solarized (Night)"),
             // Custom style names aren't used anywhere so this shouldn't be reached
-            ExtraStyles::CustomToml(_) => unreachable!(),
+            ExtraStyles::CustomToml(_, _) => unreachable!(),
         }
     }
 }
@@ -138,16 +147,10 @@ mod tests {
             palette: Palette {
                 primary: color!(0x30, 0x34, 0x46),
                 secondary: color!(0xa6, 0xd1, 0x89),
-                buttons: color!(0x41, 0x45, 0x59),
                 outgoing: color!(0xf4, 0xb8, 0xe4),
+                starred: color!(0xe5, 0xc8, 0x90, 0.6666667),
                 text_headers: color!(0x23, 0x26, 0x34),
                 text_body: color!(0xc6, 0xd0, 0xf5),
-            },
-            extension: PaletteExtension {
-                starred: color!(0xe5, 0xc8, 0x90, 0.6666667),
-                round_borders_alpha: 0.4,
-                round_containers_alpha: 0.25,
-                chart_badge_alpha: 0.2,
             },
         }
     }

--- a/src/gui/styles/types/mod.rs
+++ b/src/gui/styles/types/mod.rs
@@ -2,4 +2,5 @@ pub(super) mod color_remote;
 pub mod custom_palette;
 pub mod gradient_type;
 pub mod palette;
+pub mod palette_extension;
 pub mod style_type;

--- a/src/gui/styles/types/palette.rs
+++ b/src/gui/styles/types/palette.rs
@@ -15,7 +15,6 @@ use super::color_remote::{deserialize_color, serialize_color};
 ///
 /// Best practices:
 /// - `primary` should be a kind of neutral color
-/// - `primary` and `buttons` should be similar colors
 /// - `secondary` and `outgoing` should be complementary colors if possible
 /// - `text_headers` should be black or white and must have a strong contrast with `secondary`
 /// - `text_body` should be black or white and must have a strong contrast with `primary`
@@ -39,12 +38,12 @@ pub struct Palette {
         serialize_with = "serialize_color"
     )]
     pub outgoing: Color,
-    /// Color of active buttons (when not hovered) and inactive tabs
+    /// Color of favorites' star symbol
     #[serde(
         deserialize_with = "deserialize_color",
         serialize_with = "serialize_color"
     )]
-    pub buttons: Color,
+    pub starred: Color,
     /// Color of header and footer text
     #[serde(
         deserialize_with = "deserialize_color",
@@ -57,16 +56,6 @@ pub struct Palette {
         serialize_with = "serialize_color"
     )]
     pub text_body: Color,
-}
-
-pub fn get_colors(style: StyleType) -> Palette {
-    match style {
-        StyleType::Night => NIGHT_STYLE,
-        StyleType::Day => DAY_STYLE,
-        StyleType::DeepSea => DEEP_SEA_STYLE,
-        StyleType::MonAmour => MON_AMOUR_STYLE,
-        StyleType::Custom(style) => style.to_palette(),
-    }
 }
 
 pub fn to_rgb_color(color: Color) -> RGBColor {

--- a/src/gui/styles/types/palette.rs
+++ b/src/gui/styles/types/palette.rs
@@ -1,6 +1,9 @@
 //! Module defining the `Colors` struct, which defines the colors in use in the GUI.
 
+use std::fs::File;
 use std::hash::{Hash, Hasher};
+use std::io::{BufReader, Read};
+use std::path::Path;
 
 use iced::Color;
 use plotters::style::RGBColor;
@@ -102,7 +105,7 @@ impl Palette {
         let alpha_round_borders = if is_nightly { 0.3 } else { 0.6 };
         let alpha_round_containers = if is_nightly { 0.12 } else { 0.24 };
         let buttons_color = self.generate_buttons_color();
-        println!("ciao");
+
         PaletteExtension {
             is_nightly,
             font,
@@ -112,6 +115,28 @@ impl Palette {
             alpha_round_containers,
             buttons_color,
         }
+    }
+
+    /// Deserialize [`Palette`] from `path`.
+    ///
+    /// # Arguments
+    /// * `path` - Path to a UTF-8 encoded file containing a custom style as TOML.
+    pub fn from_file<P>(path: P) -> Result<Self, toml::de::Error>
+    where
+        P: AsRef<Path>,
+    {
+        // Try to open the file at `path`
+        let mut toml_reader = File::open(path)
+            .map_err(serde::de::Error::custom)
+            .map(BufReader::new)?;
+
+        // Read the ostensible TOML
+        let mut style_toml = String::new();
+        toml_reader
+            .read_to_string(&mut style_toml)
+            .map_err(serde::de::Error::custom)?;
+
+        toml::de::from_str(&style_toml)
     }
 }
 

--- a/src/gui/styles/types/palette.rs
+++ b/src/gui/styles/types/palette.rs
@@ -1,12 +1,14 @@
 //! Module defining the `Colors` struct, which defines the colors in use in the GUI.
 
-use crate::gui::styles::style_constants::{NIGHT_PALETTE, SARASA_MONO, SARASA_MONO_BOLD};
-use crate::gui::styles::types::color_remote::color_hash;
-use crate::gui::styles::types::palette_extension::PaletteExtension;
+use std::hash::{Hash, Hasher};
+
 use iced::Color;
 use plotters::style::RGBColor;
 use serde::{Deserialize, Serialize};
-use std::hash::{Hash, Hasher};
+
+use crate::gui::styles::style_constants::{NIGHT_PALETTE, SARASA_MONO, SARASA_MONO_BOLD};
+use crate::gui::styles::types::color_remote::color_hash;
+use crate::gui::styles::types::palette_extension::PaletteExtension;
 
 use super::color_remote::{deserialize_color, serialize_color};
 
@@ -171,6 +173,7 @@ impl Default for Palette {
 #[cfg(test)]
 mod tests {
     use iced::Color;
+
     use crate::gui::styles::style_constants::{SARASA_MONO, SARASA_MONO_BOLD};
     use crate::gui::styles::types::palette::Palette;
     use crate::gui::styles::types::palette_extension::PaletteExtension;
@@ -182,55 +185,56 @@ mod tests {
                 r: 1.0,
                 g: 0.4,
                 b: 0.05,
-                a: 1.0
+                a: 1.0,
             },
             secondary: Color {
                 r: 0.7,
                 g: 0.9,
                 b: 0.5,
-                a: 1.0
+                a: 1.0,
             },
             outgoing: Color {
                 r: 0.9,
                 g: 0.5,
                 b: 0.7,
-                a: 1.0
+                a: 1.0,
             },
             starred: Color {
                 r: 0.5,
                 g: 0.5,
                 b: 0.5,
-                a: 0.5
+                a: 0.5,
             },
             text_headers: Color {
                 r: 0.0,
                 g: 0.2,
                 b: 0.2,
-                a: 1.0
+                a: 1.0,
             },
             text_body: Color {
                 r: 0.5,
                 g: 0.5,
                 b: 0.51,
-                a: 1.0
-            }
+                a: 1.0,
+            },
         };
 
-        assert_eq!(palette.generate_palette_extension(),
-                   PaletteExtension{
-                       is_nightly: true,
-                       font: SARASA_MONO,
-                       font_headers: SARASA_MONO_BOLD,
-                       alpha_chart_badge: 0.15,
-                       alpha_round_borders: 0.3,
-                       alpha_round_containers: 0.12,
-                       buttons_color: Color {
-                           r: 1.0,
-                           g: 0.55,
-                           b: 0.2,
-                           a: 1.0
-                       }
-                   }
+        assert_eq!(
+            palette.generate_palette_extension(),
+            PaletteExtension {
+                is_nightly: true,
+                font: SARASA_MONO,
+                font_headers: SARASA_MONO_BOLD,
+                alpha_chart_badge: 0.15,
+                alpha_round_borders: 0.3,
+                alpha_round_containers: 0.12,
+                buttons_color: Color {
+                    r: 1.0,
+                    g: 0.55,
+                    b: 0.2,
+                    a: 1.0
+                }
+            }
         )
     }
 
@@ -241,42 +245,43 @@ mod tests {
                 r: 1.0,
                 g: 0.9,
                 b: 0.05,
-                a: 1.0
+                a: 1.0,
             },
             secondary: Color {
                 r: 0.7,
                 g: 0.9,
                 b: 0.5,
-                a: 1.0
+                a: 1.0,
             },
             outgoing: Color {
                 r: 0.9,
                 g: 0.5,
                 b: 0.7,
-                a: 1.0
+                a: 1.0,
             },
             starred: Color {
                 r: 0.5,
                 g: 0.5,
                 b: 0.5,
-                a: 0.5
+                a: 0.5,
             },
             text_headers: Color {
                 r: 0.7,
                 g: 0.2,
                 b: 0.2,
-                a: 1.0
+                a: 1.0,
             },
             text_body: Color {
                 r: 1.0,
                 g: 0.9,
                 b: 0.4,
-                a: 1.0
-            }
+                a: 1.0,
+            },
         };
 
-        assert_eq!(palette.generate_palette_extension(),
-            PaletteExtension{
+        assert_eq!(
+            palette.generate_palette_extension(),
+            PaletteExtension {
                 is_nightly: false,
                 font: SARASA_MONO,
                 font_headers: SARASA_MONO_BOLD,

--- a/src/gui/styles/types/palette.rs
+++ b/src/gui/styles/types/palette.rs
@@ -9,7 +9,10 @@ use iced::Color;
 use plotters::style::RGBColor;
 use serde::{Deserialize, Serialize};
 
-use crate::gui::styles::style_constants::{NIGHT_PALETTE, SARASA_MONO, SARASA_MONO_BOLD};
+use crate::gui::styles::style_constants::{
+    BUTTONS_DAY, BUTTONS_DEEP_SEA, BUTTONS_MON_AMOUR, BUTTONS_NIGHT, DAY_PALETTE, DEEP_SEA_PALETTE,
+    MON_AMOUR_PALETTE, NIGHT_PALETTE, SARASA_MONO, SARASA_MONO_BOLD,
+};
 use crate::gui::styles::types::color_remote::color_hash;
 use crate::gui::styles::types::palette_extension::PaletteExtension;
 
@@ -64,6 +67,17 @@ pub struct Palette {
 
 impl Palette {
     pub fn generate_buttons_color(self) -> Color {
+        // first check if this is one of the standard palettes...
+        if self.eq(&NIGHT_PALETTE) {
+            return BUTTONS_NIGHT;
+        } else if self.eq(&DAY_PALETTE) {
+            return BUTTONS_DAY;
+        } else if self.eq(&DEEP_SEA_PALETTE) {
+            return BUTTONS_DEEP_SEA;
+        } else if self.eq(&MON_AMOUR_PALETTE) {
+            return BUTTONS_MON_AMOUR;
+        };
+
         let primary = self.primary;
         let is_nightly = primary.r + primary.g + primary.b <= 1.5;
         if is_nightly {
@@ -197,11 +211,42 @@ impl Default for Palette {
 
 #[cfg(test)]
 mod tests {
+    use iced::color;
     use iced::Color;
 
     use crate::gui::styles::style_constants::{SARASA_MONO, SARASA_MONO_BOLD};
-    use crate::gui::styles::types::palette::Palette;
     use crate::gui::styles::types::palette_extension::PaletteExtension;
+
+    use super::Palette;
+
+    fn style_path(name: &str) -> String {
+        format!(
+            "{}/resources/themes/{}.toml",
+            env!("CARGO_MANIFEST_DIR"),
+            name
+        )
+    }
+
+    // NOTE: This has to be updated if `resources/themes/catppuccin.toml` changes
+    fn catppuccin_style() -> Palette {
+        Palette {
+            primary: color!(0x30, 0x34, 0x46),
+            secondary: color!(0xa6, 0xd1, 0x89),
+            outgoing: color!(0xf4, 0xb8, 0xe4),
+            starred: color!(0xe5, 0xc8, 0x90, 0.6666667),
+            text_headers: color!(0x23, 0x26, 0x34),
+            text_body: color!(0xc6, 0xd0, 0xf5),
+        }
+    }
+
+    #[test]
+    fn custompalette_from_file_de() -> Result<(), toml::de::Error> {
+        let style = catppuccin_style();
+        let style_de = Palette::from_file(style_path("catppuccin"))?;
+
+        assert_eq!(style, style_de);
+        Ok(())
+    }
 
     #[test]
     fn test_generate_palette_extension_dark() {

--- a/src/gui/styles/types/palette.rs
+++ b/src/gui/styles/types/palette.rs
@@ -58,6 +58,26 @@ pub struct Palette {
 }
 
 impl Palette {
+    pub fn generate_buttons_color(self) -> Color {
+        let primary = self.primary;
+        let is_nightly = primary.r + primary.g + primary.b <= 1.5;
+        if is_nightly {
+            Color {
+                r: f32::min(primary.r + 0.15, 1.0),
+                g: f32::min(primary.g + 0.15, 1.0),
+                b: f32::min(primary.b + 0.15, 1.0),
+                a: 1.0,
+            }
+        } else {
+            Color {
+                r: f32::max(primary.r - 0.15, 0.0),
+                g: f32::max(primary.g - 0.15, 0.0),
+                b: f32::max(primary.b - 0.15, 0.0),
+                a: 1.0,
+            }
+        }
+    }
+
     pub fn generate_palette_extension(self) -> PaletteExtension {
         let primary = self.primary;
         let text_body = self.text_body;
@@ -79,22 +99,8 @@ impl Palette {
         let alpha_chart_badge = if is_nightly { 0.15 } else { 0.75 };
         let alpha_round_borders = if is_nightly { 0.3 } else { 0.6 };
         let alpha_round_containers = if is_nightly { 0.12 } else { 0.24 };
-        let buttons_color = if is_nightly {
-            Color {
-                r: f32::min(primary.r + 0.15, 1.0),
-                g: f32::min(primary.g + 0.15, 1.0),
-                b: f32::min(primary.b + 0.15, 1.0),
-                a: 1.0,
-            }
-        } else {
-            Color {
-                r: f32::max(primary.r - 0.15, 0.0),
-                g: f32::max(primary.g - 0.15, 0.0),
-                b: f32::max(primary.b - 0.15, 0.0),
-                a: 1.0,
-            }
-        };
-
+        let buttons_color = self.generate_buttons_color();
+        println!("ciao");
         PaletteExtension {
             is_nightly,
             font,
@@ -159,5 +165,131 @@ pub fn mix_colors(color_1: Color, color_2: Color) -> Color {
 impl Default for Palette {
     fn default() -> Self {
         NIGHT_PALETTE
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use iced::Color;
+    use crate::gui::styles::style_constants::{SARASA_MONO, SARASA_MONO_BOLD};
+    use crate::gui::styles::types::palette::Palette;
+    use crate::gui::styles::types::palette_extension::PaletteExtension;
+
+    #[test]
+    fn test_generate_palette_extension_dark() {
+        let palette = Palette {
+            primary: Color {
+                r: 1.0,
+                g: 0.4,
+                b: 0.05,
+                a: 1.0
+            },
+            secondary: Color {
+                r: 0.7,
+                g: 0.9,
+                b: 0.5,
+                a: 1.0
+            },
+            outgoing: Color {
+                r: 0.9,
+                g: 0.5,
+                b: 0.7,
+                a: 1.0
+            },
+            starred: Color {
+                r: 0.5,
+                g: 0.5,
+                b: 0.5,
+                a: 0.5
+            },
+            text_headers: Color {
+                r: 0.0,
+                g: 0.2,
+                b: 0.2,
+                a: 1.0
+            },
+            text_body: Color {
+                r: 0.5,
+                g: 0.5,
+                b: 0.51,
+                a: 1.0
+            }
+        };
+
+        assert_eq!(palette.generate_palette_extension(),
+                   PaletteExtension{
+                       is_nightly: true,
+                       font: SARASA_MONO,
+                       font_headers: SARASA_MONO_BOLD,
+                       alpha_chart_badge: 0.15,
+                       alpha_round_borders: 0.3,
+                       alpha_round_containers: 0.12,
+                       buttons_color: Color {
+                           r: 1.0,
+                           g: 0.55,
+                           b: 0.2,
+                           a: 1.0
+                       }
+                   }
+        )
+    }
+
+    #[test]
+    fn test_generate_palette_extension_light() {
+        let palette = Palette {
+            primary: Color {
+                r: 1.0,
+                g: 0.9,
+                b: 0.05,
+                a: 1.0
+            },
+            secondary: Color {
+                r: 0.7,
+                g: 0.9,
+                b: 0.5,
+                a: 1.0
+            },
+            outgoing: Color {
+                r: 0.9,
+                g: 0.5,
+                b: 0.7,
+                a: 1.0
+            },
+            starred: Color {
+                r: 0.5,
+                g: 0.5,
+                b: 0.5,
+                a: 0.5
+            },
+            text_headers: Color {
+                r: 0.7,
+                g: 0.2,
+                b: 0.2,
+                a: 1.0
+            },
+            text_body: Color {
+                r: 1.0,
+                g: 0.9,
+                b: 0.4,
+                a: 1.0
+            }
+        };
+
+        assert_eq!(palette.generate_palette_extension(),
+            PaletteExtension{
+                is_nightly: false,
+                font: SARASA_MONO,
+                font_headers: SARASA_MONO_BOLD,
+                alpha_chart_badge: 0.75,
+                alpha_round_borders: 0.6,
+                alpha_round_containers: 0.24,
+                buttons_color: Color {
+                    r: 0.85,
+                    g: 0.75,
+                    b: 0.0,
+                    a: 1.0
+                }
+            }
+        )
     }
 }

--- a/src/gui/styles/types/palette.rs
+++ b/src/gui/styles/types/palette.rs
@@ -1,13 +1,12 @@
 //! Module defining the `Colors` struct, which defines the colors in use in the GUI.
 
+use crate::gui::styles::style_constants::{NIGHT_PALETTE, SARASA_MONO, SARASA_MONO_BOLD};
+use crate::gui::styles::types::color_remote::color_hash;
+use crate::gui::styles::types::palette_extension::PaletteExtension;
 use iced::Color;
 use plotters::style::RGBColor;
 use serde::{Deserialize, Serialize};
-
-use crate::gui::styles::style_constants::{
-    DAY_STYLE, DEEP_SEA_STYLE, MON_AMOUR_STYLE, NIGHT_STYLE,
-};
-use crate::StyleType;
+use std::hash::{Hash, Hasher};
 
 use super::color_remote::{deserialize_color, serialize_color};
 
@@ -58,6 +57,76 @@ pub struct Palette {
     pub text_body: Color,
 }
 
+impl Palette {
+    pub fn generate_palette_extension(self) -> PaletteExtension {
+        let primary = self.primary;
+        let text_body = self.text_body;
+        let text_headers = self.text_headers;
+        let is_text_body_dark = text_body.r + text_body.g + text_body.b <= 1.5;
+        let is_text_headers_dark = text_headers.r + text_headers.g + text_headers.b <= 1.5;
+
+        let is_nightly = primary.r + primary.g + primary.b <= 1.5;
+        let font = if is_text_body_dark {
+            SARASA_MONO_BOLD
+        } else {
+            SARASA_MONO
+        };
+        let font_headers = if is_text_headers_dark {
+            SARASA_MONO_BOLD
+        } else {
+            SARASA_MONO
+        };
+        let alpha_chart_badge = if is_nightly { 0.15 } else { 0.75 };
+        let alpha_round_borders = if is_nightly { 0.3 } else { 0.6 };
+        let alpha_round_containers = if is_nightly { 0.12 } else { 0.24 };
+        let buttons_color = if is_nightly {
+            Color {
+                r: f32::min(primary.r + 0.15, 1.0),
+                g: f32::min(primary.g + 0.15, 1.0),
+                b: f32::min(primary.b + 0.15, 1.0),
+                a: 1.0,
+            }
+        } else {
+            Color {
+                r: f32::max(primary.r - 0.15, 0.0),
+                g: f32::max(primary.g - 0.15, 0.0),
+                b: f32::max(primary.b - 0.15, 0.0),
+                a: 1.0,
+            }
+        };
+
+        PaletteExtension {
+            is_nightly,
+            font,
+            font_headers,
+            alpha_chart_badge,
+            alpha_round_borders,
+            alpha_round_containers,
+            buttons_color,
+        }
+    }
+}
+
+impl Hash for Palette {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let Palette {
+            primary,
+            secondary,
+            outgoing,
+            starred,
+            text_headers,
+            text_body,
+        } = self;
+
+        color_hash(*primary, state);
+        color_hash(*secondary, state);
+        color_hash(*outgoing, state);
+        color_hash(*starred, state);
+        color_hash(*text_headers, state);
+        color_hash(*text_body, state);
+    }
+}
+
 pub fn to_rgb_color(color: Color) -> RGBColor {
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     if color.r <= 1.0
@@ -89,6 +158,6 @@ pub fn mix_colors(color_1: Color, color_2: Color) -> Color {
 
 impl Default for Palette {
     fn default() -> Self {
-        get_colors(StyleType::Night)
+        NIGHT_PALETTE
     }
 }

--- a/src/gui/styles/types/palette.rs
+++ b/src/gui/styles/types/palette.rs
@@ -9,10 +9,7 @@ use iced::Color;
 use plotters::style::RGBColor;
 use serde::{Deserialize, Serialize};
 
-use crate::gui::styles::style_constants::{
-    BUTTONS_DAY, BUTTONS_DEEP_SEA, BUTTONS_MON_AMOUR, BUTTONS_NIGHT, DAY_PALETTE, DEEP_SEA_PALETTE,
-    MON_AMOUR_PALETTE, NIGHT_PALETTE, SARASA_MONO, SARASA_MONO_BOLD,
-};
+use crate::gui::styles::style_constants::{NIGHT_PALETTE, SARASA_MONO, SARASA_MONO_BOLD};
 use crate::gui::styles::types::color_remote::color_hash;
 use crate::gui::styles::types::palette_extension::PaletteExtension;
 
@@ -67,17 +64,6 @@ pub struct Palette {
 
 impl Palette {
     pub fn generate_buttons_color(self) -> Color {
-        // first check if this is one of the standard palettes...
-        if self.eq(&NIGHT_PALETTE) {
-            return BUTTONS_NIGHT;
-        } else if self.eq(&DAY_PALETTE) {
-            return BUTTONS_DAY;
-        } else if self.eq(&DEEP_SEA_PALETTE) {
-            return BUTTONS_DEEP_SEA;
-        } else if self.eq(&MON_AMOUR_PALETTE) {
-            return BUTTONS_MON_AMOUR;
-        };
-
         let primary = self.primary;
         let is_nightly = primary.r + primary.g + primary.b <= 1.5;
         if is_nightly {

--- a/src/gui/styles/types/palette_extension.rs
+++ b/src/gui/styles/types/palette_extension.rs
@@ -1,0 +1,79 @@
+use iced::{Color, Font};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::hash::{Hash, Hasher};
+use serde::de::Unexpected;
+use crate::gui::styles::style_constants::{SARASA_MONO, SARASA_MONO_BOLD};
+use crate::gui::styles::types::color_remote::color_hash;
+
+use super::color_remote::{deserialize_color, serialize_color};
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PaletteExtension {
+    pub is_nightly: bool,
+    #[serde(
+    deserialize_with = "deserialize_font",
+    serialize_with = "serialize_font"
+    )]
+    pub font: Font,
+    #[serde(
+    deserialize_with = "deserialize_font",
+    serialize_with = "serialize_font"
+    )]
+    pub font_headers: Font,
+    pub alpha_chart_badge: f32,
+    pub alpha_round_borders: f32,
+    pub alpha_round_containers: f32,
+    #[serde(
+    deserialize_with = "deserialize_color",
+    serialize_with = "serialize_color"
+    )]
+    pub buttons_color: Color,
+}
+
+impl Hash for PaletteExtension {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let PaletteExtension {
+            is_nightly,
+            font,
+            font_headers,
+            alpha_chart_badge,
+            alpha_round_borders,
+            alpha_round_containers,
+            buttons_color,
+        } = self;
+
+        is_nightly.hash(state);
+        font.hash(state);
+        font_headers.hash(state);
+        (997*(alpha_chart_badge + alpha_round_borders + alpha_round_containers) as u32).hash(state);
+        color_hash(*buttons_color, state);
+    }
+}
+
+pub(super) fn deserialize_font<'de, D>(deserializer: D) -> Result<Font, D::Error>
+    where
+        D: Deserializer<'de>,
+{
+    // Name should be SARASA_MONO or SARASA_MONO_BOLD
+    let name = String::deserialize(deserializer)?;
+
+    let regular_string = String::from("SARASA_MONO");
+    let bold_string = String::from("SARASA_MONO_BOLD");
+
+    match name {
+        regular_string => Ok(SARASA_MONO),
+        bold_string => Ok(SARASA_MONO_BOLD),
+        _ => Err(serde::de::Error::invalid_value(Unexpected::Str(&name), &"SARASA_MONO OR SARASA_MONO_BOLD"))
+    }
+}
+
+pub(super) fn serialize_font<S>(font: &Font, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+{
+    match font {
+        &SARASA_MONO => serializer.serialize_str("SARASA_MONO"),
+        &SARASA_MONO_BOLD => serializer.serialize_str("SARASA_MONO_BOLD"),
+        _ => Err(serde::ser::Error::custom("invalid font")),
+    }
+}

--- a/src/gui/styles/types/palette_extension.rs
+++ b/src/gui/styles/types/palette_extension.rs
@@ -79,3 +79,51 @@ where
         _ => Err(serde::ser::Error::custom("invalid font")),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use iced::Color;
+    use serde_test::{assert_tokens, Token};
+    use crate::gui::styles::style_constants::{SARASA_MONO, SARASA_MONO_BOLD};
+    use crate::gui::styles::types::palette_extension::PaletteExtension;
+
+    // Test if deserializing and serializing a PaletteExtension works.
+    #[test]
+    fn test_working_palette_extension_round_trip() {
+        let ext = PaletteExtension {
+            is_nightly: false,
+            font: SARASA_MONO_BOLD,
+            font_headers: SARASA_MONO,
+            alpha_chart_badge: 0.5,
+            alpha_round_borders: 0.25,
+            alpha_round_containers: 0.1778,
+            buttons_color: Color {
+                r: 0.6,
+                g: 0.4,
+                b: 0.2,
+                a: 1.0
+            }
+        };
+        assert_tokens(
+            &ext,
+            &[
+                Token::Struct { name: "PaletteExtension", len: 7 },
+                Token::Str("is_nightly"),
+                Token::Bool(false),
+                Token::Str("font"),
+                Token::Str("SARASA_MONO_BOLD"),
+                Token::Str("font_headers"),
+                Token::Str("SARASA_MONO"),
+                Token::Str("alpha_chart_badge"),
+                Token::F32(0.5),
+                Token::Str("alpha_round_borders"),
+                Token::F32(0.25),
+                Token::Str("alpha_round_containers"),
+                Token::F32(0.1778),
+                Token::Str("buttons_color"),
+                Token::Str("#996633"),
+                Token::StructEnd,
+            ],
+        );
+    }
+}

--- a/src/gui/styles/types/palette_extension.rs
+++ b/src/gui/styles/types/palette_extension.rs
@@ -1,9 +1,11 @@
-use crate::gui::styles::style_constants::{SARASA_MONO, SARASA_MONO_BOLD};
-use crate::gui::styles::types::color_remote::color_hash;
+use std::hash::{Hash, Hasher};
+
 use iced::{Color, Font};
 use serde::de::Unexpected;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::hash::{Hash, Hasher};
+
+use crate::gui::styles::style_constants::{SARASA_MONO, SARASA_MONO_BOLD};
+use crate::gui::styles::types::color_remote::color_hash;
 
 use super::color_remote::{deserialize_color, serialize_color};
 
@@ -45,7 +47,8 @@ impl Hash for PaletteExtension {
         is_nightly.hash(state);
         font.hash(state);
         font_headers.hash(state);
-        (997 * (alpha_chart_badge + alpha_round_borders + alpha_round_containers) as u32)
+        #[allow(clippy::cast_possible_truncation)]
+        (997 * (alpha_chart_badge + alpha_round_borders + alpha_round_containers) as i32)
             .hash(state);
         color_hash(*buttons_color, state);
     }
@@ -73,9 +76,9 @@ pub(super) fn serialize_font<S>(font: &Font, serializer: S) -> Result<S::Ok, S::
 where
     S: Serializer,
 {
-    match font {
-        &SARASA_MONO => serializer.serialize_str("SARASA_MONO"),
-        &SARASA_MONO_BOLD => serializer.serialize_str("SARASA_MONO_BOLD"),
+    match *font {
+        SARASA_MONO => serializer.serialize_str("SARASA_MONO"),
+        SARASA_MONO_BOLD => serializer.serialize_str("SARASA_MONO_BOLD"),
         _ => Err(serde::ser::Error::custom("invalid font")),
     }
 }
@@ -84,6 +87,7 @@ where
 mod tests {
     use iced::Color;
     use serde_test::{assert_tokens, Token};
+
     use crate::gui::styles::style_constants::{SARASA_MONO, SARASA_MONO_BOLD};
     use crate::gui::styles::types::palette_extension::PaletteExtension;
 
@@ -101,13 +105,16 @@ mod tests {
                 r: 0.6,
                 g: 0.4,
                 b: 0.2,
-                a: 1.0
-            }
+                a: 1.0,
+            },
         };
         assert_tokens(
             &ext,
             &[
-                Token::Struct { name: "PaletteExtension", len: 7 },
+                Token::Struct {
+                    name: "PaletteExtension",
+                    len: 7,
+                },
                 Token::Str("is_nightly"),
                 Token::Bool(false),
                 Token::Str("font"),

--- a/src/gui/styles/types/palette_extension.rs
+++ b/src/gui/styles/types/palette_extension.rs
@@ -1,9 +1,9 @@
-use iced::{Color, Font};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::hash::{Hash, Hasher};
-use serde::de::Unexpected;
 use crate::gui::styles::style_constants::{SARASA_MONO, SARASA_MONO_BOLD};
 use crate::gui::styles::types::color_remote::color_hash;
+use iced::{Color, Font};
+use serde::de::Unexpected;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::hash::{Hash, Hasher};
 
 use super::color_remote::{deserialize_color, serialize_color};
 
@@ -11,21 +11,21 @@ use super::color_remote::{deserialize_color, serialize_color};
 pub struct PaletteExtension {
     pub is_nightly: bool,
     #[serde(
-    deserialize_with = "deserialize_font",
-    serialize_with = "serialize_font"
+        deserialize_with = "deserialize_font",
+        serialize_with = "serialize_font"
     )]
     pub font: Font,
     #[serde(
-    deserialize_with = "deserialize_font",
-    serialize_with = "serialize_font"
+        deserialize_with = "deserialize_font",
+        serialize_with = "serialize_font"
     )]
     pub font_headers: Font,
     pub alpha_chart_badge: f32,
     pub alpha_round_borders: f32,
     pub alpha_round_containers: f32,
     #[serde(
-    deserialize_with = "deserialize_color",
-    serialize_with = "serialize_color"
+        deserialize_with = "deserialize_color",
+        serialize_with = "serialize_color"
     )]
     pub buttons_color: Color,
 }
@@ -45,31 +45,33 @@ impl Hash for PaletteExtension {
         is_nightly.hash(state);
         font.hash(state);
         font_headers.hash(state);
-        (997*(alpha_chart_badge + alpha_round_borders + alpha_round_containers) as u32).hash(state);
+        (997 * (alpha_chart_badge + alpha_round_borders + alpha_round_containers) as u32)
+            .hash(state);
         color_hash(*buttons_color, state);
     }
 }
 
 pub(super) fn deserialize_font<'de, D>(deserializer: D) -> Result<Font, D::Error>
-    where
-        D: Deserializer<'de>,
+where
+    D: Deserializer<'de>,
 {
     // Name should be SARASA_MONO or SARASA_MONO_BOLD
     let name = String::deserialize(deserializer)?;
+    let name_str = name.as_str();
 
-    let regular_string = String::from("SARASA_MONO");
-    let bold_string = String::from("SARASA_MONO_BOLD");
-
-    match name {
-        regular_string => Ok(SARASA_MONO),
-        bold_string => Ok(SARASA_MONO_BOLD),
-        _ => Err(serde::de::Error::invalid_value(Unexpected::Str(&name), &"SARASA_MONO OR SARASA_MONO_BOLD"))
+    match name_str {
+        "SARASA_MONO" => Ok(SARASA_MONO),
+        "SARASA_MONO_BOLD" => Ok(SARASA_MONO_BOLD),
+        _ => Err(serde::de::Error::invalid_value(
+            Unexpected::Str(name_str),
+            &"SARASA_MONO OR SARASA_MONO_BOLD",
+        )),
     }
 }
 
 pub(super) fn serialize_font<S>(font: &Font, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
+where
+    S: Serializer,
 {
     match font {
         &SARASA_MONO => serializer.serialize_str("SARASA_MONO"),

--- a/src/gui/styles/types/style_type.rs
+++ b/src/gui/styles/types/style_type.rs
@@ -52,7 +52,7 @@ impl StyleType {
         }
     }
 
-    pub fn get_palette_extension(self) -> PaletteExtension {
+    pub fn get_extension(self) -> PaletteExtension {
         match self {
             StyleType::Night => NIGHT_PALETTE_EXTENSION,
             StyleType::Day => DAY_PALETTE_EXTENSION,
@@ -63,7 +63,7 @@ impl StyleType {
     }
 
     pub fn get_font_weight(self) -> FontStyle {
-        if self.get_palette_extension().font.eq(&SARASA_MONO_BOLD) {
+        if self.get_extension().font.eq(&SARASA_MONO_BOLD) {
             FontStyle::Bold
         } else {
             FontStyle::Normal

--- a/src/gui/styles/types/style_type.rs
+++ b/src/gui/styles/types/style_type.rs
@@ -1,12 +1,16 @@
-use iced::{application, Color, Font};
+use iced::application;
 use iced::application::Appearance;
 use plotters::prelude::FontStyle;
 use serde::{Deserialize, Serialize};
 
-use crate::get_colors;
-use crate::gui::styles::style_constants::{DAY_STYLE, DEEP_SEA_STYLE, MON_AMOUR_STYLE, NIGHT_STYLE, SARASA_MONO, SARASA_MONO_BOLD};
+use crate::gui::styles::style_constants::{
+    DAY_PALETTE, DAY_PALETTE_EXTENSION, DEEP_SEA_PALETTE, DEEP_SEA_PALETTE_EXTENSION,
+    MON_AMOUR_PALETTE, MON_AMOUR_PALETTE_EXTENSION, NIGHT_PALETTE, NIGHT_PALETTE_EXTENSION,
+    SARASA_MONO_BOLD,
+};
 use crate::gui::styles::types::custom_palette::ExtraStyles;
 use crate::gui::styles::types::palette::Palette;
+use crate::gui::styles::types::palette_extension::PaletteExtension;
 
 /// Used to specify the kind of style of the application
 #[derive(Clone, Copy, Serialize, Deserialize, Debug, Hash, PartialEq)]
@@ -29,7 +33,7 @@ impl application::StyleSheet for StyleType {
     type Style = ();
 
     fn appearance(&self, _: &Self::Style) -> Appearance {
-        let colors = get_colors(*self);
+        let colors = self.get_palette();
         Appearance {
             background_color: colors.primary,
             text_color: colors.text_body,
@@ -38,137 +42,31 @@ impl application::StyleSheet for StyleType {
 }
 
 impl StyleType {
-    pub fn get_colors(self) -> Palette {
+    pub fn get_palette(self) -> Palette {
         match self {
-            StyleType::Night => NIGHT_STYLE,
-            StyleType::Day => DAY_STYLE,
-            StyleType::DeepSea => DEEP_SEA_STYLE,
-            StyleType::MonAmour => MON_AMOUR_STYLE,
+            StyleType::Night => NIGHT_PALETTE,
+            StyleType::Day => DAY_PALETTE,
+            StyleType::DeepSea => DEEP_SEA_PALETTE,
+            StyleType::MonAmour => MON_AMOUR_PALETTE,
             StyleType::Custom(style) => style.to_palette(),
         }
     }
 
-    pub fn is_nightly(self) -> bool {
-        let primary = get_colors(self).primary;
-        primary.r + primary.g + primary.b <= 1.5
-    }
-
-    pub fn is_text_body_dark(self) -> bool {
-        let text_body = get_colors(self).text_body;
-        text_body.r + text_body.g + text_body.b <= 1.5
-    }
-
-    pub fn is_text_headers_dark(self) -> bool {
-        let text_headers = get_colors(self).text_headers;
-        text_headers.r + text_headers.g + text_headers.b <= 1.5
-    }
-
-    pub fn get_font(self) -> Font {
-        if self.is_text_body_dark() {
-            SARASA_MONO_BOLD
-        } else {
-            SARASA_MONO
+    pub fn get_palette_extension(self) -> PaletteExtension {
+        match self {
+            StyleType::Night => NIGHT_PALETTE_EXTENSION,
+            StyleType::Day => DAY_PALETTE_EXTENSION,
+            StyleType::DeepSea => DEEP_SEA_PALETTE_EXTENSION,
+            StyleType::MonAmour => MON_AMOUR_PALETTE_EXTENSION,
+            StyleType::Custom(style) => style.to_palette_extension(),
         }
     }
 
     pub fn get_font_weight(self) -> FontStyle {
-        if self.is_text_body_dark() {
+        if self.get_palette_extension().font.eq(&SARASA_MONO_BOLD) {
             FontStyle::Bold
         } else {
             FontStyle::Normal
-        }
-    }
-
-    pub fn get_font_headers(self) -> Font {
-        if self.is_text_headers_dark() {
-            SARASA_MONO_BOLD
-        } else {
-            SARASA_MONO
-        }
-    }
-
-    pub fn get_alpha_chart_badge(self) -> f32 {
-        if self.is_nightly() {
-            0.15
-        } else {
-            0.75
-        }
-    }
-
-    pub fn get_alpha_round_borders(self) -> f32 {
-        match self {
-            StyleType::Night | StyleType::DeepSea => 0.35,
-            StyleType::Day => 0.45,
-            StyleType::MonAmour => 0.5,
-            StyleType::Custom(_) => {
-                if self.is_nightly() {
-                    0.3
-                } else {
-                    0.6
-                }
-            },
-        }
-    }
-
-    pub fn get_alpha_round_containers(self) -> f32 {
-        match self {
-            StyleType::Night | StyleType::MonAmour => 0.25,
-            StyleType::Day => 0.2,
-            StyleType::DeepSea => 0.15,
-            StyleType::Custom(_) => {
-                if self.is_nightly() {
-                    0.12
-                } else {
-                    0.24
-                }
-            },
-        }
-    }
-
-    pub fn get_buttons_color(self) -> Color {
-        match self {
-            StyleType::Night => Color {
-                r: 0.1,
-                g: 0.1,
-                b: 0.1,
-                a: 1.0,
-            },
-            StyleType::Day => Color {
-                r: 0.8,
-                g: 0.8,
-                b: 0.8,
-                a: 1.0,
-            },
-            StyleType::DeepSea => Color {
-                r: 48.0 / 255.0,
-                g: 71.0 / 255.0,
-                b: 94.0 / 255.0,
-                a: 1.0,
-            },
-            StyleType::MonAmour => Color {
-                r: 242.0 / 255.0,
-                g: 190.0 / 255.0,
-                b: 209.0 / 255.0,
-                a: 1.0,
-            },
-            StyleType::Custom(_) => {
-                let primary = get_colors(self).primary;
-                if self.is_nightly() {
-                    Color {
-                        r: f32::min(primary.r + 0.15, 1.0),
-                        g: f32::min(primary.g + 0.15, 1.0),
-                        b: f32::min(primary.b + 0.15, 1.0),
-                        a: 1.0
-                    }
-                } else {
-                    Color {
-                        r: f32::max(primary.r - 0.15, 0.0),
-                        g: f32::max(primary.g - 0.15, 0.0),
-                        b: f32::max(primary.b - 0.15, 0.0),
-                        a: 1.0
-                    }
-                }
-            }
         }
     }
 }

--- a/src/gui/styles/types/style_type.rs
+++ b/src/gui/styles/types/style_type.rs
@@ -1,9 +1,12 @@
-use iced::application;
+use iced::{application, Color, Font};
 use iced::application::Appearance;
+use plotters::prelude::FontStyle;
 use serde::{Deserialize, Serialize};
 
 use crate::get_colors;
+use crate::gui::styles::style_constants::{DAY_STYLE, DEEP_SEA_STYLE, MON_AMOUR_STYLE, NIGHT_STYLE, SARASA_MONO, SARASA_MONO_BOLD};
 use crate::gui::styles::types::custom_palette::ExtraStyles;
+use crate::gui::styles::types::palette::Palette;
 
 /// Used to specify the kind of style of the application
 #[derive(Clone, Copy, Serialize, Deserialize, Debug, Hash, PartialEq)]
@@ -35,11 +38,137 @@ impl application::StyleSheet for StyleType {
 }
 
 impl StyleType {
-    pub fn is_nightly(self) -> bool {
+    pub fn get_colors(self) -> Palette {
         match self {
-            StyleType::Night | StyleType::DeepSea => true,
-            StyleType::Day | StyleType::MonAmour => false,
-            StyleType::Custom(style) => style.is_nightly(),
+            StyleType::Night => NIGHT_STYLE,
+            StyleType::Day => DAY_STYLE,
+            StyleType::DeepSea => DEEP_SEA_STYLE,
+            StyleType::MonAmour => MON_AMOUR_STYLE,
+            StyleType::Custom(style) => style.to_palette(),
+        }
+    }
+
+    pub fn is_nightly(self) -> bool {
+        let primary = get_colors(self).primary;
+        primary.r + primary.g + primary.b <= 1.5
+    }
+
+    pub fn is_text_body_dark(self) -> bool {
+        let text_body = get_colors(self).text_body;
+        text_body.r + text_body.g + text_body.b <= 1.5
+    }
+
+    pub fn is_text_headers_dark(self) -> bool {
+        let text_headers = get_colors(self).text_headers;
+        text_headers.r + text_headers.g + text_headers.b <= 1.5
+    }
+
+    pub fn get_font(self) -> Font {
+        if self.is_text_body_dark() {
+            SARASA_MONO_BOLD
+        } else {
+            SARASA_MONO
+        }
+    }
+
+    pub fn get_font_weight(self) -> FontStyle {
+        if self.is_text_body_dark() {
+            FontStyle::Bold
+        } else {
+            FontStyle::Normal
+        }
+    }
+
+    pub fn get_font_headers(self) -> Font {
+        if self.is_text_headers_dark() {
+            SARASA_MONO_BOLD
+        } else {
+            SARASA_MONO
+        }
+    }
+
+    pub fn get_alpha_chart_badge(self) -> f32 {
+        if self.is_nightly() {
+            0.15
+        } else {
+            0.75
+        }
+    }
+
+    pub fn get_alpha_round_borders(self) -> f32 {
+        match self {
+            StyleType::Night | StyleType::DeepSea => 0.35,
+            StyleType::Day => 0.45,
+            StyleType::MonAmour => 0.5,
+            StyleType::Custom(_) => {
+                if self.is_nightly() {
+                    0.3
+                } else {
+                    0.6
+                }
+            },
+        }
+    }
+
+    pub fn get_alpha_round_containers(self) -> f32 {
+        match self {
+            StyleType::Night | StyleType::MonAmour => 0.25,
+            StyleType::Day => 0.2,
+            StyleType::DeepSea => 0.15,
+            StyleType::Custom(_) => {
+                if self.is_nightly() {
+                    0.12
+                } else {
+                    0.24
+                }
+            },
+        }
+    }
+
+    pub fn get_buttons_color(self) -> Color {
+        match self {
+            StyleType::Night => Color {
+                r: 0.1,
+                g: 0.1,
+                b: 0.1,
+                a: 1.0,
+            },
+            StyleType::Day => Color {
+                r: 0.8,
+                g: 0.8,
+                b: 0.8,
+                a: 1.0,
+            },
+            StyleType::DeepSea => Color {
+                r: 48.0 / 255.0,
+                g: 71.0 / 255.0,
+                b: 94.0 / 255.0,
+                a: 1.0,
+            },
+            StyleType::MonAmour => Color {
+                r: 242.0 / 255.0,
+                g: 190.0 / 255.0,
+                b: 209.0 / 255.0,
+                a: 1.0,
+            },
+            StyleType::Custom(_) => {
+                let primary = get_colors(self).primary;
+                if self.is_nightly() {
+                    Color {
+                        r: f32::min(primary.r + 0.15, 1.0),
+                        g: f32::min(primary.g + 0.15, 1.0),
+                        b: f32::min(primary.b + 0.15, 1.0),
+                        a: 1.0
+                    }
+                } else {
+                    Color {
+                        r: f32::max(primary.r - 0.15, 0.0),
+                        g: f32::max(primary.g - 0.15, 0.0),
+                        b: f32::max(primary.b - 0.15, 0.0),
+                        a: 1.0
+                    }
+                }
+            }
         }
     }
 }

--- a/src/gui/styles/types/style_type.rs
+++ b/src/gui/styles/types/style_type.rs
@@ -70,3 +70,148 @@ impl StyleType {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use iced::{color, Color};
+    use serde_test::{assert_tokens, Token};
+
+    use crate::gui::styles::types::custom_palette::{CustomPalette, ExtraStyles};
+    use crate::gui::styles::types::palette::Palette;
+    use crate::StyleType;
+
+    // test if deserializing and serializing a StyleType works n.1
+    // simple case: one of the default themes
+    #[test]
+    fn test_working_style_type_round_trip_1() {
+        let style = StyleType::Night;
+        assert_tokens(
+            &style,
+            &[
+                Token::Struct {
+                    name: "StyleType",
+                    len: 1,
+                },
+                Token::Str("style"),
+                Token::UnitVariant {
+                    name: "StyleType",
+                    variant: "Night",
+                },
+                Token::StructEnd,
+            ],
+        );
+    }
+
+    // test if deserializing and serializing a StyleType works n.2
+    // medium case: one predefined additional themes
+    #[test]
+    fn test_working_style_type_round_trip_2() {
+        let style = StyleType::Custom(ExtraStyles::DraculaLight);
+        assert_tokens(
+            &style,
+            &[
+                Token::Struct {
+                    name: "StyleType",
+                    len: 2,
+                },
+                Token::Str("style"),
+                Token::UnitVariant {
+                    name: "StyleType",
+                    variant: "Custom",
+                },
+                Token::Str("name"),
+                Token::Struct {
+                    name: "ExtraStyles",
+                    len: 1,
+                },
+                Token::Str("custom"),
+                Token::UnitVariant {
+                    name: "ExtraStyles",
+                    variant: "DraculaLight",
+                },
+                Token::StructEnd,
+                Token::StructEnd,
+            ],
+        );
+    }
+
+    // test if deserializing and serializing a StyleType works n.3
+    // complex case: a custom theme from a TOML file
+    #[test]
+    fn test_working_style_type_round_trip_3() {
+        let palette = Palette {
+            primary: color!(0x22, 0x22, 0x22),
+            secondary: color!(0xa6, 0xd1, 0x89),
+            outgoing: color!(0xf4, 0xb8, 0xe4),
+            starred: color!(0xe5, 0xc8, 0x90, 0.6666667),
+            text_headers: color!(0x23, 0x26, 0x34),
+            text_body: color!(0xc6, 0xd0, 0xf5),
+        };
+        let mut extension = palette.generate_palette_extension();
+        // reassigned only because of floating precision errors otherwise
+        extension.buttons_color = Color {
+            r: 0.28235295,
+            g: 0.28235295,
+            b: 0.28235295,
+            a: 1.0,
+        };
+        let custom_palette = CustomPalette { palette, extension };
+        let style = StyleType::Custom(ExtraStyles::CustomToml(custom_palette));
+
+        assert_tokens(
+            &style,
+            &[
+                Token::Struct {
+                    name: "StyleType",
+                    len: 2,
+                },
+                Token::Str("style"),
+                Token::UnitVariant {
+                    name: "StyleType",
+                    variant: "Custom",
+                },
+                Token::Str("name"),
+                Token::Struct {
+                    name: "ExtraStyles",
+                    len: 2,
+                },
+                Token::Str("custom"),
+                Token::UnitVariant {
+                    name: "ExtraStyles",
+                    variant: "CustomToml",
+                },
+                Token::Str("attributes"),
+                Token::Map { len: None },
+                Token::Str("primary"),
+                Token::Str("#222222"),
+                Token::Str("secondary"),
+                Token::Str("#a6d189"),
+                Token::Str("outgoing"),
+                Token::Str("#f4b8e4"),
+                Token::Str("starred"),
+                Token::Str("#e5c890aa"),
+                Token::Str("text_headers"),
+                Token::Str("#232634"),
+                Token::Str("text_body"),
+                Token::Str("#c6d0f5"),
+                Token::Str("is_nightly"),
+                Token::Bool(true),
+                Token::Str("font"),
+                Token::Str("SARASA_MONO"),
+                Token::Str("font_headers"),
+                Token::Str("SARASA_MONO_BOLD"),
+                Token::Str("alpha_chart_badge"),
+                Token::F32(0.15),
+                Token::Str("alpha_round_borders"),
+                Token::F32(0.3),
+                Token::Str("alpha_round_containers"),
+                Token::F32(0.12),
+                Token::Str("buttons_color"),
+                Token::Str("#484848"),
+                Token::MapEnd,
+                Token::StructEnd,
+                Token::StructEnd,
+            ],
+        );
+    }
+}

--- a/src/gui/styles/types/style_type.rs
+++ b/src/gui/styles/types/style_type.rs
@@ -48,7 +48,7 @@ impl StyleType {
             StyleType::Day => DAY_PALETTE,
             StyleType::DeepSea => DEEP_SEA_PALETTE,
             StyleType::MonAmour => MON_AMOUR_PALETTE,
-            StyleType::Custom(style) => style.to_palette(),
+            StyleType::Custom(style) => style.get_palette(),
         }
     }
 
@@ -58,7 +58,7 @@ impl StyleType {
             StyleType::Day => DAY_PALETTE_EXTENSION,
             StyleType::DeepSea => DEEP_SEA_PALETTE_EXTENSION,
             StyleType::MonAmour => MON_AMOUR_PALETTE_EXTENSION,
-            StyleType::Custom(style) => style.to_palette_extension(),
+            StyleType::Custom(style) => style.get_extension(),
         }
     }
 

--- a/src/gui/types/sniffer.rs
+++ b/src/gui/types/sniffer.rs
@@ -174,7 +174,9 @@ impl Sniffer {
             Message::LoadStyle(path) => {
                 self.settings.style_path = path.clone();
                 if let Ok(palette) = Palette::from_file(path) {
-                    self.settings.style = StyleType::Custom(ExtraStyles::CustomToml(CustomPalette::from_palette(palette)));
+                    self.settings.style = StyleType::Custom(ExtraStyles::CustomToml(
+                        CustomPalette::from_palette(palette),
+                    ));
                     self.traffic_chart.change_style(self.settings.style);
                 }
             }

--- a/src/gui/types/sniffer.rs
+++ b/src/gui/types/sniffer.rs
@@ -13,7 +13,7 @@ use crate::configs::types::config_window::ConfigWindow;
 use crate::gui::components::types::my_modal::MyModal;
 use crate::gui::pages::types::running_page::RunningPage;
 use crate::gui::pages::types::settings_page::SettingsPage;
-use crate::gui::styles::types::custom_palette::{CustomPalette, ExtraStyles};
+use crate::gui::styles::types::custom_palette::{ExtraStyles};
 use crate::gui::types::message::Message;
 use crate::gui::types::timing_events::TimingEvents;
 use crate::mmdb::asn::ASN_MMDB;
@@ -36,6 +36,7 @@ use crate::utils::types::web_page::WebPage;
 use crate::{
     ConfigDevice, ConfigSettings, Configs, InfoTraffic, RunTimeData, StyleType, TrafficChart,
 };
+use crate::gui::styles::types::palette::Palette;
 
 /// Struct on which the gui is based
 ///
@@ -172,7 +173,7 @@ impl Sniffer {
             }
             Message::LoadStyle(path) => {
                 self.settings.style_path = path.clone();
-                if let Ok(palette) = CustomPalette::from_file(path) {
+                if let Ok(palette) = Palette::from_file(path) {
                     self.settings.style = StyleType::Custom(ExtraStyles::CustomToml(palette));
                     self.traffic_chart.change_style(self.settings.style);
                 }

--- a/src/gui/types/sniffer.rs
+++ b/src/gui/types/sniffer.rs
@@ -174,7 +174,10 @@ impl Sniffer {
             Message::LoadStyle(path) => {
                 self.settings.style_path = path.clone();
                 if let Ok(palette) = Palette::from_file(path) {
-                    self.settings.style = StyleType::Custom(ExtraStyles::CustomToml(palette, palette.generate_palette_extension()));
+                    self.settings.style = StyleType::Custom(ExtraStyles::CustomToml(
+                        palette,
+                        palette.generate_palette_extension(),
+                    ));
                     self.traffic_chart.change_style(self.settings.style);
                 }
             }

--- a/src/gui/types/sniffer.rs
+++ b/src/gui/types/sniffer.rs
@@ -13,7 +13,7 @@ use crate::configs::types::config_window::ConfigWindow;
 use crate::gui::components::types::my_modal::MyModal;
 use crate::gui::pages::types::running_page::RunningPage;
 use crate::gui::pages::types::settings_page::SettingsPage;
-use crate::gui::styles::types::custom_palette::ExtraStyles;
+use crate::gui::styles::types::custom_palette::{CustomPalette, ExtraStyles};
 use crate::gui::styles::types::palette::Palette;
 use crate::gui::types::message::Message;
 use crate::gui::types::timing_events::TimingEvents;
@@ -174,10 +174,7 @@ impl Sniffer {
             Message::LoadStyle(path) => {
                 self.settings.style_path = path.clone();
                 if let Ok(palette) = Palette::from_file(path) {
-                    self.settings.style = StyleType::Custom(ExtraStyles::CustomToml(
-                        palette,
-                        palette.generate_palette_extension(),
-                    ));
+                    self.settings.style = StyleType::Custom(ExtraStyles::CustomToml(CustomPalette::from_palette(palette)));
                     self.traffic_chart.change_style(self.settings.style);
                 }
             }

--- a/src/gui/types/sniffer.rs
+++ b/src/gui/types/sniffer.rs
@@ -13,7 +13,8 @@ use crate::configs::types::config_window::ConfigWindow;
 use crate::gui::components::types::my_modal::MyModal;
 use crate::gui::pages::types::running_page::RunningPage;
 use crate::gui::pages::types::settings_page::SettingsPage;
-use crate::gui::styles::types::custom_palette::{ExtraStyles};
+use crate::gui::styles::types::custom_palette::ExtraStyles;
+use crate::gui::styles::types::palette::Palette;
 use crate::gui::types::message::Message;
 use crate::gui::types::timing_events::TimingEvents;
 use crate::mmdb::asn::ASN_MMDB;
@@ -36,7 +37,6 @@ use crate::utils::types::web_page::WebPage;
 use crate::{
     ConfigDevice, ConfigSettings, Configs, InfoTraffic, RunTimeData, StyleType, TrafficChart,
 };
-use crate::gui::styles::types::palette::Palette;
 
 /// Struct on which the gui is based
 ///
@@ -174,7 +174,7 @@ impl Sniffer {
             Message::LoadStyle(path) => {
                 self.settings.style_path = path.clone();
                 if let Ok(palette) = Palette::from_file(path) {
-                    self.settings.style = StyleType::Custom(ExtraStyles::CustomToml(palette));
+                    self.settings.style = StyleType::Custom(ExtraStyles::CustomToml(palette, palette.generate_palette_extension()));
                     self.traffic_chart.change_style(self.settings.style);
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,6 @@ use configs::types::config_device::ConfigDevice;
 use configs::types::config_settings::ConfigSettings;
 use gui::pages::types::running_page::RunningPage;
 use gui::styles::style_constants::FONT_SIZE_BODY;
-use gui::styles::types::palette::get_colors;
 use gui::styles::types::style_type::StyleType;
 use gui::types::runtime_data::RunTimeData;
 use gui::types::sniffer::Sniffer;

--- a/src/notifications/types/sound.rs
+++ b/src/notifications/types/sound.rs
@@ -1,9 +1,9 @@
-use iced::alignment::{Horizontal, Vertical};
-use iced::widget::Text;
-use iced::{Font, Length, Renderer};
 use std::fmt;
 use std::thread;
 
+use iced::alignment::{Horizontal, Vertical};
+use iced::widget::Text;
+use iced::{Font, Length, Renderer};
 use rodio::{Decoder, OutputStream, Sink};
 use serde::{Deserialize, Serialize};
 

--- a/src/report/get_report_entries.rs
+++ b/src/report/get_report_entries.rs
@@ -122,7 +122,7 @@ pub fn get_searched_entries(sniffer: &Sniffer) -> (Vec<ReportEntry>, usize) {
                     host_info.is_local,
                     host_info.traffic_type,
                     language,
-                    get_font(style),
+                    style.get_palette_extension().font,
                 );
                 ReportEntry {
                     key: key_val.0.clone(),

--- a/src/report/get_report_entries.rs
+++ b/src/report/get_report_entries.rs
@@ -122,7 +122,7 @@ pub fn get_searched_entries(sniffer: &Sniffer) -> (Vec<ReportEntry>, usize) {
                     host_info.is_local,
                     host_info.traffic_type,
                     language,
-                    style.get_palette_extension().font,
+                    style.get_extension().font,
                 );
                 ReportEntry {
                     key: key_val.0.clone(),

--- a/src/report/get_report_entries.rs
+++ b/src/report/get_report_entries.rs
@@ -3,7 +3,6 @@ use std::sync::{Arc, Mutex};
 
 use crate::countries::country_utils::get_flag_tooltip;
 use crate::countries::flags_pictures::FLAGS_WIDTH_SMALL;
-use crate::gui::styles::style_constants::get_font;
 use crate::networking::manage_packets::get_address_to_lookup;
 use crate::networking::types::address_port_pair::AddressPortPair;
 use crate::networking::types::data_info::DataInfo;


### PR DESCRIPTION
This PR simplify the user's activity when defining custom color palettes from files.

Before this PR, a user had to specify the following parameters:
- primary
- secondary
- outgoing
- text_headers
- text_body
- starred
- buttons
- round_borders_alpha
- round_containers_alpha
- chart_badge_alpha
- is_nightly

Now, users can simply define a palette specifying the following colors:
- primary
- secondary
- outgoing
- text_headers
- text_body
- starred

...and Sniffnet will automatically infer if the palette is dark or light, determining as a consequence the color of buttons and opacity values.

To achieve this, a struct `PaletteExtension` has been defined; it is computed only once per theme (thanks to the use of `once_cell`) starting from a defined `Palette`.
The struct `PaletteExtension` doesn't only include the parameters that were removed from the user definition of the color scheme, but also two more fields that host the fonts of body text and headers text.

Moreover, the style of the 8 additional themes has been updated to follow the same derivation rules of the styles defined via TOML.