### PR TITLE
Sort options for Host & Service columns in overview page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All Sniffnet releases with the relative changes are documented in this file.
 - Added possibility to totally customize the app's theme via styles defined in TOML files ([#286](https://github.com/GyulyVGC/sniffnet/pull/286) and [#419](https://github.com/GyulyVGC/sniffnet/pull/419))
 - Upgraded inspect page table: multiple new search filters, additional sorting options, and always keep a correct fields alignment ([#442](https://github.com/GyulyVGC/sniffnet/pull/442) — fixes [#63](https://github.com/GyulyVGC/sniffnet/issues/63))
 - Added support for more link types in addition to Ethernet: raw IP packets and null/loopback packets are now correctly parsed ([#421](https://github.com/GyulyVGC/sniffnet/pull/421))
+- Support changing sort strategy for network hosts and services in overview page, showing most recent items by default ([#452](https://github.com/GyulyVGC/sniffnet/pull/452))
 - IP addresses can now be copied to clipboard from the popup related to a given entry of the connections table, and a new search parameter has been introduced in Inspect page to allow users filter their connections based on IP address values ([#409](https://github.com/GyulyVGC/sniffnet/pull/409))
 - Added Japanese translation 🇯🇵 ([#343](https://github.com/GyulyVGC/sniffnet/pull/343))
 - Added Uzbek translation 🇺🇿 ([#385](https://github.com/GyulyVGC/sniffnet/pull/385))

--- a/src/gui/pages/overview_page.rs
+++ b/src/gui/pages/overview_page.rs
@@ -275,7 +275,14 @@ fn col_host(width: f32, sniffer: &Sniffer) -> Column<'static, Message, Renderer<
         .width(Length::Fixed(width))
         .align_items(Alignment::Center);
     let entries = get_host_entries(&sniffer.info_traffic, chart_type, sniffer.host_sort_type);
-    let first_entry_data_info = entries.first().unwrap().1.data_info;
+    let first_entry_data_info = entries
+        .iter()
+        .map(|(_, d)| d.data_info)
+        .max_by(|d1, d2| match chart_type {
+            ChartType::Packets => d1.tot_packets().cmp(&d2.tot_packets()),
+            ChartType::Bytes => d1.tot_bytes().cmp(&d2.tot_bytes()),
+        })
+        .unwrap_or_default();
 
     for (host, data_info_host) in &entries {
         let (incoming_bar_len, outgoing_bar_len) = get_bars_length(
@@ -380,7 +387,14 @@ fn col_service(width: f32, sniffer: &Sniffer) -> Column<'static, Message, Render
         .width(Length::Fixed(width))
         .align_items(Alignment::Center);
     let entries = get_service_entries(&sniffer.info_traffic, chart_type, sniffer.service_sort_type);
-    let first_entry_data_info = entries.first().unwrap().1;
+    let first_entry_data_info = entries
+        .iter()
+        .map(|&(_, d)| d)
+        .max_by(|d1, d2| match chart_type {
+            ChartType::Packets => d1.tot_packets().cmp(&d2.tot_packets()),
+            ChartType::Bytes => d1.tot_bytes().cmp(&d2.tot_bytes()),
+        })
+        .unwrap_or_default();
 
     for (service, data_info) in &entries {
         let (incoming_bar_len, outgoing_bar_len) =

--- a/src/gui/pages/overview_page.rs
+++ b/src/gui/pages/overview_page.rs
@@ -15,7 +15,6 @@ use iced::{Alignment, Font, Length, Renderer};
 
 use crate::countries::country_utils::get_flag_tooltip;
 use crate::countries::flags_pictures::FLAGS_WIDTH_BIG;
-use crate::countries::types::country::Country;
 use crate::gui::components::tab::get_pages_tabs;
 use crate::gui::styles::button::ButtonType;
 use crate::gui::styles::container::ContainerType;
@@ -333,16 +332,7 @@ fn col_host(width: f32, sniffer: &Sniffer) -> Column<'static, Message, Renderer<
         scroll_host = scroll_host.push(
             button(content)
                 .padding([5, 15, 5, 10])
-                .on_press(Message::Search(SearchParameters {
-                    domain: host.domain.clone(),
-                    as_name: host.asn.name.clone(),
-                    country: if host.country == Country::ZZ {
-                        String::new()
-                    } else {
-                        host.country.to_string()
-                    },
-                    ..SearchParameters::default()
-                }))
+                .on_press(Message::Search(SearchParameters::new_host_search(host)))
                 .style(ButtonType::Neutral),
         );
     }
@@ -417,10 +407,9 @@ fn col_service(width: f32, sniffer: &Sniffer) -> Column<'static, Message, Render
         scroll_service = scroll_service.push(
             button(content)
                 .padding([5, 15, 8, 10])
-                .on_press(Message::Search(SearchParameters {
-                    service: service.to_string_with_equal_prefix(),
-                    ..SearchParameters::default()
-                }))
+                .on_press(Message::Search(SearchParameters::new_service_search(
+                    service,
+                )))
                 .style(ButtonType::Neutral),
         );
     }

--- a/src/gui/pages/overview_page.rs
+++ b/src/gui/pages/overview_page.rs
@@ -687,13 +687,13 @@ fn get_bars_length(
 ) -> (f32, f32) {
     let (in_val, out_val, first_entry_tot_val) = match chart_type {
         ChartType::Packets => (
-            data_info.incoming_packets,
-            data_info.outgoing_packets,
+            data_info.incoming_packets(),
+            data_info.outgoing_packets(),
             first_entry.tot_packets(),
         ),
         ChartType::Bytes => (
-            data_info.incoming_bytes,
-            data_info.outgoing_bytes,
+            data_info.incoming_bytes(),
+            data_info.outgoing_bytes(),
             first_entry.tot_bytes(),
         ),
     };
@@ -850,20 +850,8 @@ mod tests {
 
     #[test]
     fn test_get_bars_length_simple() {
-        let first_entry = DataInfo {
-            incoming_packets: 50,
-            outgoing_packets: 50,
-            incoming_bytes: 150,
-            outgoing_bytes: 50,
-            final_timestamp: Default::default(),
-        };
-        let data_info = DataInfo {
-            incoming_packets: 25,
-            outgoing_packets: 55,
-            incoming_bytes: 165,
-            outgoing_bytes: 30,
-            final_timestamp: Default::default(),
-        };
+        let first_entry = DataInfo::new_for_tests(50, 50, 150, 50);
+        let data_info = DataInfo::new_for_tests(25, 55, 165, 30);
         assert_eq!(
             get_bars_length(200.0, ChartType::Packets, &first_entry, &data_info),
             (50.0, 110.0)
@@ -876,20 +864,8 @@ mod tests {
 
     #[test]
     fn test_get_bars_length_normalize_small_values() {
-        let first_entry = DataInfo {
-            incoming_packets: 50,
-            outgoing_packets: 50,
-            incoming_bytes: 150,
-            outgoing_bytes: 50,
-            final_timestamp: Default::default(),
-        };
-        let mut data_info = DataInfo {
-            incoming_packets: 2,
-            outgoing_packets: 1,
-            incoming_bytes: 1,
-            outgoing_bytes: 0,
-            final_timestamp: Default::default(),
-        };
+        let first_entry = DataInfo::new_for_tests(50, 50, 150, 50);
+        let mut data_info = DataInfo::new_for_tests(2, 1, 1, 0);
         assert_eq!(
             get_bars_length(200.0, ChartType::Packets, &first_entry, &data_info),
             (MIN_BARS_LENGTH / 2.0, MIN_BARS_LENGTH / 2.0)
@@ -899,13 +875,7 @@ mod tests {
             (MIN_BARS_LENGTH, 0.0)
         );
 
-        data_info = DataInfo {
-            incoming_packets: 0,
-            outgoing_packets: 3,
-            incoming_bytes: 0,
-            outgoing_bytes: 2,
-            ..data_info
-        };
+        data_info = DataInfo::new_for_tests(0, 3, 0, 2);
         assert_eq!(
             get_bars_length(200.0, ChartType::Packets, &first_entry, &data_info),
             (0.0, MIN_BARS_LENGTH)
@@ -918,20 +888,9 @@ mod tests {
 
     #[test]
     fn test_get_bars_length_normalize_very_small_values() {
-        let first_entry = DataInfo {
-            incoming_packets: u128::MAX / 2,
-            outgoing_packets: u128::MAX / 2,
-            incoming_bytes: u128::MAX / 2,
-            outgoing_bytes: u128::MAX / 2,
-            final_timestamp: Default::default(),
-        };
-        let mut data_info = DataInfo {
-            incoming_packets: 1,
-            outgoing_packets: 1,
-            incoming_bytes: 1,
-            outgoing_bytes: 1,
-            final_timestamp: Default::default(),
-        };
+        let first_entry =
+            DataInfo::new_for_tests(u128::MAX / 2, u128::MAX / 2, u128::MAX / 2, u128::MAX / 2);
+        let mut data_info = DataInfo::new_for_tests(1, 1, 1, 1);
         assert_eq!(
             get_bars_length(200.0, ChartType::Packets, &first_entry, &data_info),
             (MIN_BARS_LENGTH / 2.0, MIN_BARS_LENGTH / 2.0)
@@ -941,13 +900,7 @@ mod tests {
             (MIN_BARS_LENGTH / 2.0, MIN_BARS_LENGTH / 2.0)
         );
 
-        data_info = DataInfo {
-            incoming_packets: 0,
-            outgoing_packets: 1,
-            incoming_bytes: 0,
-            outgoing_bytes: 1,
-            ..data_info
-        };
+        data_info = DataInfo::new_for_tests(0, 1, 0, 1);
         assert_eq!(
             get_bars_length(200.0, ChartType::Packets, &first_entry, &data_info),
             (0.0, MIN_BARS_LENGTH)
@@ -957,13 +910,7 @@ mod tests {
             (0.0, MIN_BARS_LENGTH)
         );
 
-        data_info = DataInfo {
-            incoming_packets: 1,
-            outgoing_packets: 0,
-            incoming_bytes: 1,
-            outgoing_bytes: 0,
-            ..data_info
-        };
+        data_info = DataInfo::new_for_tests(1, 0, 1, 0);
         assert_eq!(
             get_bars_length(200.0, ChartType::Packets, &first_entry, &data_info),
             (MIN_BARS_LENGTH, 0.0)
@@ -976,21 +923,9 @@ mod tests {
 
     #[test]
     fn test_get_bars_length_complex() {
-        let first_entry = DataInfo {
-            incoming_packets: 350,
-            outgoing_packets: 50,
-            incoming_bytes: 12,
-            outgoing_bytes: 88,
-            final_timestamp: Default::default(),
-        };
+        let first_entry = DataInfo::new_for_tests(350, 50, 12, 88);
 
-        let mut data_info = DataInfo {
-            incoming_packets: 0,
-            outgoing_packets: 9,
-            incoming_bytes: 0,
-            outgoing_bytes: 10,
-            final_timestamp: Default::default(),
-        };
+        let mut data_info = DataInfo::new_for_tests(0, 9, 0, 10);
         assert_eq!(
             get_bars_length(722.0, ChartType::Packets, &first_entry, &data_info),
             (0.0, 16.245)
@@ -999,13 +934,7 @@ mod tests {
             get_bars_length(100.0, ChartType::Bytes, &first_entry, &data_info),
             (0.0, MIN_BARS_LENGTH)
         );
-        data_info = DataInfo {
-            incoming_packets: 9,
-            outgoing_packets: 0,
-            incoming_bytes: 13,
-            outgoing_bytes: 0,
-            ..data_info
-        };
+        data_info = DataInfo::new_for_tests(9, 0, 13, 0);
         assert_eq!(
             get_bars_length(722.0, ChartType::Packets, &first_entry, &data_info),
             (16.245, 0.0)
@@ -1015,13 +944,7 @@ mod tests {
             (13.0, 0.0)
         );
 
-        data_info = DataInfo {
-            incoming_packets: 4,
-            outgoing_packets: 5,
-            incoming_bytes: 6,
-            outgoing_bytes: 7,
-            ..data_info
-        };
+        data_info = DataInfo::new_for_tests(4, 5, 6, 7);
         assert_eq!(
             get_bars_length(722.0, ChartType::Packets, &first_entry, &data_info),
             (
@@ -1033,13 +956,7 @@ mod tests {
             get_bars_length(100.0, ChartType::Bytes, &first_entry, &data_info),
             (6.0, 7.0)
         );
-        data_info = DataInfo {
-            incoming_packets: 5,
-            outgoing_packets: 4,
-            incoming_bytes: 7,
-            outgoing_bytes: 6,
-            ..data_info
-        };
+        data_info = DataInfo::new_for_tests(5, 4, 7, 6);
         assert_eq!(
             get_bars_length(722.0, ChartType::Packets, &first_entry, &data_info),
             (
@@ -1052,13 +969,7 @@ mod tests {
             (7.0, 6.0)
         );
 
-        data_info = DataInfo {
-            incoming_packets: 1,
-            outgoing_packets: 8,
-            incoming_bytes: 1,
-            outgoing_bytes: 12,
-            ..data_info
-        };
+        data_info = DataInfo::new_for_tests(1, 8, 1, 12);
         assert_eq!(
             get_bars_length(722.0, ChartType::Packets, &first_entry, &data_info),
             (MIN_BARS_LENGTH / 2.0, 11.245)
@@ -1067,13 +978,7 @@ mod tests {
             get_bars_length(100.0, ChartType::Bytes, &first_entry, &data_info),
             (MIN_BARS_LENGTH / 2.0, 8.0)
         );
-        data_info = DataInfo {
-            incoming_packets: 8,
-            outgoing_packets: 1,
-            incoming_bytes: 12,
-            outgoing_bytes: 1,
-            ..data_info
-        };
+        data_info = DataInfo::new_for_tests(8, 1, 12, 1);
         assert_eq!(
             get_bars_length(722.0, ChartType::Packets, &first_entry, &data_info),
             (11.245, MIN_BARS_LENGTH / 2.0)
@@ -1083,13 +988,7 @@ mod tests {
             (8.0, MIN_BARS_LENGTH / 2.0)
         );
 
-        data_info = DataInfo {
-            incoming_packets: 6,
-            outgoing_packets: 1,
-            incoming_bytes: 10,
-            outgoing_bytes: 1,
-            ..data_info
-        };
+        data_info = DataInfo::new_for_tests(6, 1, 10, 1);
         assert_eq!(
             get_bars_length(722.0, ChartType::Packets, &first_entry, &data_info),
             (
@@ -1101,13 +1000,7 @@ mod tests {
             get_bars_length(100.0, ChartType::Bytes, &first_entry, &data_info),
             (6.0, MIN_BARS_LENGTH / 2.0)
         );
-        data_info = DataInfo {
-            incoming_packets: 1,
-            outgoing_packets: 6,
-            incoming_bytes: 1,
-            outgoing_bytes: 9,
-            ..data_info
-        };
+        data_info = DataInfo::new_for_tests(1, 6, 1, 9);
         assert_eq!(
             get_bars_length(722.0, ChartType::Packets, &first_entry, &data_info),
             (
@@ -1120,20 +1013,13 @@ mod tests {
             (MIN_BARS_LENGTH / 2.0, MIN_BARS_LENGTH / 2.0)
         );
 
-        data_info.incoming_bytes = 5;
-        data_info.outgoing_bytes = 5;
+        data_info = DataInfo::new_for_tests(1, 6, 5, 5);
         assert_eq!(
             get_bars_length(100.0, ChartType::Bytes, &first_entry, &data_info),
             (MIN_BARS_LENGTH / 2.0, MIN_BARS_LENGTH / 2.0)
         );
 
-        data_info = DataInfo {
-            incoming_packets: 0,
-            outgoing_packets: 0,
-            incoming_bytes: 0,
-            outgoing_bytes: 0,
-            ..data_info
-        };
+        data_info = DataInfo::new_for_tests(0, 0, 0, 0);
         assert_eq!(
             get_bars_length(722.0, ChartType::Packets, &first_entry, &data_info),
             (0.0, 0.0,)

--- a/src/gui/pages/overview_page.rs
+++ b/src/gui/pages/overview_page.rs
@@ -852,12 +852,14 @@ mod tests {
             outgoing_packets: 50,
             incoming_bytes: 150,
             outgoing_bytes: 50,
+            final_timestamp: Default::default(),
         };
         let data_info = DataInfo {
             incoming_packets: 25,
             outgoing_packets: 55,
             incoming_bytes: 165,
             outgoing_bytes: 30,
+            final_timestamp: Default::default(),
         };
         assert_eq!(
             get_bars_length(200.0, ChartType::Packets, &first_entry, &data_info),
@@ -876,12 +878,14 @@ mod tests {
             outgoing_packets: 50,
             incoming_bytes: 150,
             outgoing_bytes: 50,
+            final_timestamp: Default::default(),
         };
         let mut data_info = DataInfo {
             incoming_packets: 2,
             outgoing_packets: 1,
             incoming_bytes: 1,
             outgoing_bytes: 0,
+            final_timestamp: Default::default(),
         };
         assert_eq!(
             get_bars_length(200.0, ChartType::Packets, &first_entry, &data_info),
@@ -897,6 +901,7 @@ mod tests {
             outgoing_packets: 3,
             incoming_bytes: 0,
             outgoing_bytes: 2,
+            ..data_info
         };
         assert_eq!(
             get_bars_length(200.0, ChartType::Packets, &first_entry, &data_info),
@@ -915,12 +920,14 @@ mod tests {
             outgoing_packets: u128::MAX / 2,
             incoming_bytes: u128::MAX / 2,
             outgoing_bytes: u128::MAX / 2,
+            final_timestamp: Default::default(),
         };
         let mut data_info = DataInfo {
             incoming_packets: 1,
             outgoing_packets: 1,
             incoming_bytes: 1,
             outgoing_bytes: 1,
+            final_timestamp: Default::default(),
         };
         assert_eq!(
             get_bars_length(200.0, ChartType::Packets, &first_entry, &data_info),
@@ -936,6 +943,7 @@ mod tests {
             outgoing_packets: 1,
             incoming_bytes: 0,
             outgoing_bytes: 1,
+            ..data_info
         };
         assert_eq!(
             get_bars_length(200.0, ChartType::Packets, &first_entry, &data_info),
@@ -951,6 +959,7 @@ mod tests {
             outgoing_packets: 0,
             incoming_bytes: 1,
             outgoing_bytes: 0,
+            ..data_info
         };
         assert_eq!(
             get_bars_length(200.0, ChartType::Packets, &first_entry, &data_info),
@@ -969,6 +978,7 @@ mod tests {
             outgoing_packets: 50,
             incoming_bytes: 12,
             outgoing_bytes: 88,
+            final_timestamp: Default::default(),
         };
 
         let mut data_info = DataInfo {
@@ -976,6 +986,7 @@ mod tests {
             outgoing_packets: 9,
             incoming_bytes: 0,
             outgoing_bytes: 10,
+            final_timestamp: Default::default(),
         };
         assert_eq!(
             get_bars_length(722.0, ChartType::Packets, &first_entry, &data_info),
@@ -990,6 +1001,7 @@ mod tests {
             outgoing_packets: 0,
             incoming_bytes: 13,
             outgoing_bytes: 0,
+            ..data_info
         };
         assert_eq!(
             get_bars_length(722.0, ChartType::Packets, &first_entry, &data_info),
@@ -1005,6 +1017,7 @@ mod tests {
             outgoing_packets: 5,
             incoming_bytes: 6,
             outgoing_bytes: 7,
+            ..data_info
         };
         assert_eq!(
             get_bars_length(722.0, ChartType::Packets, &first_entry, &data_info),
@@ -1022,6 +1035,7 @@ mod tests {
             outgoing_packets: 4,
             incoming_bytes: 7,
             outgoing_bytes: 6,
+            ..data_info
         };
         assert_eq!(
             get_bars_length(722.0, ChartType::Packets, &first_entry, &data_info),
@@ -1040,6 +1054,7 @@ mod tests {
             outgoing_packets: 8,
             incoming_bytes: 1,
             outgoing_bytes: 12,
+            ..data_info
         };
         assert_eq!(
             get_bars_length(722.0, ChartType::Packets, &first_entry, &data_info),
@@ -1054,6 +1069,7 @@ mod tests {
             outgoing_packets: 1,
             incoming_bytes: 12,
             outgoing_bytes: 1,
+            ..data_info
         };
         assert_eq!(
             get_bars_length(722.0, ChartType::Packets, &first_entry, &data_info),
@@ -1069,6 +1085,7 @@ mod tests {
             outgoing_packets: 1,
             incoming_bytes: 10,
             outgoing_bytes: 1,
+            ..data_info
         };
         assert_eq!(
             get_bars_length(722.0, ChartType::Packets, &first_entry, &data_info),
@@ -1086,6 +1103,7 @@ mod tests {
             outgoing_packets: 6,
             incoming_bytes: 1,
             outgoing_bytes: 9,
+            ..data_info
         };
         assert_eq!(
             get_bars_length(722.0, ChartType::Packets, &first_entry, &data_info),
@@ -1111,6 +1129,7 @@ mod tests {
             outgoing_packets: 0,
             incoming_bytes: 0,
             outgoing_bytes: 0,
+            ..data_info
         };
         assert_eq!(
             get_bars_length(722.0, ChartType::Packets, &first_entry, &data_info),

--- a/src/gui/pages/overview_page.rs
+++ b/src/gui/pages/overview_page.rs
@@ -278,10 +278,7 @@ fn col_host(width: f32, sniffer: &Sniffer) -> Column<'static, Message, Renderer<
     let first_entry_data_info = entries
         .iter()
         .map(|(_, d)| d.data_info)
-        .max_by(|d1, d2| match chart_type {
-            ChartType::Packets => d1.tot_packets().cmp(&d2.tot_packets()),
-            ChartType::Bytes => d1.tot_bytes().cmp(&d2.tot_bytes()),
-        })
+        .max_by(|d1, d2| d1.compare(d2, SortType::Ascending, chart_type))
         .unwrap_or_default();
 
     for (host, data_info_host) in &entries {
@@ -390,10 +387,7 @@ fn col_service(width: f32, sniffer: &Sniffer) -> Column<'static, Message, Render
     let first_entry_data_info = entries
         .iter()
         .map(|&(_, d)| d)
-        .max_by(|d1, d2| match chart_type {
-            ChartType::Packets => d1.tot_packets().cmp(&d2.tot_packets()),
-            ChartType::Bytes => d1.tot_bytes().cmp(&d2.tot_bytes()),
-        })
+        .max_by(|d1, d2| d1.compare(d2, SortType::Ascending, chart_type))
         .unwrap_or_default();
 
     for (service, data_info) in &entries {

--- a/src/gui/types/message.rs
+++ b/src/gui/types/message.rs
@@ -7,6 +7,7 @@ use crate::gui::styles::types::gradient_type::GradientType;
 use crate::networking::types::host::Host;
 use crate::notifications::types::notifications::Notification;
 use crate::report::types::search_parameters::SearchParameters;
+use crate::report::types::sort_type::SortType;
 use crate::utils::types::file_info::FileInfo;
 use crate::utils::types::web_page::WebPage;
 use crate::{ChartType, IpVersion, Language, Protocol, ReportSortType, StyleType};
@@ -30,8 +31,12 @@ pub enum Message {
     PortFilter(String),
     /// Select chart type to be displayed
     ChartSelection(ChartType),
-    /// Select report type to be displayed
+    /// Select report sort type to be displayed (inspect page)
     ReportSortSelection(ReportSortType),
+    /// Select host sort type to be displayed (overview page)
+    HostSortSelection(SortType),
+    /// Select service sort type to be displayed (overview page)
+    ServiceSortSelection(SortType),
     /// Adds or removes the given host into/from the favorites
     AddOrRemoveFavorite(Host, bool),
     /// Open the supplied web page

--- a/src/gui/types/sniffer.rs
+++ b/src/gui/types/sniffer.rs
@@ -34,6 +34,7 @@ use crate::notifications::types::sound::{play, Sound};
 use crate::report::get_report_entries::get_searched_entries;
 use crate::report::types::report_sort_type::ReportSortType;
 use crate::report::types::search_parameters::SearchParameters;
+use crate::report::types::sort_type::SortType;
 use crate::secondary_threads::parse_packets::parse_packets;
 use crate::translations::types::language::Language;
 use crate::utils::types::file_info::FileInfo;
@@ -64,8 +65,12 @@ pub struct Sniffer {
     pub waiting: String,
     /// Chart displayed
     pub traffic_chart: TrafficChart,
-    /// Report type to be displayed
+    /// Report sort type (inspect page)
     pub report_sort_type: ReportSortType,
+    /// Host sort type (overview page)
+    pub host_sort_type: SortType,
+    /// Service sort type (overview page)
+    pub service_sort_type: SortType,
     /// Currently displayed modal; None if no modal is displayed
     pub modal: Option<MyModal>,
     /// Currently displayed settings page; None if settings is closed
@@ -113,6 +118,8 @@ impl Sniffer {
             waiting: ".".to_string(),
             traffic_chart: TrafficChart::new(style, language),
             report_sort_type: ReportSortType::default(),
+            host_sort_type: SortType::default(),
+            service_sort_type: SortType::default(),
             modal: None,
             settings_page: None,
             last_opened_setting: SettingsPage::Notifications,
@@ -302,6 +309,12 @@ impl Sniffer {
                     ),
                     consumer_message,
                 );
+            }
+            Message::HostSortSelection(sort_type) => {
+                self.host_sort_type = sort_type;
+            }
+            Message::ServiceSortSelection(sort_type) => {
+                self.service_sort_type = sort_type;
             }
             Message::TickInit | Message::FontLoaded(_) => {}
         }

--- a/src/gui/types/sniffer.rs
+++ b/src/gui/types/sniffer.rs
@@ -792,6 +792,50 @@ mod tests {
 
     #[test]
     #[parallel] // needed to not collide with other tests generating configs files
+    fn test_correctly_update_host_sort_kind() {
+        let mut sniffer = new_sniffer();
+
+        let mut sort = SortType::Neutral;
+
+        assert_eq!(sniffer.host_sort_type, sort);
+
+        sort = sort.next_sort();
+        sniffer.update(Message::HostSortSelection(sort));
+        assert_eq!(sniffer.host_sort_type, SortType::Descending);
+
+        sort = sort.next_sort();
+        sniffer.update(Message::HostSortSelection(sort));
+        assert_eq!(sniffer.host_sort_type, SortType::Ascending);
+
+        sort = sort.next_sort();
+        sniffer.update(Message::HostSortSelection(sort));
+        assert_eq!(sniffer.host_sort_type, SortType::Neutral);
+    }
+
+    #[test]
+    #[parallel] // needed to not collide with other tests generating configs files
+    fn test_correctly_update_service_sort_kind() {
+        let mut sniffer = new_sniffer();
+
+        let mut sort = SortType::Neutral;
+
+        assert_eq!(sniffer.service_sort_type, sort);
+
+        sort = sort.next_sort();
+        sniffer.update(Message::ServiceSortSelection(sort));
+        assert_eq!(sniffer.service_sort_type, SortType::Descending);
+
+        sort = sort.next_sort();
+        sniffer.update(Message::ServiceSortSelection(sort));
+        assert_eq!(sniffer.service_sort_type, SortType::Ascending);
+
+        sort = sort.next_sort();
+        sniffer.update(Message::ServiceSortSelection(sort));
+        assert_eq!(sniffer.service_sort_type, SortType::Neutral);
+    }
+
+    #[test]
+    #[parallel] // needed to not collide with other tests generating configs files
     fn test_correctly_update_style() {
         let mut sniffer = new_sniffer();
 

--- a/src/networking/types/data_info.rs
+++ b/src/networking/types/data_info.rs
@@ -1,9 +1,12 @@
 //! Module defining the `DataInfo` struct, which represents incoming and outgoing packets and bytes.
 
+use crate::chart::types::chart_type::ChartType;
 use chrono::{DateTime, Local};
+use std::cmp::Ordering;
 use std::ops::AddAssign;
 
 use crate::networking::types::traffic_direction::TrafficDirection;
+use crate::report::types::sort_type::SortType;
 
 /// Amount of exchanged data (packets and bytes) incoming and outgoing, with the timestamp of the latest occurrence
 // data fields are private to make them only editable via the provided methods: needed to correctly refresh timestamps
@@ -74,6 +77,21 @@ impl DataInfo {
                 outgoing_bytes: 0,
                 final_timestamp: Local::now(),
             }
+        }
+    }
+
+    pub fn compare(&self, other: &Self, sort_type: SortType, chart_type: ChartType) -> Ordering {
+        match chart_type {
+            ChartType::Packets => match sort_type {
+                SortType::Ascending => self.tot_packets().cmp(&other.tot_packets()),
+                SortType::Descending => other.tot_packets().cmp(&self.tot_packets()),
+                SortType::Neutral => other.final_timestamp.cmp(&self.final_timestamp),
+            },
+            ChartType::Bytes => match sort_type {
+                SortType::Ascending => self.tot_bytes().cmp(&other.tot_bytes()),
+                SortType::Descending => other.tot_bytes().cmp(&self.tot_bytes()),
+                SortType::Neutral => other.final_timestamp.cmp(&self.final_timestamp),
+            },
         }
     }
 

--- a/src/networking/types/data_info.rs
+++ b/src/networking/types/data_info.rs
@@ -6,21 +6,38 @@ use std::ops::AddAssign;
 use crate::networking::types::traffic_direction::TrafficDirection;
 
 /// Amount of exchanged data (packets and bytes) incoming and outgoing, with the timestamp of the latest occurrence
+// data fields are private to make them only editable via the provided methods: needed to correctly refresh timestamps
 #[derive(Clone, Default, Copy)]
 pub struct DataInfo {
     /// Incoming packets
-    pub incoming_packets: u128,
+    incoming_packets: u128,
     /// Outgoing packets
-    pub outgoing_packets: u128,
+    outgoing_packets: u128,
     /// Incoming bytes
-    pub incoming_bytes: u128,
+    incoming_bytes: u128,
     /// Outgoing bytes
-    pub outgoing_bytes: u128,
+    outgoing_bytes: u128,
     /// Latest time of occurrence
     pub final_timestamp: DateTime<Local>,
 }
 
 impl DataInfo {
+    pub fn incoming_packets(&self) -> u128 {
+        self.incoming_packets
+    }
+
+    pub fn outgoing_packets(&self) -> u128 {
+        self.outgoing_packets
+    }
+
+    pub fn incoming_bytes(&self) -> u128 {
+        self.incoming_bytes
+    }
+
+    pub fn outgoing_bytes(&self) -> u128 {
+        self.outgoing_bytes
+    }
+
     pub fn tot_packets(&self) -> u128 {
         self.incoming_packets + self.outgoing_packets
     }
@@ -57,6 +74,22 @@ impl DataInfo {
                 outgoing_bytes: 0,
                 final_timestamp: Local::now(),
             }
+        }
+    }
+
+    #[cfg(test)]
+    pub fn new_for_tests(
+        incoming_packets: u128,
+        outgoing_packets: u128,
+        incoming_bytes: u128,
+        outgoing_bytes: u128,
+    ) -> Self {
+        Self {
+            incoming_packets,
+            outgoing_packets,
+            incoming_bytes,
+            outgoing_bytes,
+            final_timestamp: Default::default(),
         }
     }
 }

--- a/src/networking/types/data_info.rs
+++ b/src/networking/types/data_info.rs
@@ -1,10 +1,11 @@
 //! Module defining the `DataInfo` struct, which represents incoming and outgoing packets and bytes.
 
+use chrono::{DateTime, Local};
 use std::ops::AddAssign;
 
 use crate::networking::types::traffic_direction::TrafficDirection;
 
-/// Amount of exchanged data (packets and bytes) incoming and outgoing
+/// Amount of exchanged data (packets and bytes) incoming and outgoing, with the timestamp of the latest occurrence
 #[derive(Clone, Default, Copy)]
 pub struct DataInfo {
     /// Incoming packets
@@ -15,6 +16,8 @@ pub struct DataInfo {
     pub incoming_bytes: u128,
     /// Outgoing bytes
     pub outgoing_bytes: u128,
+    /// Latest time of occurrence
+    pub final_timestamp: DateTime<Local>,
 }
 
 impl DataInfo {
@@ -34,6 +37,7 @@ impl DataInfo {
             self.incoming_packets += 1;
             self.incoming_bytes += bytes;
         }
+        self.final_timestamp = Local::now();
     }
 
     pub fn new_with_first_packet(bytes: u128, traffic_direction: TrafficDirection) -> Self {
@@ -43,6 +47,7 @@ impl DataInfo {
                 outgoing_packets: 1,
                 incoming_bytes: 0,
                 outgoing_bytes: bytes,
+                final_timestamp: Local::now(),
             }
         } else {
             Self {
@@ -50,6 +55,7 @@ impl DataInfo {
                 outgoing_packets: 0,
                 incoming_bytes: bytes,
                 outgoing_bytes: 0,
+                final_timestamp: Local::now(),
             }
         }
     }
@@ -61,5 +67,6 @@ impl AddAssign for DataInfo {
         self.outgoing_packets += rhs.outgoing_packets;
         self.incoming_bytes += rhs.incoming_bytes;
         self.outgoing_bytes += rhs.outgoing_bytes;
+        self.final_timestamp = Local::now();
     }
 }

--- a/src/networking/types/data_info.rs
+++ b/src/networking/types/data_info.rs
@@ -21,7 +21,7 @@ pub struct DataInfo {
     /// Outgoing bytes
     outgoing_bytes: u128,
     /// Latest time of occurrence
-    pub final_timestamp: DateTime<Local>,
+    final_timestamp: DateTime<Local>,
 }
 
 impl DataInfo {

--- a/src/report/get_report_entries.rs
+++ b/src/report/get_report_entries.rs
@@ -73,24 +73,7 @@ pub fn get_host_entries(
     let info_traffic_lock = info_traffic.lock().unwrap();
     let mut sorted_vec: Vec<(&Host, &DataInfoHost)> = info_traffic_lock.hosts.iter().collect();
 
-    sorted_vec.sort_by(|&(_, a), &(_, b)| match chart_type {
-        ChartType::Packets => match sort_type {
-            SortType::Ascending => a.data_info.tot_packets().cmp(&b.data_info.tot_packets()),
-            SortType::Descending => b.data_info.tot_packets().cmp(&a.data_info.tot_packets()),
-            SortType::Neutral => b
-                .data_info
-                .final_timestamp
-                .cmp(&a.data_info.final_timestamp),
-        },
-        ChartType::Bytes => match sort_type {
-            SortType::Ascending => a.data_info.tot_bytes().cmp(&b.data_info.tot_bytes()),
-            SortType::Descending => b.data_info.tot_bytes().cmp(&a.data_info.tot_bytes()),
-            SortType::Neutral => b
-                .data_info
-                .final_timestamp
-                .cmp(&a.data_info.final_timestamp),
-        },
-    });
+    sorted_vec.sort_by(|&(_, a), &(_, b)| a.data_info.compare(&b.data_info, sort_type, chart_type));
 
     let n_entry = min(sorted_vec.len(), 30);
     sorted_vec[0..n_entry]
@@ -111,18 +94,7 @@ pub fn get_service_entries(
         .filter(|(service, _)| service != &&Service::NotApplicable)
         .collect();
 
-    sorted_vec.sort_by(|&(_, a), &(_, b)| match chart_type {
-        ChartType::Packets => match sort_type {
-            SortType::Ascending => a.tot_packets().cmp(&b.tot_packets()),
-            SortType::Descending => b.tot_packets().cmp(&a.tot_packets()),
-            SortType::Neutral => b.final_timestamp.cmp(&a.final_timestamp),
-        },
-        ChartType::Bytes => match sort_type {
-            SortType::Ascending => a.tot_bytes().cmp(&b.tot_bytes()),
-            SortType::Descending => b.tot_bytes().cmp(&a.tot_bytes()),
-            SortType::Neutral => b.final_timestamp.cmp(&a.final_timestamp),
-        },
-    });
+    sorted_vec.sort_by(|&(_, a), &(_, b)| a.compare(b, sort_type, chart_type));
 
     let n_entry = min(sorted_vec.len(), 30);
     sorted_vec[0..n_entry]

--- a/src/report/get_report_entries.rs
+++ b/src/report/get_report_entries.rs
@@ -68,13 +68,28 @@ pub fn get_searched_entries(
 pub fn get_host_entries(
     info_traffic: &Arc<Mutex<InfoTraffic>>,
     chart_type: ChartType,
+    sort_type: SortType,
 ) -> Vec<(Host, DataInfoHost)> {
     let info_traffic_lock = info_traffic.lock().unwrap();
     let mut sorted_vec: Vec<(&Host, &DataInfoHost)> = info_traffic_lock.hosts.iter().collect();
 
     sorted_vec.sort_by(|&(_, a), &(_, b)| match chart_type {
-        ChartType::Packets => b.data_info.tot_packets().cmp(&a.data_info.tot_packets()),
-        ChartType::Bytes => b.data_info.tot_bytes().cmp(&a.data_info.tot_bytes()),
+        ChartType::Packets => match sort_type {
+            SortType::Ascending => a.data_info.tot_packets().cmp(&b.data_info.tot_packets()),
+            SortType::Descending => b.data_info.tot_packets().cmp(&a.data_info.tot_packets()),
+            SortType::Neutral => b
+                .data_info
+                .final_timestamp
+                .cmp(&a.data_info.final_timestamp),
+        },
+        ChartType::Bytes => match sort_type {
+            SortType::Ascending => a.data_info.tot_bytes().cmp(&b.data_info.tot_bytes()),
+            SortType::Descending => b.data_info.tot_bytes().cmp(&a.data_info.tot_bytes()),
+            SortType::Neutral => b
+                .data_info
+                .final_timestamp
+                .cmp(&a.data_info.final_timestamp),
+        },
     });
 
     let n_entry = min(sorted_vec.len(), 30);
@@ -87,6 +102,7 @@ pub fn get_host_entries(
 pub fn get_service_entries(
     info_traffic: &Arc<Mutex<InfoTraffic>>,
     chart_type: ChartType,
+    sort_type: SortType,
 ) -> Vec<(Service, DataInfo)> {
     let info_traffic_lock = info_traffic.lock().unwrap();
     let mut sorted_vec: Vec<(&Service, &DataInfo)> = info_traffic_lock
@@ -96,8 +112,16 @@ pub fn get_service_entries(
         .collect();
 
     sorted_vec.sort_by(|&(_, a), &(_, b)| match chart_type {
-        ChartType::Packets => b.tot_packets().cmp(&a.tot_packets()),
-        ChartType::Bytes => b.tot_bytes().cmp(&a.tot_bytes()),
+        ChartType::Packets => match sort_type {
+            SortType::Ascending => a.tot_packets().cmp(&b.tot_packets()),
+            SortType::Descending => b.tot_packets().cmp(&a.tot_packets()),
+            SortType::Neutral => b.final_timestamp.cmp(&a.final_timestamp),
+        },
+        ChartType::Bytes => match sort_type {
+            SortType::Ascending => a.tot_bytes().cmp(&b.tot_bytes()),
+            SortType::Descending => b.tot_bytes().cmp(&a.tot_bytes()),
+            SortType::Neutral => b.final_timestamp.cmp(&a.final_timestamp),
+        },
     });
 
     let n_entry = min(sorted_vec.len(), 30);

--- a/src/report/types/report_sort_type.rs
+++ b/src/report/types/report_sort_type.rs
@@ -10,7 +10,7 @@ use crate::report::types::sort_type::SortType;
 use crate::utils::types::icon::Icon;
 
 /// Struct representing the possible kinds of sort for displayed relevant connections.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct ReportSortType {
     pub byte_sort: SortType,
     pub packet_sort: SortType,
@@ -20,70 +20,30 @@ impl ReportSortType {
     pub fn next_sort(self, report_col: &ReportCol) -> Self {
         match report_col {
             ReportCol::Bytes => Self {
-                byte_sort: match self.byte_sort {
-                    SortType::Ascending => SortType::Neutral,
-                    SortType::Descending => SortType::Ascending,
-                    SortType::Neutral => SortType::Descending,
-                },
+                byte_sort: self.byte_sort.next_sort(),
                 packet_sort: SortType::Neutral,
             },
             ReportCol::Packets => Self {
                 byte_sort: SortType::Neutral,
-                packet_sort: match self.packet_sort {
-                    SortType::Ascending => SortType::Neutral,
-                    SortType::Descending => SortType::Ascending,
-                    SortType::Neutral => SortType::Descending,
-                },
+                packet_sort: self.packet_sort.next_sort(),
             },
             _ => Self::default(),
         }
     }
 
     pub fn icon(self, report_col: &ReportCol) -> Text<'static, Renderer<StyleType>> {
-        let mut size = 14;
         match report_col {
-            ReportCol::Bytes => match self.byte_sort {
-                SortType::Ascending => Icon::SortAscending,
-                SortType::Descending => Icon::SortDescending,
-                SortType::Neutral => {
-                    size = 18;
-                    Icon::SortNeutral
-                }
-            },
-            ReportCol::Packets => match self.packet_sort {
-                SortType::Ascending => Icon::SortAscending,
-                SortType::Descending => Icon::SortDescending,
-                SortType::Neutral => {
-                    size = 18;
-                    Icon::SortNeutral
-                }
-            },
-            _ => Icon::SortNeutral,
+            ReportCol::Bytes => self.byte_sort.icon(),
+            ReportCol::Packets => self.packet_sort.icon(),
+            _ => Icon::SortNeutral.to_text(),
         }
-        .to_text()
-        .size(size)
     }
 
     pub fn button_type(self, report_col: &ReportCol) -> ButtonType {
         match report_col {
-            ReportCol::Bytes => match self.byte_sort {
-                SortType::Ascending | SortType::Descending => ButtonType::SortArrowActive,
-                SortType::Neutral => ButtonType::SortArrows,
-            },
-            ReportCol::Packets => match self.packet_sort {
-                SortType::Ascending | SortType::Descending => ButtonType::SortArrowActive,
-                SortType::Neutral => ButtonType::SortArrows,
-            },
+            ReportCol::Bytes => self.byte_sort.button_type(),
+            ReportCol::Packets => self.packet_sort.button_type(),
             _ => ButtonType::SortArrows,
-        }
-    }
-}
-
-impl Default for ReportSortType {
-    fn default() -> Self {
-        Self {
-            byte_sort: SortType::Neutral,
-            packet_sort: SortType::Neutral,
         }
     }
 }

--- a/src/report/types/search_parameters.rs
+++ b/src/report/types/search_parameters.rs
@@ -1,6 +1,8 @@
+use crate::countries::types::country::Country;
 use crate::networking::types::address_port_pair::AddressPortPair;
 use crate::networking::types::host::Host;
 use crate::networking::types::info_address_port_pair::InfoAddressPortPair;
+use crate::networking::types::service::Service;
 
 /// Used to express the search filters applied to GUI inspect page
 #[derive(Clone, Debug, Default, Hash)]
@@ -69,6 +71,26 @@ impl SearchParameters {
             as_name: String::new(),
             only_favorites: false,
             ..self.clone()
+        }
+    }
+
+    pub fn new_host_search(host: &Host) -> Self {
+        Self {
+            domain: host.domain.clone(),
+            as_name: host.asn.name.clone(),
+            country: if host.country == Country::ZZ {
+                String::new()
+            } else {
+                host.country.to_string()
+            },
+            ..SearchParameters::default()
+        }
+    }
+
+    pub fn new_service_search(service: &Service) -> Self {
+        Self {
+            service: service.to_string_with_equal_prefix(),
+            ..SearchParameters::default()
         }
     }
 }

--- a/src/report/types/sort_type.rs
+++ b/src/report/types/sort_type.rs
@@ -1,6 +1,44 @@
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+use crate::gui::styles::button::ButtonType;
+use crate::gui::styles::types::style_type::StyleType;
+use crate::utils::types::icon::Icon;
+use iced::widget::Text;
+use iced::Renderer;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum SortType {
     Ascending,
     Descending,
+    #[default]
     Neutral,
+}
+
+impl SortType {
+    pub fn next_sort(self) -> Self {
+        match self {
+            SortType::Ascending => SortType::Neutral,
+            SortType::Descending => SortType::Ascending,
+            SortType::Neutral => SortType::Descending,
+        }
+    }
+
+    pub fn icon(self) -> Text<'static, Renderer<StyleType>> {
+        let mut size = 14;
+        match self {
+            SortType::Ascending => Icon::SortAscending,
+            SortType::Descending => Icon::SortDescending,
+            SortType::Neutral => {
+                size = 18;
+                Icon::SortNeutral
+            }
+        }
+        .to_text()
+        .size(size)
+    }
+
+    pub fn button_type(self) -> ButtonType {
+        match self {
+            SortType::Ascending | SortType::Descending => ButtonType::SortArrowActive,
+            SortType::Neutral => ButtonType::SortArrows,
+        }
+    }
 }


### PR DESCRIPTION
Until now, network hosts and services in overview page were always sorted by descending value of cumulative transmitted data (bytes or packets).
This was pretty limiting, primarily because the user couldn't easily see the most recent items involved in network traffic exchanges.

This PR implements the possibility to set a sorting strategy for both the network host and service lists.

By default, items are now sorted by most recent timestamp of last data exchange.
With a simple click users can change this behaviour to sort items by ascending/descending value of cumulative transmitted data (bytes or packets).