### PR TITLE
Use smoother curves to interpolate traffic chart data points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All Sniffnet releases with the relative changes are documented in this file.
 - Added support for more link types in addition to Ethernet: raw IP packets and null/loopback packets are now correctly parsed ([#421](https://github.com/GyulyVGC/sniffnet/pull/421))
 - Support changing sort strategy for network hosts and services in overview page, showing most recent items by default ([#452](https://github.com/GyulyVGC/sniffnet/pull/452))
 - IP addresses can now be copied to clipboard from the popup related to a given entry of the connections table, and a new search parameter has been introduced in Inspect page to allow users filter their connections based on IP address values ([#409](https://github.com/GyulyVGC/sniffnet/pull/409))
+- Traffic chart is now smoother and overall better-looking thanks to the new spline-based interpolation ([#461](https://github.com/GyulyVGC/sniffnet/pull/461))
 - Added Japanese translation 🇯🇵 ([#343](https://github.com/GyulyVGC/sniffnet/pull/343))
 - Added Uzbek translation 🇺🇿 ([#385](https://github.com/GyulyVGC/sniffnet/pull/385))
 - Window size and position are now remembered, so that Sniffnet can reopen with the same window properties
@@ -29,6 +30,7 @@ All Sniffnet releases with the relative changes are documented in this file.
 - Fixed a build failure on `powerpc64` ([#356](https://github.com/GyulyVGC/sniffnet/pull/356) — fixes [#353](https://github.com/GyulyVGC/sniffnet/issues/353))
 - Fixed a typo in Russian translation ([#389](https://github.com/GyulyVGC/sniffnet/pull/389))
 - Fixed icon inconsistency in case of directed broadcast traffic
+- Made byte strings consistent across the app, and added support for Terabytes and Petabytes representations
 - Fixed hosts and services data bar lengths inconsistencies in overview page
 
 ## [1.2.2] - 2023-08-08

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3567,6 +3567,7 @@ dependencies = [
  "serde",
  "serde_test",
  "serial_test",
+ "splines",
  "toml 0.8.10",
  "winres",
 ]
@@ -3624,6 +3625,12 @@ dependencies = [
  "bitflags 1.3.2",
  "num-traits",
 ]
+
+[[package]]
+name = "splines"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "228c4551e53c672e86439509545dd7ffcb966b6876c58b108e433a30e6117101"
 
 [[package]]
 name = "static_assertions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ ctrlc = { version = "3.4.2", features = ["termination"] }
 rfd = "0.13.0"
 phf = "0.11.2"
 phf_shared = "0.11.2"
+splines = "4.3.1"
 
 [target.'cfg(not(target_arch = "powerpc64"))'.dependencies]
 reqwest = { version = "0.11.24", default-features = false, features = ["json", "blocking", "rustls-tls"] }

--- a/src/chart/manage_chart_data.rs
+++ b/src/chart/manage_chart_data.rs
@@ -17,43 +17,43 @@ pub fn update_charts_data(runtime_data: &mut RunTimeData, traffic_chart: &mut Tr
         runtime_data.tot_received_packets - runtime_data.tot_received_packets_prev;
 
     // update sent bytes traffic data
-    if traffic_chart.sent_bytes.len() >= 30 {
-        traffic_chart.sent_bytes.pop_front();
+    if traffic_chart.out_bytes.len() >= 30 {
+        traffic_chart.out_bytes.pop_front();
     }
-    traffic_chart.sent_bytes.push_back((
+    traffic_chart.out_bytes.push_back((
         tot_seconds,
         -<u128 as TryInto<i64>>::try_into(sent_bytes_entry).unwrap(),
     ));
-    traffic_chart.min_bytes = get_min(&traffic_chart.sent_bytes);
+    traffic_chart.min_bytes = get_min(&traffic_chart.out_bytes);
     runtime_data.tot_sent_bytes_prev = runtime_data.tot_sent_bytes;
     // update received bytes traffic data
-    if traffic_chart.received_bytes.len() >= 30 {
-        traffic_chart.received_bytes.pop_front();
+    if traffic_chart.in_bytes.len() >= 30 {
+        traffic_chart.in_bytes.pop_front();
     }
     traffic_chart
-        .received_bytes
+        .in_bytes
         .push_back((tot_seconds, received_bytes_entry.try_into().unwrap()));
-    traffic_chart.max_bytes = get_max(&traffic_chart.received_bytes);
+    traffic_chart.max_bytes = get_max(&traffic_chart.in_bytes);
     runtime_data.tot_received_bytes_prev = runtime_data.tot_received_bytes;
 
     // update sent packets traffic data
-    if traffic_chart.sent_packets.len() >= 30 {
-        traffic_chart.sent_packets.pop_front();
+    if traffic_chart.out_packets.len() >= 30 {
+        traffic_chart.out_packets.pop_front();
     }
-    traffic_chart.sent_packets.push_back((
+    traffic_chart.out_packets.push_back((
         tot_seconds,
         -<u128 as TryInto<i64>>::try_into(sent_packets_entry).unwrap(),
     ));
-    traffic_chart.min_packets = get_min(&traffic_chart.sent_packets);
+    traffic_chart.min_packets = get_min(&traffic_chart.out_packets);
     runtime_data.tot_sent_packets_prev = runtime_data.tot_sent_packets;
     // update received packets traffic data
-    if traffic_chart.received_packets.len() >= 30 {
-        traffic_chart.received_packets.pop_front();
+    if traffic_chart.in_packets.len() >= 30 {
+        traffic_chart.in_packets.pop_front();
     }
     traffic_chart
-        .received_packets
+        .in_packets
         .push_back((tot_seconds, received_packets_entry.try_into().unwrap()));
-    traffic_chart.max_packets = get_max(&traffic_chart.received_packets);
+    traffic_chart.max_packets = get_max(&traffic_chart.in_packets);
     runtime_data.tot_received_packets_prev = runtime_data.tot_received_packets;
 }
 
@@ -154,10 +154,10 @@ mod tests {
         let tot_received = 21000 * 28 + 1000;
         let mut traffic_chart = TrafficChart {
             ticks: 29,
-            sent_bytes: sent.clone(),
-            received_bytes: received.clone(),
-            sent_packets: sent.clone(),
-            received_packets: received.clone(),
+            out_bytes: sent.clone(),
+            in_bytes: received.clone(),
+            out_packets: sent.clone(),
+            in_packets: received.clone(),
             min_bytes: -1000,
             max_bytes: 21000,
             min_packets: -1000,
@@ -187,8 +187,8 @@ mod tests {
 
         update_charts_data(&mut runtime_data, &mut traffic_chart);
 
-        assert_eq!(get_min(&traffic_chart.sent_packets), -3333);
-        assert_eq!(get_max(&traffic_chart.received_bytes), 21000);
+        assert_eq!(get_min(&traffic_chart.out_packets), -3333);
+        assert_eq!(get_max(&traffic_chart.in_bytes), 21000);
 
         // runtime_data correctly updated?
         assert_eq!(runtime_data.tot_sent_bytes_prev, tot_sent + 1111);
@@ -211,10 +211,10 @@ mod tests {
         assert_eq!(traffic_chart.min_packets, -3333);
         assert_eq!(traffic_chart.max_bytes, 21000);
         assert_eq!(traffic_chart.max_packets, 21000);
-        assert_eq!(traffic_chart.sent_bytes, sent_bytes);
-        assert_eq!(traffic_chart.received_packets, received_packets);
-        assert_eq!(traffic_chart.sent_packets, sent_packets);
-        assert_eq!(traffic_chart.received_bytes, received_bytes);
+        assert_eq!(traffic_chart.out_bytes, sent_bytes);
+        assert_eq!(traffic_chart.in_packets, received_packets);
+        assert_eq!(traffic_chart.out_packets, sent_packets);
+        assert_eq!(traffic_chart.in_bytes, received_bytes);
 
         runtime_data.tot_sent_bytes += 99;
         runtime_data.tot_received_packets += 990;
@@ -248,9 +248,9 @@ mod tests {
         assert_eq!(traffic_chart.min_packets, -3333);
         assert_eq!(traffic_chart.max_bytes, 21000);
         assert_eq!(traffic_chart.max_packets, 21000);
-        assert_eq!(traffic_chart.sent_bytes, sent_bytes);
-        assert_eq!(traffic_chart.received_packets, received_packets);
-        assert_eq!(traffic_chart.sent_packets, sent_packets);
-        assert_eq!(traffic_chart.received_bytes, received_bytes);
+        assert_eq!(traffic_chart.out_bytes, sent_bytes);
+        assert_eq!(traffic_chart.in_packets, received_packets);
+        assert_eq!(traffic_chart.out_packets, sent_packets);
+        assert_eq!(traffic_chart.in_bytes, received_bytes);
     }
 }

--- a/src/chart/manage_chart_data.rs
+++ b/src/chart/manage_chart_data.rs
@@ -9,9 +9,11 @@ pub fn update_charts_data(runtime_data: &mut RunTimeData, traffic_chart: &mut Tr
     let tot_seconds = traffic_chart.ticks as f32;
     traffic_chart.ticks += 1;
 
-    let out_bytes_entry = -1.0 * (runtime_data.tot_out_bytes - runtime_data.tot_out_bytes_prev) as f32;
+    let out_bytes_entry =
+        -1.0 * (runtime_data.tot_out_bytes - runtime_data.tot_out_bytes_prev) as f32;
     let in_bytes_entry = (runtime_data.tot_in_bytes - runtime_data.tot_in_bytes_prev) as f32;
-    let out_packets_entry = -1.0 * (runtime_data.tot_out_packets - runtime_data.tot_out_packets_prev) as f32;
+    let out_packets_entry =
+        -1.0 * (runtime_data.tot_out_packets - runtime_data.tot_out_packets_prev) as f32;
     let in_packets_entry = (runtime_data.tot_in_packets - runtime_data.tot_in_packets_prev) as f32;
 
     let out_bytes_key = Key::new(tot_seconds, out_bytes_entry, Interpolation::Cosine);

--- a/src/chart/manage_chart_data.rs
+++ b/src/chart/manage_chart_data.rs
@@ -9,12 +9,10 @@ pub fn update_charts_data(runtime_data: &mut RunTimeData, traffic_chart: &mut Tr
     let tot_seconds = traffic_chart.ticks;
     traffic_chart.ticks += 1;
 
-    let sent_bytes_entry = runtime_data.tot_sent_bytes - runtime_data.tot_sent_bytes_prev;
-    let received_bytes_entry =
-        runtime_data.tot_received_bytes - runtime_data.tot_received_bytes_prev;
-    let sent_packets_entry = runtime_data.tot_sent_packets - runtime_data.tot_sent_packets_prev;
-    let received_packets_entry =
-        runtime_data.tot_received_packets - runtime_data.tot_received_packets_prev;
+    let out_bytes_entry = runtime_data.tot_out_bytes - runtime_data.tot_out_bytes_prev;
+    let in_bytes_entry = runtime_data.tot_in_bytes - runtime_data.tot_in_bytes_prev;
+    let out_packets_entry = runtime_data.tot_out_packets - runtime_data.tot_out_packets_prev;
+    let in_packets_entry = runtime_data.tot_in_packets - runtime_data.tot_in_packets_prev;
 
     // update sent bytes traffic data
     if traffic_chart.out_bytes.len() >= 30 {
@@ -22,19 +20,19 @@ pub fn update_charts_data(runtime_data: &mut RunTimeData, traffic_chart: &mut Tr
     }
     traffic_chart.out_bytes.push_back((
         tot_seconds,
-        -<u128 as TryInto<i64>>::try_into(sent_bytes_entry).unwrap(),
+        -<u128 as TryInto<i64>>::try_into(out_bytes_entry).unwrap(),
     ));
     traffic_chart.min_bytes = get_min(&traffic_chart.out_bytes);
-    runtime_data.tot_sent_bytes_prev = runtime_data.tot_sent_bytes;
+    runtime_data.tot_out_bytes_prev = runtime_data.tot_out_bytes;
     // update received bytes traffic data
     if traffic_chart.in_bytes.len() >= 30 {
         traffic_chart.in_bytes.pop_front();
     }
     traffic_chart
         .in_bytes
-        .push_back((tot_seconds, received_bytes_entry.try_into().unwrap()));
+        .push_back((tot_seconds, in_bytes_entry.try_into().unwrap()));
     traffic_chart.max_bytes = get_max(&traffic_chart.in_bytes);
-    runtime_data.tot_received_bytes_prev = runtime_data.tot_received_bytes;
+    runtime_data.tot_in_bytes_prev = runtime_data.tot_in_bytes;
 
     // update sent packets traffic data
     if traffic_chart.out_packets.len() >= 30 {
@@ -42,19 +40,19 @@ pub fn update_charts_data(runtime_data: &mut RunTimeData, traffic_chart: &mut Tr
     }
     traffic_chart.out_packets.push_back((
         tot_seconds,
-        -<u128 as TryInto<i64>>::try_into(sent_packets_entry).unwrap(),
+        -<u128 as TryInto<i64>>::try_into(out_packets_entry).unwrap(),
     ));
     traffic_chart.min_packets = get_min(&traffic_chart.out_packets);
-    runtime_data.tot_sent_packets_prev = runtime_data.tot_sent_packets;
+    runtime_data.tot_out_packets_prev = runtime_data.tot_out_packets;
     // update received packets traffic data
     if traffic_chart.in_packets.len() >= 30 {
         traffic_chart.in_packets.pop_front();
     }
     traffic_chart
         .in_packets
-        .push_back((tot_seconds, received_packets_entry.try_into().unwrap()));
+        .push_back((tot_seconds, in_packets_entry.try_into().unwrap()));
     traffic_chart.max_packets = get_max(&traffic_chart.in_packets);
-    runtime_data.tot_received_packets_prev = runtime_data.tot_received_packets;
+    runtime_data.tot_in_packets_prev = runtime_data.tot_in_packets;
 }
 
 /// Finds the minimum y value to be displayed in chart
@@ -169,15 +167,15 @@ mod tests {
         let mut runtime_data = RunTimeData {
             all_bytes: 0,
             all_packets: 0,
-            tot_sent_bytes: tot_sent + 1111,
-            tot_received_bytes: tot_received + 2222,
-            tot_sent_packets: tot_sent + 3333,
-            tot_received_packets: tot_received + 4444,
+            tot_out_bytes: tot_sent + 1111,
+            tot_in_bytes: tot_received + 2222,
+            tot_out_packets: tot_sent + 3333,
+            tot_in_packets: tot_received + 4444,
             dropped_packets: 0,
-            tot_sent_bytes_prev: tot_sent,
-            tot_received_bytes_prev: tot_received,
-            tot_sent_packets_prev: tot_sent,
-            tot_received_packets_prev: tot_received,
+            tot_out_bytes_prev: tot_sent,
+            tot_in_bytes_prev: tot_received,
+            tot_out_packets_prev: tot_sent,
+            tot_in_packets_prev: tot_received,
             logged_notifications: Default::default(),
             tot_emitted_notifications: 0,
         };
@@ -191,10 +189,10 @@ mod tests {
         assert_eq!(get_max(&traffic_chart.in_bytes), 21000);
 
         // runtime_data correctly updated?
-        assert_eq!(runtime_data.tot_sent_bytes_prev, tot_sent + 1111);
-        assert_eq!(runtime_data.tot_received_bytes_prev, tot_received + 2222);
-        assert_eq!(runtime_data.tot_sent_packets_prev, tot_sent + 3333);
-        assert_eq!(runtime_data.tot_received_packets_prev, tot_received + 4444);
+        assert_eq!(runtime_data.tot_out_bytes_prev, tot_sent + 1111);
+        assert_eq!(runtime_data.tot_in_bytes_prev, tot_received + 2222);
+        assert_eq!(runtime_data.tot_out_packets_prev, tot_sent + 3333);
+        assert_eq!(runtime_data.tot_in_packets_prev, tot_received + 4444);
 
         let mut sent_bytes = sent.clone();
         sent_bytes.push_back((29, -1111));
@@ -216,13 +214,13 @@ mod tests {
         assert_eq!(traffic_chart.out_packets, sent_packets);
         assert_eq!(traffic_chart.in_bytes, received_bytes);
 
-        runtime_data.tot_sent_bytes += 99;
-        runtime_data.tot_received_packets += 990;
-        runtime_data.tot_received_bytes += 2;
+        runtime_data.tot_out_bytes += 99;
+        runtime_data.tot_in_packets += 990;
+        runtime_data.tot_in_bytes += 2;
         update_charts_data(&mut runtime_data, &mut traffic_chart);
-        runtime_data.tot_sent_bytes += 77;
-        runtime_data.tot_received_packets += 1;
-        runtime_data.tot_sent_packets += 220;
+        runtime_data.tot_out_bytes += 77;
+        runtime_data.tot_in_packets += 1;
+        runtime_data.tot_out_packets += 220;
         update_charts_data(&mut runtime_data, &mut traffic_chart);
 
         sent_bytes.pop_front();

--- a/src/chart/manage_chart_data.rs
+++ b/src/chart/manage_chart_data.rs
@@ -1,4 +1,4 @@
-use std::collections::VecDeque;
+use splines::{Interpolation, Key, Spline};
 
 use crate::{RunTimeData, TrafficChart};
 
@@ -6,72 +6,64 @@ use crate::{RunTimeData, TrafficChart};
 ///
 /// It updates data (packets and bytes per second) to be displayed in the chart of gui run page
 pub fn update_charts_data(runtime_data: &mut RunTimeData, traffic_chart: &mut TrafficChart) {
-    let tot_seconds = traffic_chart.ticks;
+    let tot_seconds = traffic_chart.ticks as f32;
     traffic_chart.ticks += 1;
 
-    let out_bytes_entry = runtime_data.tot_out_bytes - runtime_data.tot_out_bytes_prev;
-    let in_bytes_entry = runtime_data.tot_in_bytes - runtime_data.tot_in_bytes_prev;
-    let out_packets_entry = runtime_data.tot_out_packets - runtime_data.tot_out_packets_prev;
-    let in_packets_entry = runtime_data.tot_in_packets - runtime_data.tot_in_packets_prev;
+    let out_bytes_entry = -1.0 * (runtime_data.tot_out_bytes - runtime_data.tot_out_bytes_prev) as f32;
+    let in_bytes_entry = (runtime_data.tot_in_bytes - runtime_data.tot_in_bytes_prev) as f32;
+    let out_packets_entry = -1.0 * (runtime_data.tot_out_packets - runtime_data.tot_out_packets_prev) as f32;
+    let in_packets_entry = (runtime_data.tot_in_packets - runtime_data.tot_in_packets_prev) as f32;
+
+    let out_bytes_key = Key::new(tot_seconds, out_bytes_entry, Interpolation::Cosine);
+    let in_bytes_key = Key::new(tot_seconds, in_bytes_entry, Interpolation::Cosine);
+    let out_packets_key = Key::new(tot_seconds, out_packets_entry, Interpolation::Cosine);
+    let in_packets_key = Key::new(tot_seconds, in_packets_entry, Interpolation::Cosine);
 
     // update sent bytes traffic data
-    if traffic_chart.out_bytes.len() >= 30 {
-        traffic_chart.out_bytes.pop_front();
-    }
-    traffic_chart.out_bytes.push_back((
-        tot_seconds,
-        -<u128 as TryInto<i64>>::try_into(out_bytes_entry).unwrap(),
-    ));
+    update_spline(&mut traffic_chart.out_bytes, out_bytes_key);
     traffic_chart.min_bytes = get_min(&traffic_chart.out_bytes);
     runtime_data.tot_out_bytes_prev = runtime_data.tot_out_bytes;
+
     // update received bytes traffic data
-    if traffic_chart.in_bytes.len() >= 30 {
-        traffic_chart.in_bytes.pop_front();
-    }
-    traffic_chart
-        .in_bytes
-        .push_back((tot_seconds, in_bytes_entry.try_into().unwrap()));
+    update_spline(&mut traffic_chart.in_bytes, in_bytes_key);
     traffic_chart.max_bytes = get_max(&traffic_chart.in_bytes);
     runtime_data.tot_in_bytes_prev = runtime_data.tot_in_bytes;
 
     // update sent packets traffic data
-    if traffic_chart.out_packets.len() >= 30 {
-        traffic_chart.out_packets.pop_front();
-    }
-    traffic_chart.out_packets.push_back((
-        tot_seconds,
-        -<u128 as TryInto<i64>>::try_into(out_packets_entry).unwrap(),
-    ));
+    update_spline(&mut traffic_chart.out_packets, out_packets_key);
     traffic_chart.min_packets = get_min(&traffic_chart.out_packets);
     runtime_data.tot_out_packets_prev = runtime_data.tot_out_packets;
+
     // update received packets traffic data
-    if traffic_chart.in_packets.len() >= 30 {
-        traffic_chart.in_packets.pop_front();
-    }
-    traffic_chart
-        .in_packets
-        .push_back((tot_seconds, in_packets_entry.try_into().unwrap()));
+    update_spline(&mut traffic_chart.in_packets, in_packets_key);
     traffic_chart.max_packets = get_max(&traffic_chart.in_packets);
     runtime_data.tot_in_packets_prev = runtime_data.tot_in_packets;
 }
 
-/// Finds the minimum y value to be displayed in chart
-fn get_min(deque: &VecDeque<(u32, i64)>) -> i64 {
-    let mut min = 0;
-    for (_, x) in deque {
-        if *x < min {
-            min = *x;
+fn update_spline(spline: &mut Spline<f32, f32>, new_key: Key<f32, f32>) {
+    if spline.len() >= 30 {
+        spline.remove(0);
+    }
+    spline.add(new_key);
+}
+
+/// Finds the minimum y value to be displayed in chart.
+fn get_min(spline: &Spline<f32, f32>) -> f32 {
+    let mut min = 0.0;
+    for key in spline {
+        if key.value < min {
+            min = key.value;
         }
     }
     min
 }
 
-/// Finds the maximum y value to be displayed in chart
-fn get_max(deque: &VecDeque<(u32, i64)>) -> i64 {
-    let mut max = 0;
-    for (_, x) in deque {
-        if *x > max {
-            max = *x;
+/// Finds the maximum y value to be displayed in chart.
+fn get_max(spline: &Spline<f32, f32>) -> f32 {
+    let mut max = 0.0;
+    for key in spline {
+        if key.value > max {
+            max = key.value;
         }
     }
     max

--- a/src/chart/manage_chart_data.rs
+++ b/src/chart/manage_chart_data.rs
@@ -6,14 +6,19 @@ use crate::{RunTimeData, TrafficChart};
 ///
 /// It updates data (packets and bytes per second) to be displayed in the chart of gui run page
 pub fn update_charts_data(runtime_data: &mut RunTimeData, traffic_chart: &mut TrafficChart) {
+    #[allow(clippy::cast_precision_loss)]
     let tot_seconds = traffic_chart.ticks as f32;
     traffic_chart.ticks += 1;
 
+    #[allow(clippy::cast_precision_loss)]
     let out_bytes_entry =
         -1.0 * (runtime_data.tot_out_bytes - runtime_data.tot_out_bytes_prev) as f32;
+    #[allow(clippy::cast_precision_loss)]
     let in_bytes_entry = (runtime_data.tot_in_bytes - runtime_data.tot_in_bytes_prev) as f32;
+    #[allow(clippy::cast_precision_loss)]
     let out_packets_entry =
         -1.0 * (runtime_data.tot_out_packets - runtime_data.tot_out_packets_prev) as f32;
+    #[allow(clippy::cast_precision_loss)]
     let in_packets_entry = (runtime_data.tot_in_packets - runtime_data.tot_in_packets_prev) as f32;
 
     let out_bytes_key = Key::new(tot_seconds, out_bytes_entry, Interpolation::Cosine);

--- a/src/chart/types/traffic_chart.rs
+++ b/src/chart/types/traffic_chart.rs
@@ -15,8 +15,7 @@ use crate::gui::styles::types::palette::to_rgb_color;
 use crate::gui::types::message::Message;
 use crate::networking::types::traffic_direction::TrafficDirection;
 use crate::translations::translations::{incoming_translation, outgoing_translation};
-use crate::utils::formatted_strings::get_formatted_bytes_string_with_b;
-use crate::{ChartType, Language, StyleType};
+use crate::{ByteMultiple, ChartType, Language, StyleType};
 
 /// Struct defining the chart to be displayed in gui run page
 pub struct TrafficChart {
@@ -202,7 +201,7 @@ impl Chart<Message> for TrafficChart {
                 &|packets| packets.abs().to_string()
             } else {
                 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-                &|bytes| get_formatted_bytes_string_with_b(bytes.abs() as u128)
+                &|bytes| ByteMultiple::formatted_string(bytes.abs() as u128)
             })
             .x_labels(min(6, x_labels))
             .x_label_formatter(&std::string::ToString::to_string)

--- a/src/chart/types/traffic_chart.rs
+++ b/src/chart/types/traffic_chart.rs
@@ -92,7 +92,7 @@ impl Chart<Message> for TrafficChart {
     ) {
         let font_weight = self.style.get_font_weight();
 
-        if self.ticks <= 1 {
+        if self.ticks < 1 {
             return;
         }
         let tot_seconds = self.ticks - 1;
@@ -124,6 +124,13 @@ impl Chart<Message> for TrafficChart {
             ChartType::Bytes => get_y_axis_range(self.min_bytes, self.max_bytes),
         };
 
+        let x_labels = if self.ticks == 1 {
+            0
+        } else {
+            self.ticks as usize
+        };
+        let y_labels = 1 + (y_axis_range.end - y_axis_range.start) as usize;
+
         let mut chart = chart_builder
             .build_cartesian_2d(
                 first_time_displayed as f32..tot_seconds as f32,
@@ -143,13 +150,13 @@ impl Chart<Message> for TrafficChart {
                     .style(font_weight)
                     .color(&color_font),
             )
-            .y_labels(7)
+            .y_labels(min(5, y_labels))
             .y_label_formatter(if self.chart_type.eq(&ChartType::Packets) {
                 &|packets| packets.abs().to_string()
             } else {
                 &|bytes| get_formatted_bytes_string_with_b(bytes.abs() as u128)
             })
-            .x_labels(min(6, self.ticks as usize))
+            .x_labels(min(6, x_labels as usize))
             .x_label_formatter(&|t| t.to_string())
             .draw()
             .unwrap();

--- a/src/chart/types/traffic_chart.rs
+++ b/src/chart/types/traffic_chart.rs
@@ -7,11 +7,13 @@ use plotters::prelude::*;
 use plotters_iced::{Chart, ChartBuilder, ChartWidget, DrawingBackend};
 use splines::Spline;
 use std::cmp::min;
+use std::ops::Range;
 
 use crate::gui::app::FONT_FAMILY_NAME;
 use crate::gui::styles::style_constants::CHARTS_LINE_BORDER;
 use crate::gui::styles::types::palette::to_rgb_color;
 use crate::gui::types::message::Message;
+use crate::networking::types::traffic_direction::TrafficDirection;
 use crate::translations::translations::{incoming_translation, outgoing_translation};
 use crate::utils::formatted_strings::get_formatted_bytes_string_with_b;
 use crate::{ChartType, Language, StyleType};
@@ -80,6 +82,77 @@ impl TrafficChart {
     pub fn change_style(&mut self, style: StyleType) {
         self.style = style;
     }
+
+    fn x_axis_range(&self) -> Range<f32> {
+        let first_time_displayed = if self.ticks > 30 { self.ticks - 30 } else { 0 };
+        let tot_seconds = self.ticks - 1;
+        #[allow(clippy::cast_precision_loss)]
+        let range = first_time_displayed as f32..tot_seconds as f32;
+        range
+    }
+
+    fn y_axis_range(&self) -> Range<f32> {
+        let (min, max) = match self.chart_type {
+            ChartType::Packets => (self.min_packets, self.max_packets),
+            ChartType::Bytes => (self.min_bytes, self.max_bytes),
+        };
+        let fs = max - min;
+        let gap = fs * 0.05;
+        min - gap..max + gap
+    }
+
+    fn font(&self, size: f64) -> TextStyle<'static> {
+        (FONT_FAMILY_NAME, size)
+            .into_font()
+            .style(self.style.get_font_weight())
+            .color(&to_rgb_color(self.style.get_palette().text_body))
+    }
+
+    fn spline_to_plot(&self, direction: TrafficDirection) -> &Spline<f32, f32> {
+        match self.chart_type {
+            ChartType::Packets => {
+                if direction == TrafficDirection::Incoming {
+                    &self.in_packets
+                } else {
+                    &self.out_packets
+                }
+            }
+            ChartType::Bytes => {
+                if direction == TrafficDirection::Incoming {
+                    &self.in_bytes
+                } else {
+                    &self.out_bytes
+                }
+            }
+        }
+    }
+
+    fn series_label(&self, direction: TrafficDirection) -> &str {
+        match direction {
+            TrafficDirection::Incoming => incoming_translation(self.language),
+            TrafficDirection::Outgoing => outgoing_translation(self.language),
+        }
+    }
+
+    fn series_color(&self, direction: TrafficDirection) -> RGBColor {
+        match direction {
+            TrafficDirection::Incoming => to_rgb_color(self.style.get_palette().secondary),
+            TrafficDirection::Outgoing => to_rgb_color(self.style.get_palette().outgoing),
+        }
+    }
+
+    fn area_series<DB: DrawingBackend>(
+        &self,
+        direction: TrafficDirection,
+    ) -> AreaSeries<DB, f32, f32> {
+        let color = self.series_color(direction);
+        AreaSeries::new(
+            sample_spline(self.spline_to_plot(direction)),
+            0.0,
+            color.mix(self.style.get_extension().alpha_chart_badge.into()),
+        )
+        .border_style(ShapeStyle::from(&color).stroke_width(CHARTS_LINE_BORDER))
+    }
 }
 
 impl Chart<Message> for TrafficChart {
@@ -90,21 +163,9 @@ impl Chart<Message> for TrafficChart {
         _state: &Self::State,
         mut chart_builder: ChartBuilder<DB>,
     ) {
-        let font_weight = self.style.get_font_weight();
-
         if self.ticks < 1 {
             return;
         }
-        let tot_seconds = self.ticks - 1;
-        let first_time_displayed = if self.ticks > 30 { self.ticks - 30 } else { 0 };
-
-        let colors = self.style.get_palette();
-        let ext = self.style.get_extension();
-        let color_incoming = to_rgb_color(colors.secondary);
-        let color_outgoing = to_rgb_color(colors.outgoing);
-        let color_font = to_rgb_color(colors.text_body);
-        let color_mix = ext.alpha_chart_badge;
-        let buttons_color = to_rgb_color(ext.buttons_color);
 
         chart_builder
             .margin_right(30)
@@ -112,107 +173,61 @@ impl Chart<Message> for TrafficChart {
             .set_label_area_size(LabelAreaPosition::Left, 60)
             .set_label_area_size(LabelAreaPosition::Bottom, 50);
 
-        let get_y_axis_range = |min: f32, max: f32| {
-            let fs = max - min;
-            #[allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
-            let gap = fs * 0.05;
-            min - gap..max + gap
-        };
-
-        let y_axis_range = match self.chart_type {
-            ChartType::Packets => get_y_axis_range(self.min_packets, self.max_packets),
-            ChartType::Bytes => get_y_axis_range(self.min_bytes, self.max_bytes),
-        };
+        let x_axis_range = self.x_axis_range();
+        let y_axis_range = self.y_axis_range();
 
         let x_labels = if self.ticks == 1 {
             0
         } else {
             self.ticks as usize
         };
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let y_labels = 1 + (y_axis_range.end - y_axis_range.start) as usize;
 
         let mut chart = chart_builder
-            .build_cartesian_2d(
-                first_time_displayed as f32..tot_seconds as f32,
-                y_axis_range,
-            )
+            .build_cartesian_2d(x_axis_range, y_axis_range)
             .expect("Error drawing chart");
 
-        // Mesh
+        let buttons_color = to_rgb_color(self.style.get_extension().buttons_color);
+
+        // chart mesh
         chart
             .configure_mesh()
             .axis_style(buttons_color)
             .bold_line_style(buttons_color.mix(0.3))
             .light_line_style(buttons_color.mix(0.0))
-            .label_style(
-                (FONT_FAMILY_NAME, 12.5)
-                    .into_font()
-                    .style(font_weight)
-                    .color(&color_font),
-            )
+            .label_style(self.font(12.5))
             .y_labels(min(5, y_labels))
             .y_label_formatter(if self.chart_type.eq(&ChartType::Packets) {
                 &|packets| packets.abs().to_string()
             } else {
+                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
                 &|bytes| get_formatted_bytes_string_with_b(bytes.abs() as u128)
             })
-            .x_labels(min(6, x_labels as usize))
-            .x_label_formatter(&|t| t.to_string())
+            .x_labels(min(6, x_labels))
+            .x_label_formatter(&std::string::ToString::to_string)
             .draw()
             .unwrap();
 
-        // Incoming series
-        chart
-            .draw_series(
-                AreaSeries::new(
-                    if self.chart_type.eq(&ChartType::Packets) {
-                        sample_spline(&self.in_packets)
-                    } else {
-                        sample_spline(&self.in_bytes)
-                    },
-                    0.0,
-                    color_incoming.mix(color_mix.into()),
-                )
-                .border_style(ShapeStyle::from(&color_incoming).stroke_width(CHARTS_LINE_BORDER)),
-            )
-            .expect("Error drawing graph")
-            .label(incoming_translation(self.language))
-            .legend(move |(x, y)| {
-                Rectangle::new([(x, y - 5), (x + 25, y + 5)], color_incoming.filled())
-            });
+        // draw incoming and outgoing series
+        for direction in [TrafficDirection::Incoming, TrafficDirection::Outgoing] {
+            let area_series = self.area_series(direction);
+            let label = self.series_label(direction);
+            let legend_style = self.series_color(direction).filled();
+            chart
+                .draw_series(area_series)
+                .expect("Error drawing graph")
+                .label(label)
+                .legend(move |(x, y)| Rectangle::new([(x, y - 5), (x + 25, y + 5)], legend_style));
+        }
 
-        // Outgoing series
-        chart
-            .draw_series(
-                AreaSeries::new(
-                    if self.chart_type.eq(&ChartType::Packets) {
-                        sample_spline(&self.out_packets)
-                    } else {
-                        sample_spline(&self.out_bytes)
-                    },
-                    0.0,
-                    color_outgoing.mix(color_mix.into()),
-                )
-                .border_style(ShapeStyle::from(&color_outgoing).stroke_width(CHARTS_LINE_BORDER)),
-            )
-            .expect("Error drawing graph")
-            .label(outgoing_translation(self.language))
-            .legend(move |(x, y)| {
-                Rectangle::new([(x, y - 5), (x + 25, y + 5)], color_outgoing.filled())
-            });
-
-        // Legend
+        // chart legend
         chart
             .configure_series_labels()
             .position(SeriesLabelPosition::UpperRight)
             .background_style(buttons_color.mix(0.6))
             .border_style(buttons_color.stroke_width(CHARTS_LINE_BORDER * 2))
-            .label_font(
-                (FONT_FAMILY_NAME, 13.5)
-                    .into_font()
-                    .style(font_weight)
-                    .color(&color_font),
-            )
+            .label_font(self.font(13.5))
             .draw()
             .expect("Error drawing graph");
     }
@@ -224,9 +239,11 @@ fn sample_spline(spline: &Spline<f32, f32>) -> Vec<(f32, f32)> {
     let len = spline.len();
     let first_x = spline.get(0).unwrap().t;
     let last_x = spline.get(len - 1).unwrap().t;
+    #[allow(clippy::cast_precision_loss)]
     let delta = (last_x - first_x) / (PTS as f32 - 1.0);
     for i in 0..PTS {
-        let x = first_x + i as f32 * delta;
+        #[allow(clippy::cast_precision_loss)]
+        let x = first_x + delta * i as f32;
         let p = spline.clamped_sample(x).unwrap_or_default();
         ret_val.push((x, p));
     }

--- a/src/chart/types/traffic_chart.rs
+++ b/src/chart/types/traffic_chart.rs
@@ -109,20 +109,14 @@ impl TrafficChart {
 
     fn spline_to_plot(&self, direction: TrafficDirection) -> &Spline<f32, f32> {
         match self.chart_type {
-            ChartType::Packets => {
-                if direction == TrafficDirection::Incoming {
-                    &self.in_packets
-                } else {
-                    &self.out_packets
-                }
-            }
-            ChartType::Bytes => {
-                if direction == TrafficDirection::Incoming {
-                    &self.in_bytes
-                } else {
-                    &self.out_bytes
-                }
-            }
+            ChartType::Packets => match direction {
+                TrafficDirection::Incoming => &self.in_packets,
+                TrafficDirection::Outgoing => &self.out_packets,
+            },
+            ChartType::Bytes => match direction {
+                TrafficDirection::Incoming => &self.in_bytes,
+                TrafficDirection::Outgoing => &self.out_bytes,
+            },
         }
     }
 
@@ -195,6 +189,7 @@ impl Chart<Message> for TrafficChart {
             .axis_style(buttons_color)
             .bold_line_style(buttons_color.mix(0.3))
             .light_line_style(buttons_color.mix(0.0))
+            .max_light_lines(0)
             .label_style(self.font(12.5))
             .y_labels(min(5, y_labels))
             .y_label_formatter(if self.chart_type.eq(&ChartType::Packets) {

--- a/src/chart/types/traffic_chart.rs
+++ b/src/chart/types/traffic_chart.rs
@@ -1,6 +1,6 @@
 //! This module defines the behavior of the `TrafficChart` struct, used to display chart in GUI run page
 
-use std::cmp::{max};
+use std::cmp::max;
 use std::collections::VecDeque;
 
 use iced::alignment::{Horizontal, Vertical};
@@ -97,8 +97,8 @@ impl TrafficChart {
         let first = first as f32;
         let d = delta_x / 1000.0;
         for i in 0..1000 {
-            let p = spline.sample(first + i as f32*d).unwrap_or_default();
-            ret_val.push_back((first + i as f32*d, p));
+            let p = spline.sample(first + i as f32 * d).unwrap_or_default();
+            ret_val.push_back((first + i as f32 * d, p));
         }
         ret_val
     }
@@ -147,7 +147,10 @@ impl Chart<Message> for TrafficChart {
         };
 
         let mut chart = chart_builder
-            .build_cartesian_2d(first_time_displayed as f32..tot_seconds as f32, y_axis_range)
+            .build_cartesian_2d(
+                first_time_displayed as f32..tot_seconds as f32,
+                y_axis_range,
+            )
             .expect("Error drawing chart");
 
         // Mesh

--- a/src/gui/pages/connection_details_page.rs
+++ b/src/gui/pages/connection_details_page.rs
@@ -232,7 +232,7 @@ fn col_info(
         ),
         &format!(
             "{}\n   {} {}",
-            get_formatted_bytes_string_with_b(val.transmitted_bytes, 1),
+            get_formatted_bytes_string_with_b(val.transmitted_bytes),
             val.transmitted_packets,
             packets_translation(language)
         ),

--- a/src/gui/pages/connection_details_page.rs
+++ b/src/gui/pages/connection_details_page.rs
@@ -48,7 +48,7 @@ pub fn connection_details_page(
 ) -> Container<Message, Renderer<StyleType>> {
     Container::new(lazy(
         (
-            sniffer.runtime_data.tot_sent_packets + sniffer.runtime_data.tot_received_packets,
+            sniffer.runtime_data.tot_out_packets + sniffer.runtime_data.tot_in_packets,
             sniffer.timing_events.was_just_copy_ip(&key.address1),
             sniffer.timing_events.was_just_copy_ip(&key.address2),
         ),

--- a/src/gui/pages/connection_details_page.rs
+++ b/src/gui/pages/connection_details_page.rs
@@ -38,9 +38,9 @@ use crate::translations::translations_2::{
 use crate::translations::translations_3::{
     copy_translation, messages_translation, service_translation,
 };
-use crate::utils::formatted_strings::{get_formatted_bytes_string_with_b, get_socket_address};
+use crate::utils::formatted_strings::get_socket_address;
 use crate::utils::types::icon::Icon;
-use crate::{ConfigSettings, Language, Protocol, Sniffer, StyleType};
+use crate::{ByteMultiple, ConfigSettings, Language, Protocol, Sniffer, StyleType};
 
 pub fn connection_details_page(
     sniffer: &Sniffer,
@@ -232,7 +232,7 @@ fn col_info(
         ),
         &format!(
             "{}\n   {} {}",
-            get_formatted_bytes_string_with_b(val.transmitted_bytes),
+            ByteMultiple::formatted_string(val.transmitted_bytes),
             val.transmitted_packets,
             packets_translation(language)
         ),

--- a/src/gui/pages/inspect_page.rs
+++ b/src/gui/pages/inspect_page.rs
@@ -59,7 +59,7 @@ pub fn inspect_page(sniffer: &Sniffer) -> Container<Message, Renderer<StyleType>
 
     let report = lazy(
         (
-            sniffer.runtime_data.tot_sent_packets + sniffer.runtime_data.tot_received_packets,
+            sniffer.runtime_data.tot_out_packets + sniffer.runtime_data.tot_in_packets,
             style,
             language,
             sniffer.report_sort_type,

--- a/src/gui/pages/notifications_page.rs
+++ b/src/gui/pages/notifications_page.rs
@@ -27,9 +27,8 @@ use crate::translations::translations::{
     packets_exceeded_translation, packets_exceeded_value_translation, per_second_translation,
     threshold_translation,
 };
-use crate::utils::formatted_strings::get_formatted_bytes_string_with_b;
 use crate::utils::types::icon::Icon;
-use crate::{ConfigSettings, Language, RunningPage, Sniffer, StyleType};
+use crate::{ByteMultiple, ConfigSettings, Language, RunningPage, Sniffer, StyleType};
 
 /// Computes the body of gui notifications page
 pub fn notifications_page(sniffer: &Sniffer) -> Container<Message, Renderer<StyleType>> {
@@ -233,7 +232,7 @@ fn bytes_notification_log(
 ) -> Container<'static, Message, Renderer<StyleType>> {
     let mut threshold_str = threshold_translation(language);
     threshold_str.push_str(": ");
-    threshold_str.push_str(&get_formatted_bytes_string_with_b(
+    threshold_str.push_str(&ByteMultiple::formatted_string(
         (logged_notification.threshold).into(),
     ));
 
@@ -241,13 +240,13 @@ fn bytes_notification_log(
     let mut incoming_str = " - ".to_string();
     incoming_str.push_str(incoming_translation(language));
     incoming_str.push_str(": ");
-    incoming_str.push_str(&get_formatted_bytes_string_with_b(u128::from(
+    incoming_str.push_str(&ByteMultiple::formatted_string(u128::from(
         logged_notification.incoming,
     )));
     let mut outgoing_str = " - ".to_string();
     outgoing_str.push_str(outgoing_translation(language));
     outgoing_str.push_str(": ");
-    outgoing_str.push_str(&get_formatted_bytes_string_with_b(u128::from(
+    outgoing_str.push_str(&ByteMultiple::formatted_string(u128::from(
         logged_notification.outgoing,
     )));
     let content = Row::new()
@@ -291,7 +290,7 @@ fn bytes_notification_log(
                 .push(
                     Text::new(bytes_exceeded_value_translation(
                         language,
-                        &get_formatted_bytes_string_with_b(u128::from(
+                        &ByteMultiple::formatted_string(u128::from(
                             logged_notification.incoming + logged_notification.outgoing,
                         )),
                     ))

--- a/src/gui/pages/notifications_page.rs
+++ b/src/gui/pages/notifications_page.rs
@@ -235,24 +235,21 @@ fn bytes_notification_log(
     threshold_str.push_str(": ");
     threshold_str.push_str(&get_formatted_bytes_string_with_b(
         (logged_notification.threshold).into(),
-        1,
     ));
 
     threshold_str.push_str(&format!(" {}", per_second_translation(language)));
     let mut incoming_str = " - ".to_string();
     incoming_str.push_str(incoming_translation(language));
     incoming_str.push_str(": ");
-    incoming_str.push_str(&get_formatted_bytes_string_with_b(
-        u128::from(logged_notification.incoming),
-        1,
-    ));
+    incoming_str.push_str(&get_formatted_bytes_string_with_b(u128::from(
+        logged_notification.incoming,
+    )));
     let mut outgoing_str = " - ".to_string();
     outgoing_str.push_str(outgoing_translation(language));
     outgoing_str.push_str(": ");
-    outgoing_str.push_str(&get_formatted_bytes_string_with_b(
-        u128::from(logged_notification.outgoing),
-        1,
-    ));
+    outgoing_str.push_str(&get_formatted_bytes_string_with_b(u128::from(
+        logged_notification.outgoing,
+    )));
     let content = Row::new()
         .spacing(30)
         .align_items(Alignment::Center)
@@ -294,10 +291,9 @@ fn bytes_notification_log(
                 .push(
                     Text::new(bytes_exceeded_value_translation(
                         language,
-                        &get_formatted_bytes_string_with_b(
-                            u128::from(logged_notification.incoming + logged_notification.outgoing),
-                            1,
-                        ),
+                        &get_formatted_bytes_string_with_b(u128::from(
+                            logged_notification.incoming + logged_notification.outgoing,
+                        )),
                     ))
                     .font(font),
                 )

--- a/src/gui/pages/overview_page.rs
+++ b/src/gui/pages/overview_page.rs
@@ -63,8 +63,7 @@ pub fn overview_page(sniffer: &Sniffer) -> Container<Message, Renderer<StyleType
     if sniffer.pcap_error.is_none() {
         // NO pcap error detected
         let observed = sniffer.runtime_data.all_packets;
-        let filtered =
-            sniffer.runtime_data.tot_sent_packets + sniffer.runtime_data.tot_received_packets;
+        let filtered = sniffer.runtime_data.tot_out_packets + sniffer.runtime_data.tot_in_packets;
         let dropped = sniffer.runtime_data.dropped_packets;
         let total = observed + u128::from(dropped);
 
@@ -617,8 +616,7 @@ fn col_bytes_packets(
     font_headers: Font,
     sniffer: &Sniffer,
 ) -> Column<'static, Message, Renderer<StyleType>> {
-    let filtered_bytes =
-        sniffer.runtime_data.tot_sent_bytes + sniffer.runtime_data.tot_received_bytes;
+    let filtered_bytes = sniffer.runtime_data.tot_out_bytes + sniffer.runtime_data.tot_in_bytes;
     let all_bytes = sniffer.runtime_data.all_bytes;
     let filters = &sniffer.filters;
 

--- a/src/gui/pages/overview_page.rs
+++ b/src/gui/pages/overview_page.rs
@@ -309,10 +309,7 @@ fn col_host(width: f32, sniffer: &Sniffer) -> Column<'static, Message, Renderer<
                         Text::new(if chart_type.eq(&ChartType::Packets) {
                             data_info_host.data_info.tot_packets().to_string()
                         } else {
-                            get_formatted_bytes_string_with_b(
-                                data_info_host.data_info.tot_bytes(),
-                                1,
-                            )
+                            get_formatted_bytes_string_with_b(data_info_host.data_info.tot_bytes())
                         })
                         .font(font),
                     ),
@@ -404,7 +401,7 @@ fn col_service(width: f32, sniffer: &Sniffer) -> Column<'static, Message, Render
                         Text::new(if chart_type.eq(&ChartType::Packets) {
                             data_info.tot_packets().to_string()
                         } else {
-                            get_formatted_bytes_string_with_b(data_info.tot_bytes(), 1)
+                            get_formatted_bytes_string_with_b(data_info.tot_bytes())
                         })
                         .font(font),
                     ),
@@ -630,11 +627,11 @@ fn col_bytes_packets(
         none_translation(language).to_string()
     };
     let bytes_value = if dropped > 0 {
-        get_formatted_bytes_string_with_b(filtered_bytes, 1)
+        get_formatted_bytes_string_with_b(filtered_bytes)
     } else {
         format!(
             "{} {}",
-            &get_formatted_bytes_string_with_b(filtered_bytes, 1),
+            &get_formatted_bytes_string_with_b(filtered_bytes),
             of_total_translation(language, &get_percentage_string(all_bytes, filtered_bytes))
         )
     };

--- a/src/gui/pages/overview_page.rs
+++ b/src/gui/pages/overview_page.rs
@@ -43,11 +43,9 @@ use crate::translations::translations_2::{
     only_top_30_items_translation,
 };
 use crate::translations::translations_3::{service_translation, unsupported_link_type_translation};
-use crate::utils::formatted_strings::{
-    get_active_filters_string, get_formatted_bytes_string_with_b, get_percentage_string,
-};
+use crate::utils::formatted_strings::{get_active_filters_string, get_percentage_string};
 use crate::utils::types::icon::Icon;
-use crate::{ChartType, ConfigSettings, Language, RunningPage, StyleType};
+use crate::{ByteMultiple, ChartType, ConfigSettings, Language, RunningPage, StyleType};
 
 /// Computes the body of gui overview page
 pub fn overview_page(sniffer: &Sniffer) -> Container<Message, Renderer<StyleType>> {
@@ -309,7 +307,7 @@ fn col_host(width: f32, sniffer: &Sniffer) -> Column<'static, Message, Renderer<
                         Text::new(if chart_type.eq(&ChartType::Packets) {
                             data_info_host.data_info.tot_packets().to_string()
                         } else {
-                            get_formatted_bytes_string_with_b(data_info_host.data_info.tot_bytes())
+                            ByteMultiple::formatted_string(data_info_host.data_info.tot_bytes())
                         })
                         .font(font),
                     ),
@@ -401,7 +399,7 @@ fn col_service(width: f32, sniffer: &Sniffer) -> Column<'static, Message, Render
                         Text::new(if chart_type.eq(&ChartType::Packets) {
                             data_info.tot_packets().to_string()
                         } else {
-                            get_formatted_bytes_string_with_b(data_info.tot_bytes())
+                            ByteMultiple::formatted_string(data_info.tot_bytes())
                         })
                         .font(font),
                     ),
@@ -627,11 +625,11 @@ fn col_bytes_packets(
         none_translation(language).to_string()
     };
     let bytes_value = if dropped > 0 {
-        get_formatted_bytes_string_with_b(filtered_bytes)
+        ByteMultiple::formatted_string(filtered_bytes)
     } else {
         format!(
             "{} {}",
-            &get_formatted_bytes_string_with_b(filtered_bytes),
+            &ByteMultiple::formatted_string(filtered_bytes),
             of_total_translation(language, &get_percentage_string(all_bytes, filtered_bytes))
         )
     };

--- a/src/gui/pages/settings_notifications_page.rs
+++ b/src/gui/pages/settings_notifications_page.rs
@@ -308,7 +308,7 @@ fn input_group_bytes(
         specify_multiples_translation(language)
     );
     let mut curr_threshold_str = (bytes_notification.threshold.unwrap()
-        / bytes_notification.byte_multiple.get_multiplier())
+        / bytes_notification.byte_multiple.multiplier())
     .to_string();
     curr_threshold_str.push_str(bytes_notification.byte_multiple.get_char());
     let input_row = Row::new()

--- a/src/gui/pages/settings_notifications_page.rs
+++ b/src/gui/pages/settings_notifications_page.rs
@@ -310,7 +310,7 @@ fn input_group_bytes(
     let mut curr_threshold_str = (bytes_notification.threshold.unwrap()
         / bytes_notification.byte_multiple.multiplier())
     .to_string();
-    curr_threshold_str.push_str(bytes_notification.byte_multiple.get_char());
+    curr_threshold_str.push_str(&bytes_notification.byte_multiple.get_char());
     let input_row = Row::new()
         .spacing(5)
         .align_items(Alignment::Center)

--- a/src/gui/types/runtime_data.rs
+++ b/src/gui/types/runtime_data.rs
@@ -11,23 +11,23 @@ pub struct RunTimeData {
     /// Total number of packets (filtered and not filtered)
     pub all_packets: u128,
     /// Total sent bytes filtered
-    pub tot_sent_bytes: u128,
+    pub tot_out_bytes: u128,
     /// Total received bytes filtered
-    pub tot_received_bytes: u128,
+    pub tot_in_bytes: u128,
     /// Total sent packets filtered
-    pub tot_sent_packets: u128,
+    pub tot_out_packets: u128,
     /// Total received packets filtered
-    pub tot_received_packets: u128,
+    pub tot_in_packets: u128,
     /// Number of dropped packets
     pub dropped_packets: u32,
     /// Total sent bytes filtered before the current time interval
-    pub tot_sent_bytes_prev: u128,
+    pub tot_out_bytes_prev: u128,
     /// Total received bytes filtered before the current time interval
-    pub tot_received_bytes_prev: u128,
+    pub tot_in_bytes_prev: u128,
     /// Total sent packets filtered before the current time interval
-    pub tot_sent_packets_prev: u128,
+    pub tot_out_packets_prev: u128,
     /// Total received packets filtered before the current time interval
-    pub tot_received_packets_prev: u128,
+    pub tot_in_packets_prev: u128,
     /// Log of the received notifications
     pub logged_notifications: VecDeque<LoggedNotification>,
     /// The total number of emitted notifications
@@ -40,15 +40,15 @@ impl RunTimeData {
         RunTimeData {
             all_bytes: 0,
             all_packets: 0,
-            tot_sent_bytes: 0,
-            tot_received_bytes: 0,
-            tot_sent_packets: 0,
-            tot_received_packets: 0,
+            tot_out_bytes: 0,
+            tot_in_bytes: 0,
+            tot_out_packets: 0,
+            tot_in_packets: 0,
             dropped_packets: 0,
-            tot_sent_bytes_prev: 0,
-            tot_received_bytes_prev: 0,
-            tot_sent_packets_prev: 0,
-            tot_received_packets_prev: 0,
+            tot_out_bytes_prev: 0,
+            tot_in_bytes_prev: 0,
+            tot_out_packets_prev: 0,
+            tot_in_packets_prev: 0,
             logged_notifications: VecDeque::default(),
             tot_emitted_notifications: 0,
         }

--- a/src/gui/types/sniffer.rs
+++ b/src/gui/types/sniffer.rs
@@ -324,15 +324,15 @@ impl Sniffer {
     fn refresh_data(&mut self) -> Command<Message> {
         let info_traffic_lock = self.info_traffic.lock().unwrap();
         self.runtime_data.all_packets = info_traffic_lock.all_packets;
-        if info_traffic_lock.tot_received_packets + info_traffic_lock.tot_sent_packets == 0 {
+        if info_traffic_lock.tot_in_packets + info_traffic_lock.tot_out_packets == 0 {
             drop(info_traffic_lock);
             return self.update(Message::Waiting);
         }
-        self.runtime_data.tot_sent_packets = info_traffic_lock.tot_sent_packets;
-        self.runtime_data.tot_received_packets = info_traffic_lock.tot_received_packets;
+        self.runtime_data.tot_out_packets = info_traffic_lock.tot_out_packets;
+        self.runtime_data.tot_in_packets = info_traffic_lock.tot_in_packets;
         self.runtime_data.all_bytes = info_traffic_lock.all_bytes;
-        self.runtime_data.tot_received_bytes = info_traffic_lock.tot_received_bytes;
-        self.runtime_data.tot_sent_bytes = info_traffic_lock.tot_sent_bytes;
+        self.runtime_data.tot_in_bytes = info_traffic_lock.tot_in_bytes;
+        self.runtime_data.tot_out_bytes = info_traffic_lock.tot_out_bytes;
         self.runtime_data.dropped_packets = info_traffic_lock.dropped_packets;
         drop(info_traffic_lock);
         let emitted_notifications = notify_and_log(
@@ -527,7 +527,7 @@ impl Sniffer {
                 true,
             ) => {
                 // Running with no overlays
-                if self.runtime_data.tot_sent_packets + self.runtime_data.tot_received_packets > 0 {
+                if self.runtime_data.tot_out_packets + self.runtime_data.tot_in_packets > 0 {
                     // Running with no overlays and some packets filtered
                     self.running_page = if next {
                         self.running_page.next()
@@ -1550,7 +1550,7 @@ mod tests {
         assert_eq!(sniffer.running_page, RunningPage::Overview);
         assert_eq!(sniffer.settings_page, None);
         // switch with closed setting and some packets received => change running page
-        sniffer.runtime_data.tot_received_packets += 1;
+        sniffer.runtime_data.tot_in_packets += 1;
         sniffer.update(Message::SwitchPage(true));
         assert_eq!(sniffer.running_page, RunningPage::Inspect);
         assert_eq!(sniffer.settings_page, None);

--- a/src/networking/types/byte_multiple.rs
+++ b/src/networking/types/byte_multiple.rs
@@ -26,33 +26,55 @@ impl fmt::Display for ByteMultiple {
 }
 
 impl ByteMultiple {
-    const B_MUL: u64 = 1;
-    const KB_MUL: u64 = 1_000;
-    const MB_MUL: u64 = 1_000_000;
-    const GB_MUL: u64 = 1_000_000_000;
-    const TB_MUL: u64 = 1_000_000_000_000;
-    const PB_MUL: u64 = 1_000_000_000_000_000;
-
     pub fn multiplier(self) -> u64 {
         match self {
-            ByteMultiple::B => ByteMultiple::B_MUL,
-            ByteMultiple::KB => ByteMultiple::KB_MUL,
-            ByteMultiple::MB => ByteMultiple::MB_MUL,
-            ByteMultiple::GB => ByteMultiple::GB_MUL,
-            ByteMultiple::TB => ByteMultiple::TB_MUL,
-            ByteMultiple::PB => ByteMultiple::PB_MUL,
+            ByteMultiple::B => 1,
+            ByteMultiple::KB => 1_000,
+            ByteMultiple::MB => 1_000_000,
+            ByteMultiple::GB => 1_000_000_000,
+            ByteMultiple::TB => 1_000_000_000_000,
+            ByteMultiple::PB => 1_000_000_000_000_000,
         }
     }
 
-    pub fn get_char(&self) -> &str {
-        match self {
-            ByteMultiple::B => "",
-            ByteMultiple::KB => "K",
-            ByteMultiple::MB => "M",
-            ByteMultiple::GB => "G",
-            ByteMultiple::TB => "T",
-            ByteMultiple::PB => "P",
+    fn from_num_bytes(bytes: u128) -> Self {
+        match bytes {
+            x if (u128::MIN..u128::from(ByteMultiple::KB.multiplier())).contains(&x) => {
+                ByteMultiple::B
+            }
+            x if (u128::from(ByteMultiple::KB.multiplier())
+                ..u128::from(ByteMultiple::MB.multiplier()))
+                .contains(&x) =>
+            {
+                ByteMultiple::KB
+            }
+            x if (u128::from(ByteMultiple::MB.multiplier())
+                ..u128::from(ByteMultiple::GB.multiplier()))
+                .contains(&x) =>
+            {
+                ByteMultiple::MB
+            }
+            x if (u128::from(ByteMultiple::GB.multiplier())
+                ..u128::from(ByteMultiple::TB.multiplier()))
+                .contains(&x) =>
+            {
+                ByteMultiple::GB
+            }
+            x if (u128::from(ByteMultiple::TB.multiplier())
+                ..u128::from(ByteMultiple::PB.multiplier()))
+                .contains(&x) =>
+            {
+                ByteMultiple::TB
+            }
+            _ => ByteMultiple::PB,
         }
+    }
+
+    pub fn get_char(self) -> String {
+        self.to_string()
+            .strip_suffix('B')
+            .unwrap_or_default()
+            .to_owned()
     }
 
     pub fn from_char(ch: char) -> Self {
@@ -71,34 +93,15 @@ impl ByteMultiple {
         #[allow(clippy::cast_precision_loss)]
         let mut n = bytes as f32;
 
-        let byte_multiple = match bytes {
-            x if (0..u128::from(ByteMultiple::KB_MUL)).contains(&x) => ByteMultiple::B,
-            x if (u128::from(ByteMultiple::KB_MUL)..u128::from(ByteMultiple::MB_MUL))
-                .contains(&x) =>
-            {
-                ByteMultiple::KB
-            }
-            x if (u128::from(ByteMultiple::MB_MUL)..u128::from(ByteMultiple::GB_MUL))
-                .contains(&x) =>
-            {
-                ByteMultiple::MB
-            }
-            x if (u128::from(ByteMultiple::GB_MUL)..u128::from(ByteMultiple::TB_MUL))
-                .contains(&x) =>
-            {
-                ByteMultiple::GB
-            }
-            x if (u128::from(ByteMultiple::TB_MUL)..u128::from(ByteMultiple::PB_MUL))
-                .contains(&x) =>
-            {
-                ByteMultiple::TB
-            }
-            _ => ByteMultiple::PB,
-        };
+        let byte_multiple = ByteMultiple::from_num_bytes(bytes);
 
         #[allow(clippy::cast_precision_loss)]
         let multiplier = byte_multiple.multiplier() as f32;
         n /= multiplier;
+        if n > 999.0 && byte_multiple != ByteMultiple::PB {
+            // this allows representing e.g. 999_999 as 999 KB instead of 1000 KB
+            n = 999.0;
+        }
         let precision = usize::from(byte_multiple != ByteMultiple::B && n <= 9.95);
         format!("{n:.precision$} {byte_multiple}")
     }
@@ -110,15 +113,113 @@ mod tests {
 
     #[test]
     fn test_interpret_suffix_correctly() {
-        assert_eq!(from_char_to_multiple('B'), ByteMultiple::B);
-        assert_eq!(from_char_to_multiple('k'), ByteMultiple::KB);
-        assert_eq!(from_char_to_multiple('M'), ByteMultiple::MB);
-        assert_eq!(from_char_to_multiple('g'), ByteMultiple::GB);
+        assert_eq!(ByteMultiple::from_char('B'), ByteMultiple::B);
+        assert_eq!(ByteMultiple::from_char('k'), ByteMultiple::KB);
+        assert_eq!(ByteMultiple::from_char('M'), ByteMultiple::MB);
+        assert_eq!(ByteMultiple::from_char('g'), ByteMultiple::GB);
+        assert_eq!(ByteMultiple::from_char('t'), ByteMultiple::TB);
+        assert_eq!(ByteMultiple::from_char('P'), ByteMultiple::PB);
     }
 
     #[test]
     fn test_interpret_unknown_suffix_correctly() {
-        assert_eq!(from_char_to_multiple('T'), ByteMultiple::B);
-        assert_eq!(from_char_to_multiple('p'), ByteMultiple::B);
+        assert_eq!(ByteMultiple::from_char('E'), ByteMultiple::B);
+        assert_eq!(ByteMultiple::from_char('y'), ByteMultiple::B);
+    }
+
+    #[test]
+    fn test_byte_multiple_display() {
+        assert_eq!(format!("{}", ByteMultiple::B), "B");
+        assert_eq!(format!("{}", ByteMultiple::KB), "KB");
+        assert_eq!(format!("{}", ByteMultiple::MB), "MB");
+        assert_eq!(format!("{}", ByteMultiple::GB), "GB");
+        assert_eq!(format!("{}", ByteMultiple::TB), "TB");
+        assert_eq!(format!("{}", ByteMultiple::PB), "PB");
+    }
+
+    #[test]
+    fn test_byte_multiple_get_char() {
+        assert_eq!(ByteMultiple::B.get_char(), "");
+        assert_eq!(ByteMultiple::KB.get_char(), "K");
+        assert_eq!(ByteMultiple::MB.get_char(), "M");
+        assert_eq!(ByteMultiple::GB.get_char(), "G");
+        assert_eq!(ByteMultiple::TB.get_char(), "T");
+        assert_eq!(ByteMultiple::PB.get_char(), "P");
+    }
+
+    #[test]
+    fn test_byte_multiple_multiplier() {
+        assert_eq!(ByteMultiple::B.multiplier(), 1);
+        assert_eq!(ByteMultiple::KB.multiplier(), 1_000);
+        assert_eq!(ByteMultiple::MB.multiplier(), 1_000_000);
+        assert_eq!(ByteMultiple::GB.multiplier(), 1_000_000_000);
+        assert_eq!(ByteMultiple::TB.multiplier(), 1_000_000_000_000);
+        assert_eq!(ByteMultiple::PB.multiplier(), 1_000_000_000_000_000);
+    }
+
+    #[test]
+    fn test_byte_multiple_formatted_string() {
+        assert_eq!(ByteMultiple::formatted_string(u128::MIN), "0 B");
+        assert_eq!(ByteMultiple::formatted_string(1), "1 B");
+        assert_eq!(ByteMultiple::formatted_string(82), "82 B");
+        assert_eq!(ByteMultiple::formatted_string(999), "999 B");
+        assert_eq!(ByteMultiple::formatted_string(1_000), "1.0 KB");
+        assert_eq!(ByteMultiple::formatted_string(1_090), "1.1 KB");
+        assert_eq!(ByteMultiple::formatted_string(1_990), "2.0 KB");
+        assert_eq!(ByteMultiple::formatted_string(9_090), "9.1 KB");
+        assert_eq!(ByteMultiple::formatted_string(9_950), "9.9 KB");
+        assert_eq!(ByteMultiple::formatted_string(9_951), "10 KB");
+        assert_eq!(ByteMultiple::formatted_string(71_324), "71 KB");
+        assert_eq!(ByteMultiple::formatted_string(821_789), "822 KB");
+        assert_eq!(ByteMultiple::formatted_string(999_499), "999 KB");
+        assert_eq!(ByteMultiple::formatted_string(999_999), "999 KB");
+        assert_eq!(ByteMultiple::formatted_string(1_000_000), "1.0 MB");
+        assert_eq!(ByteMultiple::formatted_string(3_790_000), "3.8 MB");
+        assert_eq!(ByteMultiple::formatted_string(9_950_000), "9.9 MB");
+        assert_eq!(ByteMultiple::formatted_string(9_951_000), "10 MB");
+        assert_eq!(ByteMultiple::formatted_string(49_499_000), "49 MB");
+        assert_eq!(ByteMultiple::formatted_string(49_500_000), "50 MB");
+        assert_eq!(ByteMultiple::formatted_string(670_900_000), "671 MB");
+        assert_eq!(ByteMultiple::formatted_string(998_199_999), "998 MB");
+        assert_eq!(ByteMultiple::formatted_string(999_999_999), "999 MB");
+        assert_eq!(ByteMultiple::formatted_string(1_000_000_000), "1.0 GB");
+        assert_eq!(ByteMultiple::formatted_string(7_770_000_000), "7.8 GB");
+        assert_eq!(ByteMultiple::formatted_string(9_950_000_000), "9.9 GB");
+        assert_eq!(ByteMultiple::formatted_string(9_951_000_000), "10 GB");
+        assert_eq!(ByteMultiple::formatted_string(19_951_000_000), "20 GB");
+        assert_eq!(ByteMultiple::formatted_string(399_951_000_000), "400 GB");
+        assert_eq!(ByteMultiple::formatted_string(999_999_999_999), "999 GB");
+        assert_eq!(ByteMultiple::formatted_string(1_000_000_000_000), "1.0 TB");
+        assert_eq!(ByteMultiple::formatted_string(9_950_000_000_000), "9.9 TB");
+        assert_eq!(ByteMultiple::formatted_string(9_951_000_000_000), "10 TB");
+        assert_eq!(
+            ByteMultiple::formatted_string(999_950_000_000_000),
+            "999 TB"
+        );
+        assert_eq!(
+            ByteMultiple::formatted_string(999_999_999_999_999),
+            "999 TB"
+        );
+        assert_eq!(
+            ByteMultiple::formatted_string(1_000_000_000_000_000),
+            "1.0 PB"
+        );
+        assert_eq!(
+            ByteMultiple::formatted_string(1_000_000_000_000_000_0),
+            "10 PB"
+        );
+        assert_eq!(
+            ByteMultiple::formatted_string(999_999_999_000_000_000),
+            "1000 PB"
+        );
+        assert_eq!(
+            ByteMultiple::formatted_string(1_000_000_000_000_000_000_000),
+            "1000000 PB"
+        );
+        assert_eq!(
+            ByteMultiple::formatted_string(u128::MAX / 2),
+            "170141184077655307190272 PB"
+        );
+        assert_eq!(ByteMultiple::formatted_string(u128::MAX), "inf PB");
     }
 }

--- a/src/networking/types/byte_multiple.rs
+++ b/src/networking/types/byte_multiple.rs
@@ -7,12 +7,16 @@ use serde::{Deserialize, Serialize};
 pub enum ByteMultiple {
     /// A Byte
     B,
-    /// A thousand Bytes
+    /// 10^3 Bytes
     KB,
-    /// A million Bytes
+    /// 10^6 Bytes
     MB,
-    /// A billion Bytes
+    /// 10^9 Bytes
     GB,
+    /// 10^12 Bytes
+    TB,
+    /// 10^15 Bytes
+    PB,
 }
 
 impl fmt::Display for ByteMultiple {
@@ -22,12 +26,21 @@ impl fmt::Display for ByteMultiple {
 }
 
 impl ByteMultiple {
-    pub fn get_multiplier(self) -> u64 {
+    const B_MUL: u64 = 1;
+    const KB_MUL: u64 = 1_000;
+    const MB_MUL: u64 = 1_000_000;
+    const GB_MUL: u64 = 1_000_000_000;
+    const TB_MUL: u64 = 1_000_000_000_000;
+    const PB_MUL: u64 = 1_000_000_000_000_000;
+
+    pub fn multiplier(self) -> u64 {
         match self {
-            ByteMultiple::B => 1,
-            ByteMultiple::KB => 1_000,
-            ByteMultiple::MB => 1_000_000,
-            ByteMultiple::GB => 1_000_000_000,
+            ByteMultiple::B => ByteMultiple::B_MUL,
+            ByteMultiple::KB => ByteMultiple::KB_MUL,
+            ByteMultiple::MB => ByteMultiple::MB_MUL,
+            ByteMultiple::GB => ByteMultiple::GB_MUL,
+            ByteMultiple::TB => ByteMultiple::TB_MUL,
+            ByteMultiple::PB => ByteMultiple::PB_MUL,
         }
     }
 
@@ -37,16 +50,57 @@ impl ByteMultiple {
             ByteMultiple::KB => "K",
             ByteMultiple::MB => "M",
             ByteMultiple::GB => "G",
+            ByteMultiple::TB => "T",
+            ByteMultiple::PB => "P",
         }
     }
-}
 
-pub fn from_char_to_multiple(ch: char) -> ByteMultiple {
-    match ch.to_ascii_uppercase() {
-        'K' => ByteMultiple::KB,
-        'M' => ByteMultiple::MB,
-        'G' => ByteMultiple::GB,
-        _ => ByteMultiple::B,
+    pub fn from_char(ch: char) -> Self {
+        match ch.to_ascii_uppercase() {
+            'K' => ByteMultiple::KB,
+            'M' => ByteMultiple::MB,
+            'G' => ByteMultiple::GB,
+            'T' => ByteMultiple::TB,
+            'P' => ByteMultiple::PB,
+            _ => ByteMultiple::B,
+        }
+    }
+
+    /// Returns a String representing a quantity of bytes with its proper multiple (B, KB, MB, GB, TB)
+    pub fn formatted_string(bytes: u128) -> String {
+        #[allow(clippy::cast_precision_loss)]
+        let mut n = bytes as f32;
+
+        let byte_multiple = match bytes {
+            x if (0..u128::from(ByteMultiple::KB_MUL)).contains(&x) => ByteMultiple::B,
+            x if (u128::from(ByteMultiple::KB_MUL)..u128::from(ByteMultiple::MB_MUL))
+                .contains(&x) =>
+            {
+                ByteMultiple::KB
+            }
+            x if (u128::from(ByteMultiple::MB_MUL)..u128::from(ByteMultiple::GB_MUL))
+                .contains(&x) =>
+            {
+                ByteMultiple::MB
+            }
+            x if (u128::from(ByteMultiple::GB_MUL)..u128::from(ByteMultiple::TB_MUL))
+                .contains(&x) =>
+            {
+                ByteMultiple::GB
+            }
+            x if (u128::from(ByteMultiple::TB_MUL)..u128::from(ByteMultiple::PB_MUL))
+                .contains(&x) =>
+            {
+                ByteMultiple::TB
+            }
+            _ => ByteMultiple::PB,
+        };
+
+        #[allow(clippy::cast_precision_loss)]
+        let multiplier = byte_multiple.multiplier() as f32;
+        n /= multiplier;
+        let precision = usize::from(byte_multiple != ByteMultiple::B && n <= 9.95);
+        format!("{n:.precision$} {byte_multiple}")
     }
 }
 

--- a/src/networking/types/info_traffic.rs
+++ b/src/networking/types/info_traffic.rs
@@ -14,13 +14,13 @@ use crate::Service;
 /// Struct to be shared between the threads in charge of parsing packets and update reports.
 pub struct InfoTraffic {
     /// Total amount of filtered bytes received.
-    pub tot_received_bytes: u128,
+    pub tot_in_bytes: u128,
     /// Total amount of filtered bytes sent.
-    pub tot_sent_bytes: u128,
+    pub tot_out_bytes: u128,
     /// Total amount of filtered packets received.
-    pub tot_received_packets: u128,
+    pub tot_in_packets: u128,
     /// Total amount of filtered packets sent.
-    pub tot_sent_packets: u128,
+    pub tot_out_packets: u128,
     /// Total packets including those not filtered
     pub all_packets: u128,
     /// Total bytes including those not filtered
@@ -47,10 +47,10 @@ impl InfoTraffic {
     /// Constructs a new `InfoTraffic` element.
     pub fn new() -> Self {
         InfoTraffic {
-            tot_received_bytes: 0,
-            tot_sent_bytes: 0,
-            tot_received_packets: 0,
-            tot_sent_packets: 0,
+            tot_in_bytes: 0,
+            tot_out_bytes: 0,
+            tot_in_packets: 0,
+            tot_out_packets: 0,
             all_packets: 0,
             all_bytes: 0,
             dropped_packets: 0,
@@ -67,12 +67,12 @@ impl InfoTraffic {
     pub fn add_packet(&mut self, bytes: u128, traffic_direction: TrafficDirection) {
         if traffic_direction == TrafficDirection::Outgoing {
             //increment number of sent packets and bytes
-            self.tot_sent_packets += 1;
-            self.tot_sent_bytes += bytes;
+            self.tot_out_packets += 1;
+            self.tot_out_bytes += bytes;
         } else {
             //increment number of received packets and bytes
-            self.tot_received_packets += 1;
-            self.tot_received_bytes += bytes;
+            self.tot_in_packets += 1;
+            self.tot_in_bytes += bytes;
         }
     }
 }

--- a/src/notifications/notify_and_log.rs
+++ b/src/notifications/notify_and_log.rs
@@ -21,9 +21,8 @@ pub fn notify_and_log(
     let mut emitted_notifications = 0;
     // packets threshold
     if notifications.packets_notification.threshold.is_some() {
-        let sent_packets_entry = runtime_data.tot_sent_packets - runtime_data.tot_sent_packets_prev;
-        let received_packets_entry =
-            runtime_data.tot_received_packets - runtime_data.tot_received_packets_prev;
+        let sent_packets_entry = runtime_data.tot_out_packets - runtime_data.tot_out_packets_prev;
+        let received_packets_entry = runtime_data.tot_in_packets - runtime_data.tot_in_packets_prev;
         if received_packets_entry + sent_packets_entry
             > u128::from(notifications.packets_notification.threshold.unwrap())
         {
@@ -52,9 +51,8 @@ pub fn notify_and_log(
     }
     // bytes threshold
     if notifications.bytes_notification.threshold.is_some() {
-        let sent_bytes_entry = runtime_data.tot_sent_bytes - runtime_data.tot_sent_bytes_prev;
-        let received_bytes_entry =
-            runtime_data.tot_received_bytes - runtime_data.tot_received_bytes_prev;
+        let sent_bytes_entry = runtime_data.tot_out_bytes - runtime_data.tot_out_bytes_prev;
+        let received_bytes_entry = runtime_data.tot_in_bytes - runtime_data.tot_in_bytes_prev;
         if received_bytes_entry + sent_bytes_entry
             > u128::from(notifications.bytes_notification.threshold.unwrap())
         {

--- a/src/notifications/types/notifications.rs
+++ b/src/notifications/types/notifications.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
 
-use crate::networking::types::byte_multiple::from_char_to_multiple;
 use crate::notifications::types::sound::Sound;
 use crate::ByteMultiple;
 
@@ -110,16 +109,16 @@ impl BytesNotification {
         } else {
             // multiple
             let last_char = value.chars().last().unwrap();
-            byte_multiple_inserted = from_char_to_multiple(last_char);
+            byte_multiple_inserted = ByteMultiple::from_char(last_char);
             let without_multiple = value[0..value.len() - 1].trim().to_string();
             if without_multiple.parse::<u64>().is_ok()
                 && TryInto::<u64>::try_into(
                     without_multiple.parse::<u128>().unwrap()
-                        * u128::from(byte_multiple_inserted.get_multiplier()),
+                        * u128::from(byte_multiple_inserted.multiplier()),
                 )
                 .is_ok()
             {
-                without_multiple.parse::<u64>().unwrap() * byte_multiple_inserted.get_multiplier()
+                without_multiple.parse::<u64>().unwrap() * byte_multiple_inserted.multiplier()
             } else if without_multiple.is_empty() {
                 byte_multiple_inserted = ByteMultiple::B;
                 0

--- a/src/report/types/report_col.rs
+++ b/src/report/types/report_col.rs
@@ -90,7 +90,7 @@ impl ReportCol {
             }
             ReportCol::Proto => key.protocol.to_string(),
             ReportCol::Service => val.service.to_string(),
-            ReportCol::Bytes => get_formatted_bytes_string(val.transmitted_bytes, 1),
+            ReportCol::Bytes => get_formatted_bytes_string(val.transmitted_bytes),
             ReportCol::Packets => val.transmitted_packets.to_string(),
         }
     }

--- a/src/report/types/report_col.rs
+++ b/src/report/types/report_col.rs
@@ -7,7 +7,7 @@ use crate::translations::translations::{
 use crate::translations::translations_2::{destination_translation, source_translation};
 use crate::translations::translations_3::{port_translation, service_translation};
 use crate::translations::types::language::Language;
-use crate::utils::formatted_strings::get_formatted_bytes_string;
+use crate::ByteMultiple;
 
 // total width: 1012.0
 
@@ -90,7 +90,7 @@ impl ReportCol {
             }
             ReportCol::Proto => key.protocol.to_string(),
             ReportCol::Service => val.service.to_string(),
-            ReportCol::Bytes => get_formatted_bytes_string(val.transmitted_bytes),
+            ReportCol::Bytes => ByteMultiple::formatted_string(val.transmitted_bytes),
             ReportCol::Packets => val.transmitted_packets.to_string(),
         }
     }

--- a/src/utils/formatted_strings.rs
+++ b/src/utils/formatted_strings.rs
@@ -78,7 +78,7 @@ pub fn get_active_filters_string(filters: &Filters, language: Language) -> Strin
 }
 
 /// Returns a String representing a quantity of bytes with its proper multiple (K, M, G, T)
-pub fn get_formatted_bytes_string(bytes: u128, precision: usize) -> String {
+pub fn get_formatted_bytes_string(bytes: u128) -> String {
     let mut multiple_transmitted = String::new();
     #[allow(clippy::cast_precision_loss)]
     let mut n = bytes as f32;
@@ -108,13 +108,14 @@ pub fn get_formatted_bytes_string(bytes: u128, precision: usize) -> String {
         n.to_string()
     } else {
         // with multiple
+        let precision = usize::from(n <= 9.95);
         format!("{n:.precision$} {multiple_transmitted}")
     }
 }
 
 /// Returns a String representing a quantity of bytes with its proper multiple (B, KB, MB, GB, TB)
-pub fn get_formatted_bytes_string_with_b(bytes: u128, precision: usize) -> String {
-    let mut bytes_string = get_formatted_bytes_string(bytes, precision);
+pub fn get_formatted_bytes_string_with_b(bytes: u128) -> String {
+    let mut bytes_string = get_formatted_bytes_string(bytes);
     if bytes_string.parse::<f32>().is_ok() {
         // no multiple
         bytes_string.push(' ');

--- a/src/utils/formatted_strings.rs
+++ b/src/utils/formatted_strings.rs
@@ -77,53 +77,6 @@ pub fn get_active_filters_string(filters: &Filters, language: Language) -> Strin
     filters_string
 }
 
-/// Returns a String representing a quantity of bytes with its proper multiple (K, M, G, T)
-pub fn get_formatted_bytes_string(bytes: u128) -> String {
-    let mut multiple_transmitted = String::new();
-    #[allow(clippy::cast_precision_loss)]
-    let mut n = bytes as f32;
-
-    match bytes {
-        0..=999 => {}
-        1_000..=999_999 => {
-            n /= 1000_f32;
-            multiple_transmitted.push('K');
-        } // kilo
-        1_000_000..=999_999_999 => {
-            n /= 1_000_000_f32;
-            multiple_transmitted.push('M');
-        } // mega
-        1_000_000_000..=999_999_999_999 => {
-            n /= 1_000_000_000_f32;
-            multiple_transmitted.push('G');
-        } // giga
-        _ => {
-            n /= 1_000_000_000_000_f32;
-            multiple_transmitted.push('T');
-        } // tera
-    }
-
-    if multiple_transmitted.is_empty() {
-        // no multiple
-        n.to_string()
-    } else {
-        // with multiple
-        let precision = usize::from(n <= 9.95);
-        format!("{n:.precision$} {multiple_transmitted}")
-    }
-}
-
-/// Returns a String representing a quantity of bytes with its proper multiple (B, KB, MB, GB, TB)
-pub fn get_formatted_bytes_string_with_b(bytes: u128) -> String {
-    let mut bytes_string = get_formatted_bytes_string(bytes);
-    if bytes_string.parse::<f32>().is_ok() {
-        // no multiple
-        bytes_string.push(' ');
-    }
-    bytes_string.push('B');
-    bytes_string
-}
-
 // /// Returns the default report path
 // pub fn get_default_report_file_path() -> String {
 //     return if let Ok(mut config_path) = confy::get_configuration_file_path(SNIFFNET_LOWERCASE, "file") {


### PR DESCRIPTION
This PR changes the **interpolation method** used for data points represented in the traffic chart.

Instead of linear interpolation, now a **cosine-like spline** is used.
This results in a smoother and overall better-looking traffic chart (see pictures below).

***

<div align=center>

<h3> Before </h3>
<img width=80% src="https://github.com/GyulyVGC/sniffnet/assets/100347457/813d970f-c185-476d-911e-fa2782eb03e8">


<h3> After </h3>
<img width=80% src="https://github.com/GyulyVGC/sniffnet/assets/100347457/73cc9f11-b2f5-41d6-8b4b-b6001145cc8d">

</div>
