### PR TITLE
Graceful termination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ All Sniffnet releases with the relative changes are documented in this file.
 - Added Uzbek translation 🇺🇿 ([#385](https://github.com/GyulyVGC/sniffnet/pull/385))
 - Window size and position are now remembered, so that Sniffnet can reopen with the same window properties
 - Users can now provide custom paths for MMDB files to allow using the commercial versions of the country and ASN databases (fixes [#243](https://github.com/GyulyVGC/sniffnet/issues/243))
-- The app's configurations are now stored only on application close, instead of needlessly store them each time the settings popup is closed
+- Added new command line option `--restore-default` to restore the default configurations of the app (settings, window properties, and device selected at startup)
+- The app's configurations are now stored only on application close, instead of needlessly store them each time the settings popup is closed ([#420](https://github.com/GyulyVGC/sniffnet/pull/420))
 - The textual output report is not generated anymore
 - Settings "Language" tab has been removed. Language selection and other options are now included in a new settings tab "General" ([#365](https://github.com/GyulyVGC/sniffnet/pull/365))
 - Updated Portuguese translation to v1.2 ([#398](https://github.com/GyulyVGC/sniffnet/pull/398))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,6 +598,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "ctrlc"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b467862cc8610ca6fc9a1532d7777cee0804e678ab45410897b9396495994a0b"
+dependencies = [
+ "nix 0.27.1",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "d3d12"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2005,6 +2015,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3154,6 +3175,7 @@ version = "1.2.2"
 dependencies = [
  "chrono",
  "confy",
+ "ctrlc",
  "dns-lookup",
  "etherparse",
  "iced",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,9 +35,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -803,9 +803,9 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "fdeflate"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7caf4086251adeba90011a7ff9bd1f6d7f7595be0871867daa4dbb0fcf2ca932"
+checksum = "209098dd6dfc4445aa6111f0e98653ac323eaa4dfd212c9ca3931bf9955c31bd"
 dependencies = [
  "simd-adler32",
 ]
@@ -1281,9 +1281,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.58"
+version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20"
+checksum = "b6a67363e2aa4443928ce15e57ebae94fd8949958fd1223c4cfc0cd473ad7539"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1821,9 +1821,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "memmap2"
@@ -2714,9 +2714,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "relative-path"
-version = "1.9.0"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c707298afce11da2efef2f600116fa93ffa7a032b5d7b628aa17711ec81383ca"
+checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
 
 [[package]]
 name = "renderdoc-sys"
@@ -2970,11 +2970,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3435,15 +3435,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.8.1"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
+checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
 dependencies = [
  "cfg-if",
  "fastrand 2.0.1",
  "redox_syscall 0.4.1",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4307,11 +4307,11 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.51.1"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.48.5",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -4592,9 +4592,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.5.30"
+version = "0.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b5c3db89721d50d0e2a673f5043fc4722f76dcc352d7b1ab8b8288bed4ed2c5"
+checksum = "97a4882e6b134d6c28953a387571f1acdd3496830d5e36c5e3a1075580ea641c"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,6 +619,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.3",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.9",
+]
+
+[[package]]
 name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3090,6 +3103,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
+dependencies = [
+ "dashmap",
+ "lazy_static",
+ "parking_lot 0.12.1",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.43",
+]
+
+[[package]]
 name = "shlex"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3189,6 +3225,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_test",
+ "serial_test",
  "toml 0.8.8",
  "winres",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ reqwest = { version = "0.11.23", features = ["json", "blocking"] }
 [dev-dependencies]
 serde_test = "1.0.176"
 rstest = "0.18.2"
+serial_test = { version = "2.0.0", default_features = false }
 
 #───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ rodio = { version = "0.17.3", default_features = false, features = ["mp3"] }
 dns-lookup = "2.0.4"
 toml = "0.8.8"
 once_cell = "1.19.0"
+ctrlc = "3.4.2"
 
 [target.'cfg(not(target_arch = "powerpc64"))'.dependencies]
 reqwest = { version = "0.11.23", default-features = false, features = ["json", "blocking", "rustls-tls"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ rodio = { version = "0.17.3", default_features = false, features = ["mp3"] }
 dns-lookup = "2.0.4"
 toml = "0.8.8"
 once_cell = "1.19.0"
-ctrlc = "3.4.2"
+ctrlc = { version = "3.4.2", features = ["termination"] }
 
 [target.'cfg(not(target_arch = "powerpc64"))'.dependencies]
 reqwest = { version = "0.11.23", default-features = false, features = ["json", "blocking", "rustls-tls"] }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,4 +1,5 @@
 use crate::utils::formatted_strings::APP_VERSION;
+use crate::{Configs, SNIFFNET_LOWERCASE};
 
 /// Parse CLI arguments, and exit if `--help`, `--version`, or an
 /// unknown argument was supplied
@@ -8,6 +9,7 @@ pub fn parse_cli_args() {
         match arg.as_str() {
             "--help" | "-h" => print_help(),
             "--version" | "-v" => print_version(),
+            "--restore-default" => restore_default(),
             _ => {
                 unknown_argument(&arg);
                 std::process::exit(1);
@@ -20,21 +22,88 @@ pub fn parse_cli_args() {
 fn print_help() {
     println!(
         "Application to comfortably monitor your Internet traffic\n\
-        Usage: sniffnet [OPTIONS]\n\
+        Usage: {SNIFFNET_LOWERCASE} [OPTIONS]\n\
         Options:\n\
-        \t-h, --help      Print help\n\
-        \t-v, --version   Print version info\n\
+        \t-h, --help            Print help\n\
+        \t--restore-default     Restore default settings\n\
+        \t-v, --version         Print version info\n\
         (Run without options to start the app)"
     );
 }
 
 fn print_version() {
-    println!("sniffnet {APP_VERSION}");
+    println!("{SNIFFNET_LOWERCASE} {APP_VERSION}");
+}
+
+fn restore_default() {
+    Configs::default().store();
+    println!("Default settings have been restored");
 }
 
 fn unknown_argument(arg: &str) {
     eprintln!(
-        "sniffnet: unknown option '{arg}'\n\
-        For more information, try 'sniffnet --help'"
+        "{SNIFFNET_LOWERCASE}: unknown option '{arg}'\n\
+        For more information, try '{SNIFFNET_LOWERCASE} --help'"
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gui::styles::types::custom_palette::ExtraStyles;
+    use crate::gui::styles::types::gradient_type::GradientType;
+    use crate::notifications::types::notifications::Notifications;
+    use crate::{ConfigDevice, ConfigSettings, ConfigWindow, Language, Sniffer, StyleType};
+    use serial_test::serial;
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    #[serial]
+    fn test_restore_default_configs() {
+        // initial configs stored are the default ones
+        assert_eq!(Configs::load(), Configs::default());
+        let modified_configs = Configs {
+            settings: ConfigSettings {
+                color_gradient: GradientType::Wild,
+                language: Language::ZH,
+                scale_factor: 0.65,
+                mmdb_country: "countrymmdb".to_string(),
+                mmdb_asn: "asnmmdb".to_string(),
+                style_path: format!(
+                    "{}/resources/themes/catppuccin.toml",
+                    env!("CARGO_MANIFEST_DIR")
+                ),
+                notifications: Notifications {
+                    volume: 100,
+                    packets_notification: Default::default(),
+                    bytes_notification: Default::default(),
+                    favorite_notification: Default::default(),
+                },
+                style: StyleType::Custom(ExtraStyles::DraculaDark),
+            },
+            device: ConfigDevice {
+                device_name: "hey-hey".to_string(),
+            },
+            window: ConfigWindow {
+                position: (440, 99),
+                size: (452, 870),
+            },
+        };
+        // we want to be sure that modified config is different from defaults
+        assert_ne!(Configs::default(), modified_configs);
+        //store modified configs
+        modified_configs.clone().store();
+        // assert they've been stored
+        assert_eq!(Configs::load(), modified_configs);
+        // restore defaults
+        restore_default();
+        // assert that defaults are stored
+        assert_eq!(Configs::load(), Configs::default());
+
+        // only needed because it will delete config files via its Drop implementation
+        Sniffer::new(
+            &Arc::new(Mutex::new(Configs::default())),
+            Arc::new(Mutex::new(Some(true))),
+        );
+    }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -49,13 +49,16 @@ fn unknown_argument(arg: &str) {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    use serial_test::serial;
+
     use crate::gui::styles::types::custom_palette::ExtraStyles;
     use crate::gui::styles::types::gradient_type::GradientType;
     use crate::notifications::types::notifications::Notifications;
     use crate::{ConfigDevice, ConfigSettings, ConfigWindow, Language, Sniffer, StyleType};
-    use serial_test::serial;
-    use std::sync::{Arc, Mutex};
+
+    use super::*;
 
     #[test]
     #[serial]

--- a/src/configs/types/config_device.rs
+++ b/src/configs/types/config_device.rs
@@ -3,7 +3,7 @@
 
 use std::sync::{Arc, Mutex};
 
-use pcap::Device;
+use pcap::{Device, DeviceFlags};
 use serde::{Deserialize, Serialize};
 
 use crate::networking::types::my_device::MyDevice;
@@ -16,12 +16,21 @@ pub struct ConfigDevice {
 impl Default for ConfigDevice {
     fn default() -> Self {
         Self {
-            device_name: Device::lookup().unwrap().unwrap().name,
+            device_name: Device::lookup()
+                .unwrap_or(None)
+                .unwrap_or(Device {
+                    name: String::new(),
+                    desc: None,
+                    addresses: vec![],
+                    flags: DeviceFlags::empty(),
+                })
+                .name,
         }
     }
 }
 
 impl ConfigDevice {
+    #[cfg(not(test))]
     pub fn load() -> Self {
         if let Ok(device) = confy::load::<ConfigDevice>("sniffnet", "device") {
             device
@@ -31,12 +40,13 @@ impl ConfigDevice {
         }
     }
 
+    #[cfg(not(test))]
     pub fn store(self) {
         confy::store("sniffnet", "device", self).unwrap_or(());
     }
 
     pub fn to_my_device(&self) -> MyDevice {
-        for device in Device::list().unwrap() {
+        for device in Device::list().unwrap_or_default() {
             if device.name.eq(&self.device_name) {
                 return MyDevice {
                     name: device.name,
@@ -45,11 +55,36 @@ impl ConfigDevice {
                 };
             }
         }
-        let standard_device = Device::lookup().unwrap().unwrap();
+        let standard_device = Device::lookup().unwrap_or(None).unwrap_or(Device {
+            name: String::new(),
+            desc: None,
+            addresses: vec![],
+            flags: DeviceFlags::empty(),
+        });
         MyDevice {
             name: standard_device.name,
             desc: standard_device.desc,
             addresses: Arc::new(Mutex::new(standard_device.addresses)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ConfigDevice;
+
+    impl ConfigDevice {
+        pub fn test_path() -> String {
+            format!("{}/{}.toml", env!("CARGO_MANIFEST_DIR"), "device")
+        }
+
+        pub fn load() -> Self {
+            confy::load_path::<ConfigDevice>(ConfigDevice::test_path())
+                .unwrap_or(ConfigDevice::default())
+        }
+
+        pub fn store(self) {
+            confy::store_path(ConfigDevice::test_path(), self).unwrap_or(());
         }
     }
 }

--- a/src/configs/types/config_device.rs
+++ b/src/configs/types/config_device.rs
@@ -8,7 +8,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::networking::types::my_device::MyDevice;
 
-#[derive(Serialize, Deserialize, Clone)]
+#[cfg(not(test))]
+use crate::SNIFFNET_LOWERCASE;
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
 pub struct ConfigDevice {
     pub device_name: String,
 }
@@ -30,19 +33,22 @@ impl Default for ConfigDevice {
 }
 
 impl ConfigDevice {
+    const FILE_NAME: &'static str = "device";
+
     #[cfg(not(test))]
     pub fn load() -> Self {
-        if let Ok(device) = confy::load::<ConfigDevice>("sniffnet", "device") {
+        if let Ok(device) = confy::load::<ConfigDevice>(SNIFFNET_LOWERCASE, Self::FILE_NAME) {
             device
         } else {
-            confy::store("sniffnet", "device", ConfigDevice::default()).unwrap_or(());
+            confy::store(SNIFFNET_LOWERCASE, Self::FILE_NAME, ConfigDevice::default())
+                .unwrap_or(());
             ConfigDevice::default()
         }
     }
 
     #[cfg(not(test))]
     pub fn store(self) {
-        confy::store("sniffnet", "device", self).unwrap_or(());
+        confy::store(SNIFFNET_LOWERCASE, Self::FILE_NAME, self).unwrap_or(());
     }
 
     pub fn to_my_device(&self) -> MyDevice {
@@ -75,7 +81,7 @@ mod tests {
 
     impl ConfigDevice {
         pub fn test_path() -> String {
-            format!("{}/{}.toml", env!("CARGO_MANIFEST_DIR"), "device")
+            format!("{}/{}.toml", env!("CARGO_MANIFEST_DIR"), Self::FILE_NAME)
         }
 
         pub fn load() -> Self {

--- a/src/configs/types/config_device.rs
+++ b/src/configs/types/config_device.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::networking::types::my_device::MyDevice;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct ConfigDevice {
     pub device_name: String,
 }

--- a/src/configs/types/config_device.rs
+++ b/src/configs/types/config_device.rs
@@ -7,7 +7,6 @@ use pcap::{Device, DeviceFlags};
 use serde::{Deserialize, Serialize};
 
 use crate::networking::types::my_device::MyDevice;
-
 #[cfg(not(test))]
 use crate::SNIFFNET_LOWERCASE;
 

--- a/src/configs/types/config_settings.rs
+++ b/src/configs/types/config_settings.rs
@@ -7,7 +7,7 @@ use crate::gui::styles::types::gradient_type::GradientType;
 use crate::notifications::types::notifications::Notifications;
 use crate::{Language, StyleType};
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
 pub struct ConfigSettings {
     pub color_gradient: GradientType,
     pub language: Language,
@@ -21,6 +21,7 @@ pub struct ConfigSettings {
 }
 
 impl ConfigSettings {
+    #[cfg(not(test))]
     pub fn load() -> Self {
         if let Ok(settings) = confy::load::<ConfigSettings>("sniffnet", "settings") {
             settings
@@ -30,6 +31,7 @@ impl ConfigSettings {
         }
     }
 
+    #[cfg(not(test))]
     pub fn store(self) {
         confy::store("sniffnet", "settings", self).unwrap_or(());
     }
@@ -46,6 +48,26 @@ impl Default for ConfigSettings {
             style_path: String::new(),
             notifications: Notifications::default(),
             style: StyleType::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ConfigSettings;
+
+    impl ConfigSettings {
+        pub fn test_path() -> String {
+            format!("{}/{}.toml", env!("CARGO_MANIFEST_DIR"), "settings")
+        }
+
+        pub fn load() -> Self {
+            confy::load_path::<ConfigSettings>(ConfigSettings::test_path())
+                .unwrap_or(ConfigSettings::default())
+        }
+
+        pub fn store(self) {
+            confy::store_path(ConfigSettings::test_path(), self).unwrap_or(());
         }
     }
 }

--- a/src/configs/types/config_settings.rs
+++ b/src/configs/types/config_settings.rs
@@ -5,10 +5,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::gui::styles::types::gradient_type::GradientType;
 use crate::notifications::types::notifications::Notifications;
-use crate::{Language, StyleType};
-
 #[cfg(not(test))]
 use crate::SNIFFNET_LOWERCASE;
+use crate::{Language, StyleType};
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
 pub struct ConfigSettings {

--- a/src/configs/types/config_settings.rs
+++ b/src/configs/types/config_settings.rs
@@ -7,6 +7,9 @@ use crate::gui::styles::types::gradient_type::GradientType;
 use crate::notifications::types::notifications::Notifications;
 use crate::{Language, StyleType};
 
+#[cfg(not(test))]
+use crate::SNIFFNET_LOWERCASE;
+
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
 pub struct ConfigSettings {
     pub color_gradient: GradientType,
@@ -21,19 +24,26 @@ pub struct ConfigSettings {
 }
 
 impl ConfigSettings {
+    const FILE_NAME: &'static str = "settings";
+
     #[cfg(not(test))]
     pub fn load() -> Self {
-        if let Ok(settings) = confy::load::<ConfigSettings>("sniffnet", "settings") {
+        if let Ok(settings) = confy::load::<ConfigSettings>(SNIFFNET_LOWERCASE, Self::FILE_NAME) {
             settings
         } else {
-            confy::store("sniffnet", "settings", ConfigSettings::default()).unwrap_or(());
+            confy::store(
+                SNIFFNET_LOWERCASE,
+                Self::FILE_NAME,
+                ConfigSettings::default(),
+            )
+            .unwrap_or(());
             ConfigSettings::default()
         }
     }
 
     #[cfg(not(test))]
     pub fn store(self) {
-        confy::store("sniffnet", "settings", self).unwrap_or(());
+        confy::store(SNIFFNET_LOWERCASE, Self::FILE_NAME, self).unwrap_or(());
     }
 }
 
@@ -58,7 +68,7 @@ mod tests {
 
     impl ConfigSettings {
         pub fn test_path() -> String {
-            format!("{}/{}.toml", env!("CARGO_MANIFEST_DIR"), "settings")
+            format!("{}/{}.toml", env!("CARGO_MANIFEST_DIR"), Self::FILE_NAME)
         }
 
         pub fn load() -> Self {

--- a/src/configs/types/config_window.rs
+++ b/src/configs/types/config_window.rs
@@ -1,13 +1,14 @@
 use iced::window::Position;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Copy, Clone)]
+#[derive(Serialize, Deserialize, Copy, Clone, PartialEq, Debug)]
 pub struct ConfigWindow {
     pub position: (i32, i32),
     pub size: (u32, u32),
 }
 
 impl ConfigWindow {
+    #[cfg(not(test))]
     pub fn load() -> Self {
         if let Ok(window) = confy::load::<ConfigWindow>("sniffnet", "window") {
             window
@@ -17,6 +18,7 @@ impl ConfigWindow {
         }
     }
 
+    #[cfg(not(test))]
     pub fn store(self) {
         confy::store("sniffnet", "window", self).unwrap_or(());
     }
@@ -38,5 +40,25 @@ pub trait ToPosition {
 impl ToPosition for (i32, i32) {
     fn to_position(self) -> Position {
         Position::Specific(self.0, self.1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ConfigWindow;
+
+    impl ConfigWindow {
+        pub fn test_path() -> String {
+            format!("{}/{}.toml", env!("CARGO_MANIFEST_DIR"), "window")
+        }
+
+        pub fn load() -> Self {
+            confy::load_path::<ConfigWindow>(ConfigWindow::test_path())
+                .unwrap_or(ConfigWindow::default())
+        }
+
+        pub fn store(self) {
+            confy::store_path(ConfigWindow::test_path(), self).unwrap_or(());
+        }
     }
 }

--- a/src/configs/types/config_window.rs
+++ b/src/configs/types/config_window.rs
@@ -1,6 +1,9 @@
 use iced::window::Position;
 use serde::{Deserialize, Serialize};
 
+#[cfg(not(test))]
+use crate::SNIFFNET_LOWERCASE;
+
 #[derive(Serialize, Deserialize, Copy, Clone, PartialEq, Debug)]
 pub struct ConfigWindow {
     pub position: (i32, i32),
@@ -8,19 +11,21 @@ pub struct ConfigWindow {
 }
 
 impl ConfigWindow {
+    const FILE_NAME: &'static str = "window";
     #[cfg(not(test))]
     pub fn load() -> Self {
-        if let Ok(window) = confy::load::<ConfigWindow>("sniffnet", "window") {
+        if let Ok(window) = confy::load::<ConfigWindow>(SNIFFNET_LOWERCASE, Self::FILE_NAME) {
             window
         } else {
-            confy::store("sniffnet", "window", ConfigWindow::default()).unwrap_or(());
+            confy::store(SNIFFNET_LOWERCASE, Self::FILE_NAME, ConfigWindow::default())
+                .unwrap_or(());
             ConfigWindow::default()
         }
     }
 
     #[cfg(not(test))]
     pub fn store(self) {
-        confy::store("sniffnet", "window", self).unwrap_or(());
+        confy::store(SNIFFNET_LOWERCASE, Self::FILE_NAME, self).unwrap_or(());
     }
 }
 
@@ -49,7 +54,7 @@ mod tests {
 
     impl ConfigWindow {
         pub fn test_path() -> String {
-            format!("{}/{}.toml", env!("CARGO_MANIFEST_DIR"), "window")
+            format!("{}/{}.toml", env!("CARGO_MANIFEST_DIR"), Self::FILE_NAME)
         }
 
         pub fn load() -> Self {

--- a/src/configs/types/configs.rs
+++ b/src/configs/types/configs.rs
@@ -1,6 +1,6 @@
 use crate::{ConfigDevice, ConfigSettings, ConfigWindow};
 
-#[derive(Default, Clone)]
+#[derive(Default, Clone, PartialEq, Debug)]
 pub struct Configs {
     pub settings: ConfigSettings,
     pub device: ConfigDevice,

--- a/src/configs/types/configs.rs
+++ b/src/configs/types/configs.rs
@@ -1,6 +1,6 @@
 use crate::{ConfigDevice, ConfigSettings, ConfigWindow};
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Configs {
     pub settings: ConfigSettings,
     pub device: ConfigDevice,

--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -59,9 +59,10 @@ impl Application for Sniffer {
     }
 
     fn view(&self) -> Element<Message, Renderer<StyleType>> {
-        let style = self.settings.style;
-        let language = self.settings.language;
-        let color_gradient = self.settings.color_gradient;
+        let settings = &self.configs.lock().unwrap().settings;
+        let style = settings.style;
+        let language = settings.language;
+        let color_gradient = settings.color_gradient;
         let font = style.get_extension().font;
         let font_headers = style.get_extension().font_headers;
 
@@ -175,10 +176,10 @@ impl Application for Sniffer {
     }
 
     fn theme(&self) -> Self::Theme {
-        self.settings.style
+        self.configs.lock().unwrap().settings.style
     }
 
     fn scale_factor(&self) -> f64 {
-        self.settings.scale_factor
+        self.configs.lock().unwrap().settings.scale_factor
     }
 }

--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -28,7 +28,7 @@ use crate::gui::pages::types::settings_page::SettingsPage;
 use crate::gui::styles::style_constants::{ICONS_BYTES, SARASA_MONO_BOLD_BYTES, SARASA_MONO_BYTES};
 use crate::gui::types::message::Message;
 use crate::gui::types::sniffer::Sniffer;
-use crate::StyleType;
+use crate::{ConfigSettings, StyleType};
 
 /// Update period (milliseconds)
 pub const PERIOD_TICK: u64 = 1000;
@@ -59,10 +59,12 @@ impl Application for Sniffer {
     }
 
     fn view(&self) -> Element<Message, Renderer<StyleType>> {
-        let settings = &self.configs.lock().unwrap().settings;
-        let style = settings.style;
-        let language = settings.language;
-        let color_gradient = settings.color_gradient;
+        let ConfigSettings {
+            style,
+            language,
+            color_gradient,
+            ..
+        } = self.configs.lock().unwrap().settings;
         let font = style.get_extension().font;
         let font_headers = style.get_extension().font_headers;
 

--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -142,7 +142,7 @@ impl Application for Sniffer {
                 modifiers,
             }) => match modifiers {
                 Modifiers::COMMAND => match key_code {
-                    KeyCode::Q => Some(Message::Quit),
+                    KeyCode::Q => Some(Message::CloseRequested),
                     KeyCode::Comma => Some(Message::OpenLastSettings),
                     KeyCode::Backspace => Some(Message::ResetButtonPressed),
                     KeyCode::D => Some(Message::CtrlDPressed),

--- a/src/gui/components/modal.rs
+++ b/src/gui/components/modal.rs
@@ -142,6 +142,7 @@ fn confirm_button_row(
 /// A widget that centers a modal element over some base element
 pub struct Modal<'a, Message, Renderer> {
     base: Element<'a, Message, Renderer>,
+    #[allow(clippy::struct_field_names)]
     modal: Element<'a, Message, Renderer>,
     on_blur: Option<Message>,
 }

--- a/src/gui/pages/connection_details_page.rs
+++ b/src/gui/pages/connection_details_page.rs
@@ -37,7 +37,7 @@ use crate::translations::translations_2::{
 use crate::translations::translations_3::{copy_translation, messages_translation};
 use crate::utils::formatted_strings::{get_formatted_bytes_string_with_b, get_socket_address};
 use crate::utils::types::icon::Icon;
-use crate::{Language, Protocol, Sniffer, StyleType};
+use crate::{ConfigSettings, Language, Protocol, Sniffer, StyleType};
 
 pub fn connection_details_page(
     sniffer: &Sniffer,
@@ -57,10 +57,12 @@ fn page_content(
     sniffer: &Sniffer,
     key: &AddressPortPair,
 ) -> Container<'static, Message, Renderer<StyleType>> {
-    let settings = &sniffer.configs.lock().unwrap().settings;
-    let style = settings.style;
-    let language = settings.language;
-    let color_gradient = settings.color_gradient;
+    let ConfigSettings {
+        style,
+        language,
+        color_gradient,
+        ..
+    } = sniffer.configs.lock().unwrap().settings;
     let font = style.get_extension().font;
     let font_headers = style.get_extension().font_headers;
 
@@ -304,9 +306,9 @@ fn get_local_tooltip(
     address_to_lookup: &str,
     key: &AddressPortPair,
 ) -> Tooltip<'static, Message, Renderer<StyleType>> {
-    let settings = &sniffer.configs.lock().unwrap().settings;
-    let style = settings.style;
-    let language = settings.language;
+    let ConfigSettings {
+        style, language, ..
+    } = sniffer.configs.lock().unwrap().settings;
 
     let my_interface_addresses = &*sniffer.device.addresses.lock().unwrap();
     get_computer_tooltip(

--- a/src/gui/pages/connection_details_page.rs
+++ b/src/gui/pages/connection_details_page.rs
@@ -57,9 +57,10 @@ fn page_content(
     sniffer: &Sniffer,
     key: &AddressPortPair,
 ) -> Container<'static, Message, Renderer<StyleType>> {
-    let style = sniffer.settings.style;
-    let language = sniffer.settings.language;
-    let color_gradient = sniffer.settings.color_gradient;
+    let settings = &sniffer.configs.lock().unwrap().settings;
+    let style = settings.style;
+    let language = settings.language;
+    let color_gradient = settings.color_gradient;
     let font = style.get_extension().font;
     let font_headers = style.get_extension().font_headers;
 
@@ -303,8 +304,9 @@ fn get_local_tooltip(
     address_to_lookup: &str,
     key: &AddressPortPair,
 ) -> Tooltip<'static, Message, Renderer<StyleType>> {
-    let style = sniffer.settings.style;
-    let language = sniffer.settings.language;
+    let settings = &sniffer.configs.lock().unwrap().settings;
+    let style = settings.style;
+    let language = settings.language;
 
     let my_interface_addresses = &*sniffer.device.addresses.lock().unwrap();
     get_computer_tooltip(

--- a/src/gui/pages/initial_page.rs
+++ b/src/gui/pages/initial_page.rs
@@ -39,9 +39,10 @@ use crate::{IpVersion, Language, Protocol, StyleType};
 
 /// Computes the body of gui initial page
 pub fn initial_page(sniffer: &Sniffer) -> Container<Message, Renderer<StyleType>> {
-    let style = sniffer.settings.style;
-    let language = sniffer.settings.language;
-    let color_gradient = sniffer.settings.color_gradient;
+    let settings = &sniffer.configs.lock().unwrap().settings;
+    let style = settings.style;
+    let language = settings.language;
+    let color_gradient = settings.color_gradient;
     let font = style.get_extension().font;
 
     let col_adapter = get_col_adapter(sniffer, font);
@@ -291,7 +292,8 @@ fn button_start(
 }
 
 fn get_col_adapter(sniffer: &Sniffer, font: Font) -> Column<Message, Renderer<StyleType>> {
-    let language = sniffer.settings.language;
+    let settings = &sniffer.configs.lock().unwrap().settings;
+    let language = settings.language;
 
     let mut dev_str_list = vec![];
     for dev in Device::list().expect("Error retrieving device list\r\n") {

--- a/src/gui/pages/initial_page.rs
+++ b/src/gui/pages/initial_page.rs
@@ -35,14 +35,16 @@ use crate::translations::translations::{
 use crate::translations::translations_3::port_translation;
 use crate::utils::formatted_strings::get_invalid_filters_string;
 use crate::utils::types::icon::Icon;
-use crate::{IpVersion, Language, Protocol, StyleType};
+use crate::{ConfigSettings, IpVersion, Language, Protocol, StyleType};
 
 /// Computes the body of gui initial page
 pub fn initial_page(sniffer: &Sniffer) -> Container<Message, Renderer<StyleType>> {
-    let settings = &sniffer.configs.lock().unwrap().settings;
-    let style = settings.style;
-    let language = settings.language;
-    let color_gradient = settings.color_gradient;
+    let ConfigSettings {
+        style,
+        language,
+        color_gradient,
+        ..
+    } = sniffer.configs.lock().unwrap().settings;
     let font = style.get_extension().font;
 
     let col_adapter = get_col_adapter(sniffer, font);
@@ -292,8 +294,7 @@ fn button_start(
 }
 
 fn get_col_adapter(sniffer: &Sniffer, font: Font) -> Column<Message, Renderer<StyleType>> {
-    let settings = &sniffer.configs.lock().unwrap().settings;
-    let language = settings.language;
+    let ConfigSettings { language, .. } = sniffer.configs.lock().unwrap().settings;
 
     let mut dev_str_list = vec![];
     for dev in Device::list().expect("Error retrieving device list\r\n") {

--- a/src/gui/pages/inspect_page.rs
+++ b/src/gui/pages/inspect_page.rs
@@ -29,8 +29,9 @@ use crate::{Language, ReportSortType, RunningPage, Sniffer, StyleType};
 
 /// Computes the body of gui inspect page
 pub fn inspect_page(sniffer: &Sniffer) -> Container<Message, Renderer<StyleType>> {
-    let style = sniffer.settings.style;
-    let language = sniffer.settings.language;
+    let settings = &sniffer.configs.lock().unwrap().settings;
+    let style = settings.style;
+    let language = settings.language;
     let font = style.get_extension().font;
     let font_headers = style.get_extension().font_headers;
 
@@ -110,8 +111,9 @@ pub fn inspect_page(sniffer: &Sniffer) -> Container<Message, Renderer<StyleType>
 }
 
 fn lazy_report(sniffer: &Sniffer) -> Container<'static, Message, Renderer<StyleType>> {
-    let style = sniffer.settings.style;
-    let language = sniffer.settings.language;
+    let settings = &sniffer.configs.lock().unwrap().settings;
+    let style = settings.style;
+    let language = settings.language;
     let font = style.get_extension().font;
 
     let (search_results, results_number) = get_searched_entries(sniffer);

--- a/src/gui/pages/inspect_page.rs
+++ b/src/gui/pages/inspect_page.rs
@@ -25,13 +25,13 @@ use crate::translations::translations_2::{
     showing_results_translation, sort_by_translation,
 };
 use crate::utils::types::icon::Icon;
-use crate::{Language, ReportSortType, RunningPage, Sniffer, StyleType};
+use crate::{ConfigSettings, Language, ReportSortType, RunningPage, Sniffer, StyleType};
 
 /// Computes the body of gui inspect page
 pub fn inspect_page(sniffer: &Sniffer) -> Container<Message, Renderer<StyleType>> {
-    let settings = &sniffer.configs.lock().unwrap().settings;
-    let style = settings.style;
-    let language = settings.language;
+    let ConfigSettings {
+        style, language, ..
+    } = sniffer.configs.lock().unwrap().settings;
     let font = style.get_extension().font;
     let font_headers = style.get_extension().font_headers;
 
@@ -111,9 +111,9 @@ pub fn inspect_page(sniffer: &Sniffer) -> Container<Message, Renderer<StyleType>
 }
 
 fn lazy_report(sniffer: &Sniffer) -> Container<'static, Message, Renderer<StyleType>> {
-    let settings = &sniffer.configs.lock().unwrap().settings;
-    let style = settings.style;
-    let language = settings.language;
+    let ConfigSettings {
+        style, language, ..
+    } = sniffer.configs.lock().unwrap().settings;
     let font = style.get_extension().font;
 
     let (search_results, results_number) = get_searched_entries(sniffer);

--- a/src/gui/pages/notifications_page.rs
+++ b/src/gui/pages/notifications_page.rs
@@ -33,9 +33,10 @@ use crate::{Language, RunningPage, Sniffer, StyleType};
 
 /// Computes the body of gui notifications page
 pub fn notifications_page(sniffer: &Sniffer) -> Container<Message, Renderer<StyleType>> {
-    let style = sniffer.settings.style;
-    let language = sniffer.settings.language;
-    let notifications = sniffer.settings.notifications;
+    let settings = &sniffer.configs.lock().unwrap().settings;
+    let style = settings.style;
+    let language = settings.language;
+    let notifications = settings.notifications;
     let font = style.get_extension().font;
     let font_headers = style.get_extension().font_headers;
 
@@ -396,8 +397,9 @@ fn get_button_clear_all(
 }
 
 fn lazy_logged_notifications(sniffer: &Sniffer) -> Column<'static, Message, Renderer<StyleType>> {
-    let style = sniffer.settings.style;
-    let language = sniffer.settings.language;
+    let settings = &sniffer.configs.lock().unwrap().settings;
+    let style = settings.style;
+    let language = settings.language;
     let font = style.get_extension().font;
     let mut ret_val = Column::new()
         .width(Length::Fixed(830.0))

--- a/src/gui/pages/notifications_page.rs
+++ b/src/gui/pages/notifications_page.rs
@@ -29,14 +29,16 @@ use crate::translations::translations::{
 };
 use crate::utils::formatted_strings::get_formatted_bytes_string_with_b;
 use crate::utils::types::icon::Icon;
-use crate::{Language, RunningPage, Sniffer, StyleType};
+use crate::{ConfigSettings, Language, RunningPage, Sniffer, StyleType};
 
 /// Computes the body of gui notifications page
 pub fn notifications_page(sniffer: &Sniffer) -> Container<Message, Renderer<StyleType>> {
-    let settings = &sniffer.configs.lock().unwrap().settings;
-    let style = settings.style;
-    let language = settings.language;
-    let notifications = settings.notifications;
+    let ConfigSettings {
+        style,
+        language,
+        notifications,
+        ..
+    } = sniffer.configs.lock().unwrap().settings;
     let font = style.get_extension().font;
     let font_headers = style.get_extension().font_headers;
 
@@ -397,9 +399,9 @@ fn get_button_clear_all(
 }
 
 fn lazy_logged_notifications(sniffer: &Sniffer) -> Column<'static, Message, Renderer<StyleType>> {
-    let settings = &sniffer.configs.lock().unwrap().settings;
-    let style = settings.style;
-    let language = settings.language;
+    let ConfigSettings {
+        style, language, ..
+    } = sniffer.configs.lock().unwrap().settings;
     let font = style.get_extension().font;
     let mut ret_val = Column::new()
         .width(Length::Fixed(830.0))

--- a/src/gui/pages/overview_page.rs
+++ b/src/gui/pages/overview_page.rs
@@ -49,8 +49,9 @@ use crate::{AppProtocol, ChartType, Language, RunningPage, StyleType};
 
 /// Computes the body of gui overview page
 pub fn overview_page(sniffer: &Sniffer) -> Container<Message, Renderer<StyleType>> {
-    let style = sniffer.settings.style;
-    let language = sniffer.settings.language;
+    let settings = &sniffer.configs.lock().unwrap().settings;
+    let style = settings.style;
+    let language = settings.language;
     let font = style.get_extension().font;
     let font_headers = style.get_extension().font_headers;
 
@@ -240,8 +241,9 @@ fn lazy_row_report(sniffer: &Sniffer) -> Container<'static, Message, Renderer<St
 }
 
 fn col_host(width: f32, sniffer: &Sniffer) -> Column<'static, Message, Renderer<StyleType>> {
-    let language = sniffer.settings.language;
-    let style = sniffer.settings.style;
+    let settings = &sniffer.configs.lock().unwrap().settings;
+    let language = settings.language;
+    let style = settings.style;
     let font = style.get_extension().font;
     let chart_type = sniffer.traffic_chart.chart_type;
 
@@ -337,8 +339,9 @@ fn col_host(width: f32, sniffer: &Sniffer) -> Column<'static, Message, Renderer<
 }
 
 fn col_app(width: f32, sniffer: &Sniffer) -> Column<'static, Message, Renderer<StyleType>> {
-    let style = sniffer.settings.style;
-    let language = sniffer.settings.language;
+    let settings = &sniffer.configs.lock().unwrap().settings;
+    let style = settings.style;
+    let language = settings.language;
     let font = style.get_extension().font;
     let chart_type = sniffer.traffic_chart.chart_type;
 
@@ -412,8 +415,9 @@ fn lazy_col_info(
     dropped: u32,
     sniffer: &Sniffer,
 ) -> Container<'static, Message, Renderer<StyleType>> {
-    let style = sniffer.settings.style;
-    let language = sniffer.settings.language;
+    let settings = &sniffer.configs.lock().unwrap().settings;
+    let style = settings.style;
+    let language = settings.language;
     let font = style.get_extension().font;
     let filtered_bytes =
         sniffer.runtime_data.tot_sent_bytes + sniffer.runtime_data.tot_received_bytes;
@@ -464,8 +468,9 @@ fn lazy_col_info(
 }
 
 fn container_chart(sniffer: &Sniffer, font: Font) -> Container<Message, Renderer<StyleType>> {
+    let settings = &sniffer.configs.lock().unwrap().settings;
     let traffic_chart = &sniffer.traffic_chart;
-    let language = sniffer.settings.language;
+    let language = settings.language;
 
     let mut chart_info_string = String::from("(");
     chart_info_string.push_str(if traffic_chart.chart_type.eq(&ChartType::Packets) {

--- a/src/gui/pages/overview_page.rs
+++ b/src/gui/pages/overview_page.rs
@@ -45,13 +45,13 @@ use crate::utils::formatted_strings::{
     get_active_filters_string, get_formatted_bytes_string_with_b, get_percentage_string,
 };
 use crate::utils::types::icon::Icon;
-use crate::{AppProtocol, ChartType, Language, RunningPage, StyleType};
+use crate::{AppProtocol, ChartType, ConfigSettings, Language, RunningPage, StyleType};
 
 /// Computes the body of gui overview page
 pub fn overview_page(sniffer: &Sniffer) -> Container<Message, Renderer<StyleType>> {
-    let settings = &sniffer.configs.lock().unwrap().settings;
-    let style = settings.style;
-    let language = settings.language;
+    let ConfigSettings {
+        style, language, ..
+    } = sniffer.configs.lock().unwrap().settings;
     let font = style.get_extension().font;
     let font_headers = style.get_extension().font_headers;
 
@@ -241,9 +241,9 @@ fn lazy_row_report(sniffer: &Sniffer) -> Container<'static, Message, Renderer<St
 }
 
 fn col_host(width: f32, sniffer: &Sniffer) -> Column<'static, Message, Renderer<StyleType>> {
-    let settings = &sniffer.configs.lock().unwrap().settings;
-    let language = settings.language;
-    let style = settings.style;
+    let ConfigSettings {
+        style, language, ..
+    } = sniffer.configs.lock().unwrap().settings;
     let font = style.get_extension().font;
     let chart_type = sniffer.traffic_chart.chart_type;
 
@@ -339,9 +339,9 @@ fn col_host(width: f32, sniffer: &Sniffer) -> Column<'static, Message, Renderer<
 }
 
 fn col_app(width: f32, sniffer: &Sniffer) -> Column<'static, Message, Renderer<StyleType>> {
-    let settings = &sniffer.configs.lock().unwrap().settings;
-    let style = settings.style;
-    let language = settings.language;
+    let ConfigSettings {
+        style, language, ..
+    } = sniffer.configs.lock().unwrap().settings;
     let font = style.get_extension().font;
     let chart_type = sniffer.traffic_chart.chart_type;
 
@@ -415,9 +415,9 @@ fn lazy_col_info(
     dropped: u32,
     sniffer: &Sniffer,
 ) -> Container<'static, Message, Renderer<StyleType>> {
-    let settings = &sniffer.configs.lock().unwrap().settings;
-    let style = settings.style;
-    let language = settings.language;
+    let ConfigSettings {
+        style, language, ..
+    } = sniffer.configs.lock().unwrap().settings;
     let font = style.get_extension().font;
     let filtered_bytes =
         sniffer.runtime_data.tot_sent_bytes + sniffer.runtime_data.tot_received_bytes;
@@ -468,9 +468,8 @@ fn lazy_col_info(
 }
 
 fn container_chart(sniffer: &Sniffer, font: Font) -> Container<Message, Renderer<StyleType>> {
-    let settings = &sniffer.configs.lock().unwrap().settings;
+    let ConfigSettings { language, .. } = sniffer.configs.lock().unwrap().settings;
     let traffic_chart = &sniffer.traffic_chart;
-    let language = settings.language;
 
     let mut chart_info_string = String::from("(");
     chart_info_string.push_str(if traffic_chart.chart_type.eq(&ChartType::Packets) {

--- a/src/gui/pages/overview_page.rs
+++ b/src/gui/pages/overview_page.rs
@@ -256,7 +256,7 @@ fn col_host(width: f32, sniffer: &Sniffer) -> Column<'static, Message, Renderer<
         let (incoming_bar_len, outgoing_bar_len) = get_bars_length(
             width * 0.86,
             chart_type,
-            &entries.get(0).unwrap().1.data_info.clone(),
+            &entries.first().unwrap().1.data_info.clone(),
             &data_info_host.data_info,
         );
 
@@ -362,7 +362,7 @@ fn col_app(width: f32, sniffer: &Sniffer) -> Column<'static, Message, Renderer<S
         let (mut incoming_bar_len, mut outgoing_bar_len) = get_bars_length(
             width * 0.88,
             chart_type,
-            &entries.get(0).unwrap().1.clone(),
+            &entries.first().unwrap().1.clone(),
             data_info,
         );
 

--- a/src/gui/pages/settings_general_page.rs
+++ b/src/gui/pages/settings_general_page.rs
@@ -28,9 +28,10 @@ use crate::utils::types::web_page::WebPage;
 use crate::{Language, RunningPage, Sniffer, StyleType};
 
 pub fn settings_general_page(sniffer: &Sniffer) -> Container<Message, Renderer<StyleType>> {
-    let style = sniffer.settings.style;
-    let language = sniffer.settings.language;
-    let color_gradient = sniffer.settings.color_gradient;
+    let settings = &sniffer.configs.lock().unwrap().settings;
+    let style = settings.style;
+    let language = settings.language;
+    let color_gradient = settings.color_gradient;
     let font = style.get_extension().font;
     let font_headers = style.get_extension().font_headers;
 
@@ -57,7 +58,8 @@ fn column_all_general_setting(
     sniffer: &Sniffer,
     font: Font,
 ) -> Column<'static, Message, Renderer<StyleType>> {
-    let language = sniffer.settings.language;
+    let settings = &sniffer.configs.lock().unwrap().settings;
+    let language = settings.language;
 
     let is_editable = sniffer.running_page.eq(&RunningPage::Init);
 
@@ -67,7 +69,7 @@ fn column_all_general_setting(
         .push(row_language_scale_factor(
             language,
             font,
-            sniffer.settings.scale_factor,
+            settings.scale_factor,
         ))
         .push(Rule::horizontal(25));
 
@@ -85,8 +87,8 @@ fn column_all_general_setting(
         is_editable,
         language,
         font,
-        &sniffer.settings.mmdb_country,
-        &sniffer.settings.mmdb_asn,
+        &settings.mmdb_country,
+        &settings.mmdb_asn,
         &sniffer.country_mmdb_reader,
         &sniffer.asn_mmdb_reader,
     ));

--- a/src/gui/pages/settings_general_page.rs
+++ b/src/gui/pages/settings_general_page.rs
@@ -25,13 +25,15 @@ use crate::translations::translations_3::{
     mmdb_files_translation, params_not_editable_translation, zoom_translation,
 };
 use crate::utils::types::web_page::WebPage;
-use crate::{Language, RunningPage, Sniffer, StyleType};
+use crate::{ConfigSettings, Language, RunningPage, Sniffer, StyleType};
 
 pub fn settings_general_page(sniffer: &Sniffer) -> Container<Message, Renderer<StyleType>> {
-    let settings = &sniffer.configs.lock().unwrap().settings;
-    let style = settings.style;
-    let language = settings.language;
-    let color_gradient = settings.color_gradient;
+    let ConfigSettings {
+        style,
+        language,
+        color_gradient,
+        ..
+    } = sniffer.configs.lock().unwrap().settings;
     let font = style.get_extension().font;
     let font_headers = style.get_extension().font_headers;
 
@@ -58,19 +60,20 @@ fn column_all_general_setting(
     sniffer: &Sniffer,
     font: Font,
 ) -> Column<'static, Message, Renderer<StyleType>> {
-    let settings = &sniffer.configs.lock().unwrap().settings;
-    let language = settings.language;
+    let ConfigSettings {
+        language,
+        scale_factor,
+        mmdb_country,
+        mmdb_asn,
+        ..
+    } = sniffer.configs.lock().unwrap().settings.clone();
 
     let is_editable = sniffer.running_page.eq(&RunningPage::Init);
 
     let mut column = Column::new()
         .align_items(Alignment::Center)
         .padding([5, 10])
-        .push(row_language_scale_factor(
-            language,
-            font,
-            settings.scale_factor,
-        ))
+        .push(row_language_scale_factor(language, font, scale_factor))
         .push(Rule::horizontal(25));
 
     if !is_editable {
@@ -87,8 +90,8 @@ fn column_all_general_setting(
         is_editable,
         language,
         font,
-        &settings.mmdb_country,
-        &settings.mmdb_asn,
+        &mmdb_country,
+        &mmdb_asn,
         &sniffer.country_mmdb_reader,
         &sniffer.asn_mmdb_reader,
     ));

--- a/src/gui/pages/settings_notifications_page.rs
+++ b/src/gui/pages/settings_notifications_page.rs
@@ -28,14 +28,16 @@ use crate::translations::translations::{
     volume_translation,
 };
 use crate::utils::types::icon::Icon;
-use crate::{Language, Sniffer, StyleType};
+use crate::{ConfigSettings, Language, Sniffer, StyleType};
 
 pub fn settings_notifications_page(sniffer: &Sniffer) -> Container<Message, Renderer<StyleType>> {
-    let settings = &sniffer.configs.lock().unwrap().settings;
-    let style = settings.style;
-    let language = settings.language;
-    let color_gradient = settings.color_gradient;
-    let notifications = settings.notifications;
+    let ConfigSettings {
+        style,
+        language,
+        color_gradient,
+        notifications,
+        ..
+    } = sniffer.configs.lock().unwrap().settings;
     let font = style.get_extension().font;
     let font_headers = style.get_extension().font_headers;
 

--- a/src/gui/pages/settings_notifications_page.rs
+++ b/src/gui/pages/settings_notifications_page.rs
@@ -31,10 +31,11 @@ use crate::utils::types::icon::Icon;
 use crate::{Language, Sniffer, StyleType};
 
 pub fn settings_notifications_page(sniffer: &Sniffer) -> Container<Message, Renderer<StyleType>> {
-    let style = sniffer.settings.style;
-    let language = sniffer.settings.language;
-    let color_gradient = sniffer.settings.color_gradient;
-    let notifications = sniffer.settings.notifications;
+    let settings = &sniffer.configs.lock().unwrap().settings;
+    let style = settings.style;
+    let language = settings.language;
+    let color_gradient = settings.color_gradient;
+    let notifications = settings.notifications;
     let font = style.get_extension().font;
     let font_headers = style.get_extension().font_headers;
 

--- a/src/gui/pages/settings_style_page.rs
+++ b/src/gui/pages/settings_style_page.rs
@@ -30,10 +30,11 @@ use crate::StyleType::{Day, DeepSea, MonAmour, Night};
 use crate::{Language, Sniffer, StyleType};
 
 pub fn settings_style_page(sniffer: &Sniffer) -> Container<Message, Renderer<StyleType>> {
-    let style = sniffer.settings.style;
-    let style_path = &sniffer.settings.style_path;
-    let color_gradient = sniffer.settings.color_gradient;
-    let language = sniffer.settings.language;
+    let settings = &sniffer.configs.lock().unwrap().settings;
+    let style = settings.style;
+    let style_path = settings.style_path.clone();
+    let color_gradient = settings.color_gradient;
+    let language = settings.language;
     let font = style.get_extension().font;
     let font_headers = style.get_extension().font_headers;
 
@@ -100,8 +101,8 @@ pub fn settings_style_page(sniffer: &Sniffer) -> Container<Message, Renderer<Sty
         styles_col = styles_col.push(children);
     }
     styles_col = styles_col
-        .push(lazy((style_path, style), move |_| {
-            lazy_custom_style_input(language, font, style_path, style)
+        .push(lazy((style_path.clone(), style), move |_| {
+            lazy_custom_style_input(language, font, &style_path, style)
         }))
         .push(vertical_space(10));
 

--- a/src/gui/pages/settings_style_page.rs
+++ b/src/gui/pages/settings_style_page.rs
@@ -27,14 +27,16 @@ use crate::translations::translations_2::color_gradients_translation;
 use crate::translations::translations_3::custom_style_translation;
 use crate::utils::types::icon::Icon;
 use crate::StyleType::{Day, DeepSea, MonAmour, Night};
-use crate::{Language, Sniffer, StyleType};
+use crate::{ConfigSettings, Language, Sniffer, StyleType};
 
 pub fn settings_style_page(sniffer: &Sniffer) -> Container<Message, Renderer<StyleType>> {
-    let settings = &sniffer.configs.lock().unwrap().settings;
-    let style = settings.style;
-    let style_path = settings.style_path.clone();
-    let color_gradient = settings.color_gradient;
-    let language = settings.language;
+    let ConfigSettings {
+        style,
+        language,
+        color_gradient,
+        style_path,
+        ..
+    } = sniffer.configs.lock().unwrap().settings.clone();
     let font = style.get_extension().font;
     let font_headers = style.get_extension().font_headers;
 

--- a/src/gui/styles/types/style_type.rs
+++ b/src/gui/styles/types/style_type.rs
@@ -32,7 +32,7 @@ impl Default for StyleType {
 impl application::StyleSheet for StyleType {
     type Style = ();
 
-    fn appearance(&self, _: &Self::Style) -> Appearance {
+    fn appearance(&self, (): &Self::Style) -> Appearance {
         let colors = self.get_palette();
         Appearance {
             background_color: colors.primary,

--- a/src/gui/types/message.rs
+++ b/src/gui/types/message.rs
@@ -65,8 +65,6 @@ pub enum Message {
     ClearAllNotifications,
     /// Set notifications volume
     ChangeVolume(u8),
-    /// Quits the app. Used when Ctrl+Q keys are pressed.
-    Quit,
     /// Switch from a page to the next (previous) one if true (false), when the tab (shift+tab) key is pressed.
     SwitchPage(bool),
     /// The enter (return) key has been pressed

--- a/src/gui/types/sniffer.rs
+++ b/src/gui/types/sniffer.rs
@@ -562,13 +562,14 @@ impl Sniffer {
 mod tests {
     #![allow(unused_must_use)]
 
-    use serial_test::{parallel, serial};
     use std::collections::{HashSet, VecDeque};
     use std::fs::remove_file;
     use std::ops::Sub;
     use std::path::Path;
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
+
+    use serial_test::{parallel, serial};
 
     use crate::countries::types::country::Country;
     use crate::gui::components::types::my_modal::MyModal;

--- a/src/gui/types/sniffer.rs
+++ b/src/gui/types/sniffer.rs
@@ -585,9 +585,16 @@ mod tests {
         RunningPage, Sniffer, StyleType,
     };
 
+    fn new_sniffer() -> Sniffer {
+        Sniffer::new(
+            &Arc::new(Mutex::new(Configs::default())),
+            Arc::new(Mutex::new(None)),
+        )
+    }
+
     #[test]
     fn test_correctly_update_ip_version() {
-        let mut sniffer = Sniffer::new(&Configs::default(), Arc::new(Mutex::new(None)));
+        let mut sniffer = new_sniffer();
 
         assert_eq!(sniffer.filters.ip_versions, HashSet::from(IpVersion::ALL));
         sniffer.update(Message::IpVersionSelection(IpVersion::IPv6, true));
@@ -603,7 +610,7 @@ mod tests {
 
     #[test]
     fn test_correctly_update_protocol() {
-        let mut sniffer = Sniffer::new(&Configs::default(), Arc::new(Mutex::new(None)));
+        let mut sniffer = new_sniffer();
 
         assert_eq!(sniffer.filters.protocols, HashSet::from(Protocol::ALL));
         sniffer.update(Message::ProtocolSelection(Protocol::UDP, true));
@@ -623,7 +630,7 @@ mod tests {
 
     #[test]
     fn test_correctly_update_chart_kind() {
-        let mut sniffer = Sniffer::new(&Configs::default(), Arc::new(Mutex::new(None)));
+        let mut sniffer = new_sniffer();
 
         assert_eq!(sniffer.traffic_chart.chart_type, ChartType::Bytes);
         sniffer.update(Message::ChartSelection(ChartType::Packets));
@@ -636,7 +643,7 @@ mod tests {
 
     #[test]
     fn test_correctly_update_report_kind() {
-        let mut sniffer = Sniffer::new(&Configs::default(), Arc::new(Mutex::new(None)));
+        let mut sniffer = new_sniffer();
 
         assert_eq!(sniffer.report_sort_type, ReportSortType::MostRecent);
         sniffer.update(Message::ReportSortSelection(ReportSortType::MostBytes));
@@ -651,23 +658,38 @@ mod tests {
 
     #[test]
     fn test_correctly_update_style() {
-        let mut sniffer = Sniffer::new(&Configs::default(), Arc::new(Mutex::new(None)));
+        let mut sniffer = new_sniffer();
 
         sniffer.update(Message::Style(StyleType::MonAmour));
-        assert_eq!(sniffer.settings.style, StyleType::MonAmour);
+        assert_eq!(
+            sniffer.configs.lock().unwrap().settings.style,
+            StyleType::MonAmour
+        );
         sniffer.update(Message::Style(StyleType::Day));
-        assert_eq!(sniffer.settings.style, StyleType::Day);
+        assert_eq!(
+            sniffer.configs.lock().unwrap().settings.style,
+            StyleType::Day
+        );
         sniffer.update(Message::Style(StyleType::Night));
-        assert_eq!(sniffer.settings.style, StyleType::Night);
+        assert_eq!(
+            sniffer.configs.lock().unwrap().settings.style,
+            StyleType::Night
+        );
         sniffer.update(Message::Style(StyleType::DeepSea));
-        assert_eq!(sniffer.settings.style, StyleType::DeepSea);
+        assert_eq!(
+            sniffer.configs.lock().unwrap().settings.style,
+            StyleType::DeepSea
+        );
         sniffer.update(Message::Style(StyleType::DeepSea));
-        assert_eq!(sniffer.settings.style, StyleType::DeepSea);
+        assert_eq!(
+            sniffer.configs.lock().unwrap().settings.style,
+            StyleType::DeepSea
+        );
     }
 
     #[test]
     fn test_waiting_dots_update() {
-        let mut sniffer = Sniffer::new(&Configs::default(), Arc::new(Mutex::new(None)));
+        let mut sniffer = new_sniffer();
 
         assert_eq!(sniffer.waiting, ".".to_string());
         sniffer.update(Message::Waiting);
@@ -682,7 +704,7 @@ mod tests {
 
     #[test]
     fn test_modify_favorite_connections() {
-        let mut sniffer = Sniffer::new(&Configs::default(), Arc::new(Mutex::new(None)));
+        let mut sniffer = new_sniffer();
         // remove 1
         sniffer.update(Message::AddOrRemoveFavorite(
             Host {
@@ -871,7 +893,7 @@ mod tests {
 
     #[test]
     fn test_show_and_hide_modal_and_settings() {
-        let mut sniffer = Sniffer::new(&Configs::default(), Arc::new(Mutex::new(None)));
+        let mut sniffer = new_sniffer();
 
         assert_eq!(sniffer.modal, None);
         assert_eq!(sniffer.settings_page, None);
@@ -958,29 +980,56 @@ mod tests {
 
     #[test]
     fn test_correctly_update_language() {
-        let mut sniffer = Sniffer::new(&Configs::default(), Arc::new(Mutex::new(None)));
+        let mut sniffer = new_sniffer();
 
-        assert_eq!(sniffer.settings.language, Language::EN);
+        assert_eq!(
+            sniffer.configs.lock().unwrap().settings.language,
+            Language::EN
+        );
         assert_eq!(sniffer.traffic_chart.language, Language::EN);
         sniffer.update(Message::LanguageSelection(Language::IT));
-        assert_eq!(sniffer.settings.language, Language::IT);
+        assert_eq!(
+            sniffer.configs.lock().unwrap().settings.language,
+            Language::IT
+        );
         assert_eq!(sniffer.traffic_chart.language, Language::IT);
         sniffer.update(Message::LanguageSelection(Language::IT));
-        assert_eq!(sniffer.settings.language, Language::IT);
+        assert_eq!(
+            sniffer.configs.lock().unwrap().settings.language,
+            Language::IT
+        );
         assert_eq!(sniffer.traffic_chart.language, Language::IT);
         sniffer.update(Message::LanguageSelection(Language::ZH));
-        assert_eq!(sniffer.settings.language, Language::ZH);
+        assert_eq!(
+            sniffer.configs.lock().unwrap().settings.language,
+            Language::ZH
+        );
         assert_eq!(sniffer.traffic_chart.language, Language::ZH);
     }
 
     #[test]
     fn test_correctly_update_notification_settings() {
-        let mut sniffer = Sniffer::new(&Configs::default(), Arc::new(Mutex::new(None)));
+        let mut sniffer = new_sniffer();
 
         // initial default state
-        assert_eq!(sniffer.settings.notifications.volume, 60);
         assert_eq!(
-            sniffer.settings.notifications.packets_notification,
+            sniffer
+                .configs
+                .lock()
+                .unwrap()
+                .settings
+                .notifications
+                .volume,
+            60
+        );
+        assert_eq!(
+            sniffer
+                .configs
+                .lock()
+                .unwrap()
+                .settings
+                .notifications
+                .packets_notification,
             PacketsNotification {
                 threshold: None,
                 sound: Sound::Gulp,
@@ -988,7 +1037,13 @@ mod tests {
             }
         );
         assert_eq!(
-            sniffer.settings.notifications.bytes_notification,
+            sniffer
+                .configs
+                .lock()
+                .unwrap()
+                .settings
+                .notifications
+                .bytes_notification,
             BytesNotification {
                 threshold: None,
                 byte_multiple: ByteMultiple::KB,
@@ -997,7 +1052,13 @@ mod tests {
             }
         );
         assert_eq!(
-            sniffer.settings.notifications.favorite_notification,
+            sniffer
+                .configs
+                .lock()
+                .unwrap()
+                .settings
+                .notifications
+                .favorite_notification,
             FavoriteNotification {
                 notify_on_favorite: false,
                 sound: Sound::Swhoosh,
@@ -1005,9 +1066,24 @@ mod tests {
         );
         // change volume
         sniffer.update(Message::ChangeVolume(95));
-        assert_eq!(sniffer.settings.notifications.volume, 95);
         assert_eq!(
-            sniffer.settings.notifications.packets_notification,
+            sniffer
+                .configs
+                .lock()
+                .unwrap()
+                .settings
+                .notifications
+                .volume,
+            95
+        );
+        assert_eq!(
+            sniffer
+                .configs
+                .lock()
+                .unwrap()
+                .settings
+                .notifications
+                .packets_notification,
             PacketsNotification {
                 threshold: None,
                 sound: Sound::Gulp,
@@ -1015,7 +1091,13 @@ mod tests {
             }
         );
         assert_eq!(
-            sniffer.settings.notifications.bytes_notification,
+            sniffer
+                .configs
+                .lock()
+                .unwrap()
+                .settings
+                .notifications
+                .bytes_notification,
             BytesNotification {
                 threshold: None,
                 byte_multiple: ByteMultiple::KB,
@@ -1024,7 +1106,13 @@ mod tests {
             }
         );
         assert_eq!(
-            sniffer.settings.notifications.favorite_notification,
+            sniffer
+                .configs
+                .lock()
+                .unwrap()
+                .settings
+                .notifications
+                .favorite_notification,
             FavoriteNotification {
                 notify_on_favorite: false,
                 sound: Sound::Swhoosh,
@@ -1039,9 +1127,24 @@ mod tests {
             }),
             false,
         ));
-        assert_eq!(sniffer.settings.notifications.volume, 95);
         assert_eq!(
-            sniffer.settings.notifications.packets_notification,
+            sniffer
+                .configs
+                .lock()
+                .unwrap()
+                .settings
+                .notifications
+                .volume,
+            95
+        );
+        assert_eq!(
+            sniffer
+                .configs
+                .lock()
+                .unwrap()
+                .settings
+                .notifications
+                .packets_notification,
             PacketsNotification {
                 threshold: Some(1122),
                 sound: Sound::None,
@@ -1049,7 +1152,13 @@ mod tests {
             }
         );
         assert_eq!(
-            sniffer.settings.notifications.bytes_notification,
+            sniffer
+                .configs
+                .lock()
+                .unwrap()
+                .settings
+                .notifications
+                .bytes_notification,
             BytesNotification {
                 threshold: None,
                 byte_multiple: ByteMultiple::KB,
@@ -1058,7 +1167,13 @@ mod tests {
             }
         );
         assert_eq!(
-            sniffer.settings.notifications.favorite_notification,
+            sniffer
+                .configs
+                .lock()
+                .unwrap()
+                .settings
+                .notifications
+                .favorite_notification,
             FavoriteNotification {
                 notify_on_favorite: false,
                 sound: Sound::Swhoosh,
@@ -1074,9 +1189,24 @@ mod tests {
             }),
             true,
         ));
-        assert_eq!(sniffer.settings.notifications.volume, 95);
         assert_eq!(
-            sniffer.settings.notifications.packets_notification,
+            sniffer
+                .configs
+                .lock()
+                .unwrap()
+                .settings
+                .notifications
+                .volume,
+            95
+        );
+        assert_eq!(
+            sniffer
+                .configs
+                .lock()
+                .unwrap()
+                .settings
+                .notifications
+                .packets_notification,
             PacketsNotification {
                 threshold: Some(1122),
                 sound: Sound::None,
@@ -1084,7 +1214,13 @@ mod tests {
             }
         );
         assert_eq!(
-            sniffer.settings.notifications.bytes_notification,
+            sniffer
+                .configs
+                .lock()
+                .unwrap()
+                .settings
+                .notifications
+                .bytes_notification,
             BytesNotification {
                 threshold: Some(3),
                 byte_multiple: ByteMultiple::GB,
@@ -1093,7 +1229,13 @@ mod tests {
             }
         );
         assert_eq!(
-            sniffer.settings.notifications.favorite_notification,
+            sniffer
+                .configs
+                .lock()
+                .unwrap()
+                .settings
+                .notifications
+                .favorite_notification,
             FavoriteNotification {
                 notify_on_favorite: false,
                 sound: Sound::Swhoosh,
@@ -1107,9 +1249,24 @@ mod tests {
             }),
             true,
         ));
-        assert_eq!(sniffer.settings.notifications.volume, 95);
         assert_eq!(
-            sniffer.settings.notifications.packets_notification,
+            sniffer
+                .configs
+                .lock()
+                .unwrap()
+                .settings
+                .notifications
+                .volume,
+            95
+        );
+        assert_eq!(
+            sniffer
+                .configs
+                .lock()
+                .unwrap()
+                .settings
+                .notifications
+                .packets_notification,
             PacketsNotification {
                 threshold: Some(1122),
                 sound: Sound::None,
@@ -1117,7 +1274,13 @@ mod tests {
             }
         );
         assert_eq!(
-            sniffer.settings.notifications.bytes_notification,
+            sniffer
+                .configs
+                .lock()
+                .unwrap()
+                .settings
+                .notifications
+                .bytes_notification,
             BytesNotification {
                 threshold: Some(3),
                 byte_multiple: ByteMultiple::GB,
@@ -1126,7 +1289,13 @@ mod tests {
             }
         );
         assert_eq!(
-            sniffer.settings.notifications.favorite_notification,
+            sniffer
+                .configs
+                .lock()
+                .unwrap()
+                .settings
+                .notifications
+                .favorite_notification,
             FavoriteNotification {
                 notify_on_favorite: true,
                 sound: Sound::Pop
@@ -1136,7 +1305,7 @@ mod tests {
 
     #[test]
     fn test_clear_all_notifications() {
-        let mut sniffer = Sniffer::new(&Configs::default(), Arc::new(Mutex::new(None)));
+        let mut sniffer = new_sniffer();
         sniffer.runtime_data.logged_notifications =
             VecDeque::from([LoggedNotification::PacketsThresholdExceeded(
                 PacketsThresholdExceeded {
@@ -1158,7 +1327,7 @@ mod tests {
 
     #[test]
     fn test_correctly_switch_running_and_settings_pages() {
-        let mut sniffer = Sniffer::new(&Configs::default(), Arc::new(Mutex::new(None)));
+        let mut sniffer = new_sniffer();
         sniffer.timing_events.focus = std::time::Instant::now().sub(Duration::from_millis(400));
 
         // initial status

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,7 @@ pub fn main() -> iced::Result {
     // gracefully close the app when receiving SIGINT, SIGTERM, or SIGHUP
     ctrlc::set_handler(move || {
         configs2.lock().unwrap().clone().store();
-        process::exit(0);
+        process::exit(130);
     })
     .expect("Error setting Ctrl-C handler");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,14 +81,14 @@ pub fn main() -> iced::Result {
 
     print_cli_welcome_message();
 
-    let window_properties = configs1.lock().unwrap().window;
+    let ConfigWindow { size, position } = configs1.lock().unwrap().window;
 
     Sniffer::run(Settings {
         // id needed for Linux Wayland; should match StartupWMClass in .desktop file; see issue #292
         id: Some("sniffnet".to_string()),
         window: window::Settings {
-            size: window_properties.size, // start size
-            position: window_properties.position.to_position(),
+            size, // start size
+            position: position.to_position(),
             min_size: Some((800, 500)), // min size allowed
             max_size: None,
             visible: true,

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,8 @@ mod secondary_threads;
 mod translations;
 mod utils;
 
+pub const SNIFFNET_LOWERCASE: &str = "sniffnet";
+
 /// Entry point of application execution
 ///
 /// It initializes shared variables and loads configuration parameters
@@ -85,7 +87,7 @@ pub fn main() -> iced::Result {
 
     Sniffer::run(Settings {
         // id needed for Linux Wayland; should match StartupWMClass in .desktop file; see issue #292
-        id: Some("sniffnet".to_string()),
+        id: Some(String::from(SNIFFNET_LOWERCASE)),
         window: window::Settings {
             size, // start size
             position: position.to_position(),
@@ -98,7 +100,7 @@ pub fn main() -> iced::Result {
             icon: None,
             #[cfg(target_os = "linux")]
             platform_specific: PlatformSpecific {
-                application_id: "sniffnet".to_string(),
+                application_id: String::from(SNIFFNET_LOWERCASE),
             },
             ..Default::default()
         },

--- a/src/notifications/types/notifications.rs
+++ b/src/notifications/types/notifications.rs
@@ -5,7 +5,7 @@ use crate::notifications::types::sound::Sound;
 use crate::ByteMultiple;
 
 /// Used to contain the notifications configuration set by the user
-#[derive(Clone, Serialize, Deserialize, Copy)]
+#[derive(Clone, Serialize, Deserialize, Copy, PartialEq, Debug)]
 pub struct Notifications {
     pub volume: u8,
     pub packets_notification: PacketsNotification,

--- a/src/report/get_report_entries.rs
+++ b/src/report/get_report_entries.rs
@@ -15,8 +15,9 @@ use crate::{AppProtocol, ChartType, InfoTraffic, ReportSortType, Sniffer};
 /// Returns the elements which satisfy the search constraints and belong to the given page,
 /// and the total number of elements which satisfy the search constraints
 pub fn get_searched_entries(sniffer: &Sniffer) -> (Vec<ReportEntry>, usize) {
-    let style = sniffer.settings.style;
-    let language = sniffer.settings.language;
+    let settings = &sniffer.configs.lock().unwrap().settings;
+    let style = settings.style;
+    let language = settings.language;
 
     let info_traffic_lock = sniffer.info_traffic.lock().unwrap();
     let mut all_results: Vec<(&AddressPortPair, &InfoAddressPortPair)> = info_traffic_lock

--- a/src/report/get_report_entries.rs
+++ b/src/report/get_report_entries.rs
@@ -10,14 +10,14 @@ use crate::networking::types::data_info_host::DataInfoHost;
 use crate::networking::types::host::Host;
 use crate::networking::types::info_address_port_pair::InfoAddressPortPair;
 use crate::report::types::report_entry::ReportEntry;
-use crate::{AppProtocol, ChartType, InfoTraffic, ReportSortType, Sniffer};
+use crate::{AppProtocol, ChartType, ConfigSettings, InfoTraffic, ReportSortType, Sniffer};
 
 /// Returns the elements which satisfy the search constraints and belong to the given page,
 /// and the total number of elements which satisfy the search constraints
 pub fn get_searched_entries(sniffer: &Sniffer) -> (Vec<ReportEntry>, usize) {
-    let settings = &sniffer.configs.lock().unwrap().settings;
-    let style = settings.style;
-    let language = settings.language;
+    let ConfigSettings {
+        style, language, ..
+    } = sniffer.configs.lock().unwrap().settings;
 
     let info_traffic_lock = sniffer.info_traffic.lock().unwrap();
     let mut all_results: Vec<(&AddressPortPair, &InfoAddressPortPair)> = info_traffic_lock

--- a/src/secondary_threads/check_updates.rs
+++ b/src/secondary_threads/check_updates.rs
@@ -2,6 +2,7 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
+use crate::SNIFFNET_LOWERCASE;
 use serde::Deserialize;
 
 use crate::utils::formatted_strings::APP_VERSION;
@@ -23,7 +24,7 @@ fn is_newer_release_available(max_retries: u8, seconds_between_retries: u8) -> O
     let client = reqwest::blocking::Client::new();
     let response = client
         .get("https://api.github.com/repos/GyulyVGC/sniffnet/releases/latest")
-        .header("User-agent", format!("sniffnet-{APP_VERSION}"))
+        .header("User-agent", format!("{SNIFFNET_LOWERCASE}-{APP_VERSION}"))
         .header("Accept", "application/vnd.github+json")
         .header("X-GitHub-Api-Version", "2022-11-28")
         .send();
@@ -35,7 +36,7 @@ fn is_newer_release_available(max_retries: u8, seconds_between_retries: u8) -> O
         if result_json.is_err() {
             let response2 = client
                 .get("https://api.github.com/repos/GyulyVGC/sniffnet/releases/latest")
-                .header("User-agent", format!("sniffnet-{APP_VERSION}"))
+                .header("User-agent", format!("{SNIFFNET_LOWERCASE}-{APP_VERSION}"))
                 .header("Accept", "application/vnd.github+json")
                 .header("X-GitHub-Api-Version", "2022-11-28")
                 .send();

--- a/src/secondary_threads/check_updates.rs
+++ b/src/secondary_threads/check_updates.rs
@@ -2,10 +2,10 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
-use crate::SNIFFNET_LOWERCASE;
 use serde::Deserialize;
 
 use crate::utils::formatted_strings::APP_VERSION;
+use crate::SNIFFNET_LOWERCASE;
 
 #[derive(Deserialize, Debug)]
 struct AppVersion {

--- a/src/utils/formatted_strings.rs
+++ b/src/utils/formatted_strings.rs
@@ -120,7 +120,7 @@ pub fn get_formatted_bytes_string_with_b(bytes: u128) -> String {
 
 // /// Returns the default report path
 // pub fn get_default_report_file_path() -> String {
-//     return if let Ok(mut config_path) = confy::get_configuration_file_path("sniffnet", "file") {
+//     return if let Ok(mut config_path) = confy::get_configuration_file_path(SNIFFNET_LOWERCASE, "file") {
 //         config_path.pop();
 //         config_path.push(PCAP_FILE_NAME);
 //         config_path.to_string_lossy().to_string()
@@ -138,7 +138,7 @@ pub fn get_formatted_bytes_string_with_b(bytes: u128) -> String {
 //     if let Ok(custom_file) = File::create(custom_path) {
 //         return custom_file;
 //     } else if let Ok(mut config_path) =
-//         confy::get_configuration_file_path("sniffnet", "file")
+//         confy::get_configuration_file_path(SNIFFNET_LOWERCASE, "file")
 //     {
 //         config_path.pop();
 //         config_path.push(PCAP_FILE_NAME);


### PR DESCRIPTION
Adds support for graceful termination in presence of `SIGINT`, `SIGTERM`, and `SIGHUP`.

Sniffnet needs to save some configurations (settings, window properties, and name of last sniffed device) before closing.

Gracefully terminating the application when the aforementioned signals are received means being able to save such configurations when the user quits Sniffnet in an unconventional way (e.g., by pressing `ctrl` + `C` in terminal, by sending `kill` command, or by closing the terminal that launched the execution).