### PR TITLE
feat: pcap write

### DIFF
--- a/src/secondary_threads/mod.rs
+++ b/src/secondary_threads/mod.rs
@@ -1,2 +1,3 @@
 pub mod check_updates;
 pub mod parse_packets;
+pub mod writer;

--- a/src/secondary_threads/writer.rs
+++ b/src/secondary_threads/writer.rs
@@ -1,0 +1,16 @@
+use pcap::*;
+use std::sync::mpsc::Receiver;
+
+pub fn writer(cap: &Capture<Active>, rx: Receiver<Packet>) {
+    // let mut cap = Capture::from_device(device)
+    //     .unwrap()
+    //     .immediate_mode(true)
+    //     .open()
+    //     .unwrap();
+
+    let mut savefile = cap.savefile("test.pcap").unwrap();
+    loop {
+        let packet = rx.recv().unwrap();
+        savefile.write(&packet);
+    }
+}


### PR DESCRIPTION
I created a mpsc channel and spawned a new thread for write operation. I am facing problems with sharing ownership of `cap` between threads (`thread_parse_packets`, `thread_write_packets`) and borrowing `Packet`.

```
error[E0382]: use of moved value: `cap`
   --> src/gui/types/sniffer.rs:412:24
    |
388 |             let cap = Arc::new(Mutex::new(unwrapped_cap));
    |                 --- move occurs because `cap` has type `std::sync::Arc<std::sync::Mutex<pcap::Capture<pcap::Active>>>`, which does not implement the `Copy` trait
...
397 |                 .spawn(move || {
    |                        ------- value moved into closure here
...
401 |                         &cap.lock().unwrap(),
    |                          --- variable moved due to use in closure
...
412 |                 .spawn(move || writer(&cap.lock().unwrap(), rx));
    |                        ^^^^^^^         --- use occurs due to use in closure
    |                        |
    |                        value used here after move

error[E0596]: cannot borrow `*cap` as mutable, as it is behind a `&` reference
  --> src/secondary_threads/parse_packets.rs:43:15
   |
43 |         match cap.next_packet() {
   |               ^^^ `cap` is a `&` reference, so the data it refers to cannot be borrowed as mutable
   |
help: consider changing this to be a mutable reference
   |
31 |     mut cap: &mut Capture<Active>,
   |               +++

error: lifetime may not live long enough
  --> src/secondary_threads/parse_packets.rs:55:21
   |
31 |     mut cap: &Capture<Active>,
   |              - let's call the lifetime of this reference `'1`
...
36 |     tx: Sender<Packet>,
   |     -- has type `std::sync::mpsc::Sender<pcap::Packet<'2>>`
...
55 |                     tx.send(packet);
   |                     ^^^^^^^^^^^^^^^ argument requires that `'1` must outlive `'2`

error[E0505]: cannot move out of `packet` because it is borrowed
  --> src/secondary_threads/parse_packets.rs:55:29
   |
50 |             Ok(packet) => {
   |                ------ binding `packet` declared here
...
54 |                 if let Ok(headers) = get_sniffable_headers(&packet, my_link_type) {
   |                                                            ------- borrow of `packet` occurs here
55 |                     tx.send(packet);
   |                             ^^^^^^ move out of `packet` occurs here
...
62 |                         headers,
   |                         ------- borrow later used here

error[E0596]: cannot borrow `*cap` as mutable, as it is behind a `&` reference
  --> src/secondary_threads/parse_packets.rs:96:40
   |
96 |                     if let Ok(stats) = cap.stats() {
   |                                        ^^^ `cap` is a `&` reference, so the data it refers to cannot be borrowed as mutable
```

Could you help @GyulyVGC?