### PR TITLE
Export PCAP files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ $RECYCLE.BIN/
 ### Custom... ###
 Dockerfile
 lcov.info
+*.pcap

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All Sniffnet releases with the relative changes are documented in this file.
 ## [UNRELEASED]
 - Added support for ICMP connections and messages ([#417](https://github.com/GyulyVGC/sniffnet/pull/417) — fixes [#288](https://github.com/GyulyVGC/sniffnet/issues/288))
 - Added capability to identify 6000+ upper layer services, protocols, trojans, and worms ([#450](https://github.com/GyulyVGC/sniffnet/pull/450) — fixes [#374](https://github.com/GyulyVGC/sniffnet/issues/374))
+- Added feature to optionally export the analysis as a PCAP file with a custom path ([#473](https://github.com/GyulyVGC/sniffnet/pull/473) — fixes [#162](https://github.com/GyulyVGC/sniffnet/issues/162) and [#291](https://github.com/GyulyVGC/sniffnet/issues/291))
 - Introduced new filtering capabilities to allow users specify custom values of ports and IP addresses ([#414](https://github.com/GyulyVGC/sniffnet/pull/414))
 - The size of text and widgets can now be customised by setting a proper zoom value (fixes [#202](https://github.com/GyulyVGC/sniffnet/issues/202) and [#344](https://github.com/GyulyVGC/sniffnet/issues/344))
 - Added possibility to totally customize the app's theme via styles defined in TOML files ([#286](https://github.com/GyulyVGC/sniffnet/pull/286) and [#419](https://github.com/GyulyVGC/sniffnet/pull/419))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,13 +39,13 @@ strip = true
 [dependencies]
 pcap = "1.2.0"
 etherparse = "0.14.2"
-chrono = { version = "0.4.33", default_features = false, features = ["clock"] }
+chrono = { version = "0.4.35", default_features = false, features = ["clock"] }
 plotters = { version = "0.3.5", default_features = false, features = ["area_series"] }
 iced = { version = "0.12.1", features = ["tokio", "svg", "advanced", "lazy"] }
 plotters-iced = "0.10.0"
 maxminddb = "0.24.0"
-confy = "0.6.0"
-serde = { version = "1.0.196", default_features = false, features = ["derive"] }
+confy = "0.6.1"
+serde = { version = "1.0.197", default_features = false, features = ["derive"] }
 rodio = { version = "0.17.3", default_features = false, features = ["mp3"] }
 dns-lookup = "2.0.4"
 toml = "0.8.10"

--- a/src/configs/types/config_device.rs
+++ b/src/configs/types/config_device.rs
@@ -58,7 +58,7 @@ impl ConfigDevice {
                     name: device.name,
                     desc: device.desc,
                     addresses: Arc::new(Mutex::new(device.addresses)),
-                    link_type: MyLinkType::NotYetAssigned,
+                    link_type: MyLinkType::default(),
                 };
             }
         }
@@ -72,7 +72,7 @@ impl ConfigDevice {
             name: standard_device.name,
             desc: standard_device.desc,
             addresses: Arc::new(Mutex::new(standard_device.addresses)),
-            link_type: MyLinkType::NotYetAssigned,
+            link_type: MyLinkType::default(),
         }
     }
 }

--- a/src/gui/pages/initial_page.rs
+++ b/src/gui/pages/initial_page.rs
@@ -3,7 +3,7 @@
 //! It contains elements to select network adapter and traffic filters.
 
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::Path;
 
 use iced::alignment::{Horizontal, Vertical};
 use iced::widget::scrollable::Direction;
@@ -88,13 +88,17 @@ pub fn initial_page(sniffer: &Sniffer) -> Container<Message, StyleType> {
                 .push(col_port_filter),
         )
         .push(Rule::horizontal(40))
-        .push(get_export_pcap_group(
-            sniffer.export_pcap,
-            sniffer.output_pcap_dir.clone(),
-            sniffer.output_pcap_file.clone(),
-            language,
-            font,
-        ))
+        .push(
+            Container::new(get_export_pcap_group(
+                sniffer.export_pcap,
+                &sniffer.output_pcap_dir,
+                &sniffer.output_pcap_file,
+                language,
+                font,
+            ))
+            .height(Length::Fill)
+            .align_y(Vertical::Top),
+        )
         .push(
             Container::new(button_start(
                 font,
@@ -104,7 +108,7 @@ pub fn initial_page(sniffer: &Sniffer) -> Container<Message, StyleType> {
             ))
             .width(Length::Fill)
             .height(Length::Fill)
-            .align_y(Vertical::Center)
+            .align_y(Vertical::Top)
             .align_x(Horizontal::Center),
         );
 
@@ -371,8 +375,8 @@ fn get_col_adapter(sniffer: &Sniffer, font: Font) -> Column<Message, StyleType> 
 
 fn get_export_pcap_group(
     export_pcap: bool,
-    output_pcap_path: PathBuf,
-    output_pcap_file: String,
+    output_pcap_path: &Path,
+    output_pcap_file: &str,
     language: Language,
     font: Font,
 ) -> Container<'static, Message, StyleType> {
@@ -392,10 +396,23 @@ fn get_export_pcap_group(
                 Row::new()
                     .align_items(Alignment::Center)
                     .spacing(5)
+                    .push(Text::new(format!("{}:", file_name_translation(language))).font(font))
+                    .push(
+                        TextInput::new("sniffnet.pcap", output_pcap_file)
+                            .on_input(Message::OutputPcapFile)
+                            .padding([2, 5])
+                            .font(font)
+                            .width(200),
+                    ),
+            )
+            .push(
+                Row::new()
+                    .align_items(Alignment::Center)
+                    .spacing(5)
                     .push(Text::new(format!("{}:", directory_translation(language))).font(font))
                     .push(
                         Text::new(get_path_termination_string(
-                            &output_pcap_path.to_string_lossy().to_string(),
+                            &output_pcap_path.to_string_lossy(),
                             25,
                         ))
                         .font(font),
@@ -408,19 +425,6 @@ fn get_export_pcap_group(
                         true,
                         Message::OutputPcapDir,
                     )),
-            )
-            .push(
-                Row::new()
-                    .align_items(Alignment::Center)
-                    .spacing(5)
-                    .push(Text::new(format!("{}:", file_name_translation(language))).font(font))
-                    .push(
-                        TextInput::new("sniffnet.pcap", &output_pcap_file)
-                            .on_input(Message::OutputPcapFile)
-                            .padding([2, 5])
-                            .font(font)
-                            .width(200),
-                    ),
             );
         ret_val = ret_val.push(inner_col);
         Container::new(ret_val)

--- a/src/gui/pages/initial_page.rs
+++ b/src/gui/pages/initial_page.rs
@@ -406,15 +406,9 @@ fn get_export_pcap_group(
                     .align_items(Alignment::Center)
                     .spacing(5)
                     .push(Text::new(format!("{}:", directory_translation(language))).font(font))
-                    .push(
-                        Text::new(get_path_termination_string(
-                            &directory.to_string_lossy(),
-                            25,
-                        ))
-                        .font(font),
-                    )
+                    .push(Text::new(get_path_termination_string(directory, 25)).font(font))
                     .push(button_open_file(
-                        directory.to_string_lossy().to_string(),
+                        directory.to_owned(),
                         FileInfo::Directory,
                         language,
                         font,

--- a/src/gui/pages/settings_general_page.rs
+++ b/src/gui/pages/settings_general_page.rs
@@ -291,7 +291,8 @@ fn button_clear_mmdb(
             .font(font)
             .vertical_alignment(Vertical::Center)
             .horizontal_alignment(Horizontal::Center)
-            .size(15),
+            .size(15)
+            .line_height(LineHeight::Relative(1.0)),
     )
     .padding(2)
     .height(20)

--- a/src/gui/pages/settings_notifications_page.rs
+++ b/src/gui/pages/settings_notifications_page.rs
@@ -279,7 +279,7 @@ fn input_group_packets(
                     false,
                 )
             })
-            .padding([3, 5])
+            .padding([2, 5])
             .font(font)
             .width(100),
         )
@@ -326,7 +326,7 @@ fn input_group_bytes(
                 let bytes_notification = BytesNotification::from(&value, Some(bytes_notification));
                 Message::UpdateNotificationSettings(Notification::Bytes(bytes_notification), false)
             })
-            .padding([3, 5])
+            .padding([2, 5])
             .font(font)
             .width(100),
         )

--- a/src/gui/types/export_pcap.rs
+++ b/src/gui/types/export_pcap.rs
@@ -1,0 +1,60 @@
+use std::path::PathBuf;
+
+pub struct ExportPcap {
+    enabled: bool,
+    file_name: String,
+    directory: PathBuf,
+}
+
+impl ExportPcap {
+    pub const DEFAULT_FILE_NAME: &'static str = "sniffnet.pcap";
+
+    pub fn toggle(&mut self) {
+        self.enabled = !self.enabled;
+    }
+
+    pub fn set_file_name(&mut self, file_name: String) {
+        self.file_name = file_name;
+    }
+
+    pub fn set_directory(&mut self, directory: PathBuf) {
+        self.directory = directory;
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    pub fn file_name(&self) -> &str {
+        &self.file_name
+    }
+
+    pub fn directory(&self) -> &PathBuf {
+        &self.directory
+    }
+
+    pub fn full_path(&self) -> Option<String> {
+        if self.enabled {
+            let mut full_path = self.directory.clone();
+            let file_name = if self.file_name.is_empty() {
+                Self::DEFAULT_FILE_NAME
+            } else {
+                &self.file_name
+            };
+            full_path.push(file_name);
+            Some(full_path.to_string_lossy().to_string())
+        } else {
+            None
+        }
+    }
+}
+
+impl Default for ExportPcap {
+    fn default() -> Self {
+        ExportPcap {
+            enabled: false,
+            file_name: String::from(Self::DEFAULT_FILE_NAME),
+            directory: PathBuf::from(std::env::var("HOME").unwrap_or_default()),
+        }
+    }
+}

--- a/src/gui/types/message.rs
+++ b/src/gui/types/message.rs
@@ -99,12 +99,16 @@ pub enum Message {
     CustomCountryDb(String),
     /// The ASN MMDB custom path has been updated
     CustomAsnDb(String),
-    // /// The path for the output report has been updated
-    // CustomReport(String),
     /// Save the configurations of the app and quit
     CloseRequested,
     /// Copies the given string to clipboard
     CopyIp(String),
     /// Launch a new file dialog
     OpenFile(String, FileInfo, fn(String) -> Message),
+    /// Toggle export pcap file
+    ToggleExportPcap,
+    /// The output PCAP directory has been updated
+    OutputPcapDir(String),
+    /// The output PCAP file name has been updated
+    OutputPcapFile(String),
 }

--- a/src/gui/types/mod.rs
+++ b/src/gui/types/mod.rs
@@ -1,3 +1,4 @@
+pub mod export_pcap;
 pub mod message;
 pub mod runtime_data;
 pub mod sniffer;

--- a/src/gui/types/sniffer.rs
+++ b/src/gui/types/sniffer.rs
@@ -325,7 +325,7 @@ impl Sniffer {
                 self.export_pcap.toggle();
             }
             Message::OutputPcapDir(path) => {
-                self.export_pcap.set_directory(path.into());
+                self.export_pcap.set_directory(path);
             }
             Message::OutputPcapFile(name) => {
                 self.export_pcap.set_file_name(name);

--- a/src/gui/types/sniffer.rs
+++ b/src/gui/types/sniffer.rs
@@ -23,7 +23,7 @@ use crate::gui::types::timing_events::TimingEvents;
 use crate::mmdb::asn::ASN_MMDB;
 use crate::mmdb::country::COUNTRY_MMDB;
 use crate::mmdb::types::mmdb_reader::MmdbReader;
-use crate::networking::manage_packets::get_capture_context;
+use crate::networking::types::capture_context::CaptureContext;
 use crate::networking::types::filters::Filters;
 use crate::networking::types::host::Host;
 use crate::networking::types::ip_collection::AddressCollection;
@@ -397,8 +397,8 @@ impl Sniffer {
         self.set_adapter(current_device_name);
         let device = self.device.clone();
         let pcap_path = self.export_pcap.full_path();
-        let capture_context = get_capture_context(&device, &pcap_path);
-        self.pcap_error = capture_context.error();
+        let capture_context = CaptureContext::new(&device, &pcap_path);
+        self.pcap_error = capture_context.error().map(ToString::to_string);
         let info_traffic_mutex = self.info_traffic.clone();
         *info_traffic_mutex.lock().unwrap() = InfoTraffic::new();
         self.runtime_data = RunTimeData::new();
@@ -414,7 +414,7 @@ impl Sniffer {
             let filters = self.filters.clone();
             let country_mmdb_reader = self.country_mmdb_reader.clone();
             let asn_mmdb_reader = self.asn_mmdb_reader.clone();
-            self.device.link_type = capture_context.my_link_type().unwrap_or_default();
+            self.device.link_type = capture_context.my_link_type();
             thread::Builder::new()
                 .name("thread_parse_packets".to_string())
                 .spawn(move || {

--- a/src/gui/types/sniffer.rs
+++ b/src/gui/types/sniffer.rs
@@ -616,20 +616,19 @@ impl Sniffer {
             folder_path.to_string_lossy().to_string()
         };
 
-        let dialog = rfd::AsyncFileDialog::new().set_title(file_info.action_info(language));
+        let dialog = rfd::AsyncFileDialog::new()
+            .set_title(file_info.action_info(language))
+            .set_directory(starting_directory);
+
         let picked = if file_info == FileInfo::Directory {
-            dialog
-                .pick_folder()
-                .await
-                .unwrap_or_else(|| FileHandle::from(PathBuf::from(&old_file)))
+            dialog.pick_folder().await
         } else {
             dialog
                 .add_filter(file_info.get_extension(), &[file_info.get_extension()])
-                .set_directory(starting_directory)
                 .pick_file()
                 .await
-                .unwrap_or_else(|| FileHandle::from(PathBuf::from(&old_file)))
-        };
+        }
+        .unwrap_or_else(|| FileHandle::from(PathBuf::from(&old_file)));
 
         picked.path().to_string_lossy().to_string()
     }

--- a/src/networking/manage_packets.rs
+++ b/src/networking/manage_packets.rs
@@ -6,12 +6,13 @@ use std::sync::{Arc, Mutex};
 use chrono::Local;
 use dns_lookup::lookup_addr;
 use etherparse::{Ethernet2Header, LaxPacketHeaders, NetHeaders, TransportHeader};
-use pcap::{Active, Address, Capture, Device};
+use pcap::{Address, Capture, Device};
 
 use crate::mmdb::asn::get_asn;
 use crate::mmdb::country::get_country;
 use crate::mmdb::types::mmdb_reader::MmdbReader;
 use crate::networking::types::address_port_pair::AddressPortPair;
+use crate::networking::types::capture_context::CaptureContext;
 use crate::networking::types::data_info_host::DataInfoHost;
 use crate::networking::types::host::Host;
 use crate::networking::types::icmp_type::{IcmpType, IcmpTypeV4, IcmpTypeV6};
@@ -564,34 +565,33 @@ pub fn is_my_address(local_address: &String, my_interface_addresses: &Vec<Addres
 }
 
 /// Determines if the capture opening resolves into an Error
-pub fn get_capture_result(
-    device: &MyDevice,
-    pcap_path: &Option<String>,
-) -> (Option<String>, Option<Capture<Active>>) {
-    let cap_result = Capture::from_device(device.to_pcap_device())
+pub fn get_capture_context(device: &MyDevice, pcap_path: &Option<String>) -> CaptureContext {
+    let cap_res = Capture::from_device(device.to_pcap_device())
         .expect("Capture initialization error\n\r")
         .promisc(true)
         .snaplen(if pcap_path.is_some() {
             i32::from(u16::MAX)
         } else {
-            256
-        }) //limit stored packets slice dimension (to keep more in the buffer)
+            256 //limit stored packets slice dimension (to keep more in the buffer)
+        })
         .immediate_mode(true) //parse packets ASAP!
         .open();
-    if cap_result.is_err() {
-        let err_string = cap_result.err().unwrap().to_string();
-        (Some(err_string), None)
-    } else if let Some(path) = pcap_path {
-        // assert the file can be created
-        let file = cap_result.as_ref().unwrap().savefile(path);
-        if file.is_err() {
-            let err_string = file.err().unwrap().to_string();
-            (Some(err_string), None)
+
+    if let Err(e) = &cap_res {
+        return CaptureContext::Error(e.to_string());
+    }
+
+    let cap = cap_res.unwrap();
+
+    if let Some(path) = pcap_path {
+        let savefile_res = cap.savefile(path);
+        if let Err(e) = savefile_res {
+            CaptureContext::Error(e.to_string())
         } else {
-            (None, cap_result.ok())
+            CaptureContext::new_online_with_savefile(cap, savefile_res.unwrap())
         }
     } else {
-        (None, cap_result.ok())
+        CaptureContext::new_online(cap)
     }
 }
 

--- a/src/networking/manage_packets.rs
+++ b/src/networking/manage_packets.rs
@@ -564,11 +564,14 @@ pub fn is_my_address(local_address: &String, my_interface_addresses: &Vec<Addres
 }
 
 /// Determines if the capture opening resolves into an Error
-pub fn get_capture_result(device: &MyDevice) -> (Option<String>, Option<Capture<Active>>) {
+pub fn get_capture_result(
+    device: &MyDevice,
+    export_pcap: bool,
+) -> (Option<String>, Option<Capture<Active>>) {
     let cap_result = Capture::from_device(device.to_pcap_device())
         .expect("Capture initialization error\n\r")
         .promisc(true)
-        .snaplen(u16::MAX as i32) //limit stored packets slice dimension (to keep more in the buffer)
+        .snaplen(if export_pcap { u16::MAX as i32 } else { 256 }) //limit stored packets slice dimension (to keep more in the buffer)
         .immediate_mode(true) //parse packets ASAP!
         .open();
     if cap_result.is_err() {

--- a/src/networking/manage_packets.rs
+++ b/src/networking/manage_packets.rs
@@ -568,7 +568,7 @@ pub fn get_capture_result(device: &MyDevice) -> (Option<String>, Option<Capture<
     let cap_result = Capture::from_device(device.to_pcap_device())
         .expect("Capture initialization error\n\r")
         .promisc(true)
-        .snaplen(256) //limit stored packets slice dimension (to keep more in the buffer)
+        .snaplen(u16::MAX as i32) //limit stored packets slice dimension (to keep more in the buffer)
         .immediate_mode(true) //parse packets ASAP!
         .open();
     if cap_result.is_err() {

--- a/src/networking/types/capture_context.rs
+++ b/src/networking/types/capture_context.rs
@@ -1,0 +1,57 @@
+use crate::networking::types::my_link_type::MyLinkType;
+use pcap::{Active, Capture, Savefile};
+
+pub enum CaptureContext {
+    Online(Online),
+    OnlineWithSavefile(OnlineWithSavefile),
+    Error(String),
+}
+
+impl CaptureContext {
+    pub fn new_online(cap: Capture<Active>) -> CaptureContext {
+        CaptureContext::Online(Online { cap })
+    }
+
+    pub fn new_online_with_savefile(cap: Capture<Active>, savefile: Savefile) -> CaptureContext {
+        CaptureContext::OnlineWithSavefile(OnlineWithSavefile {
+            online: Online { cap },
+            savefile,
+        })
+    }
+
+    pub fn error(&self) -> Option<String> {
+        match self {
+            CaptureContext::Error(e) => Some(e.clone()),
+            _ => None,
+        }
+    }
+
+    pub fn consume(self) -> (Capture<Active>, Option<Savefile>) {
+        match self {
+            CaptureContext::Online(o) => (o.cap, None),
+            CaptureContext::OnlineWithSavefile(ows) => (ows.online.cap, Some(ows.savefile)),
+            CaptureContext::Error(_) => panic!(),
+        }
+    }
+
+    pub fn my_link_type(&self) -> Option<MyLinkType> {
+        match self {
+            CaptureContext::Online(o) => {
+                Some(MyLinkType::from_pcap_link_type(o.cap.get_datalink()))
+            }
+            CaptureContext::OnlineWithSavefile(ows) => Some(MyLinkType::from_pcap_link_type(
+                ows.online.cap.get_datalink(),
+            )),
+            CaptureContext::Error(_) => None,
+        }
+    }
+}
+
+pub struct Online {
+    cap: Capture<Active>,
+}
+
+pub struct OnlineWithSavefile {
+    online: Online,
+    savefile: Savefile,
+}

--- a/src/networking/types/capture_context.rs
+++ b/src/networking/types/capture_context.rs
@@ -1,3 +1,4 @@
+use crate::networking::types::my_device::MyDevice;
 use crate::networking::types::my_link_type::MyLinkType;
 use pcap::{Active, Capture, Savefile};
 
@@ -8,41 +9,69 @@ pub enum CaptureContext {
 }
 
 impl CaptureContext {
-    pub fn new_online(cap: Capture<Active>) -> CaptureContext {
-        CaptureContext::Online(Online { cap })
+    pub fn new(device: &MyDevice, pcap_path: &Option<String>) -> Self {
+        let cap_res = Capture::from_device(device.to_pcap_device())
+            .expect("Capture initialization error\n\r")
+            .promisc(true)
+            .snaplen(if pcap_path.is_some() {
+                i32::from(u16::MAX)
+            } else {
+                256 //limit stored packets slice dimension (to keep more in the buffer)
+            })
+            .immediate_mode(true) //parse packets ASAP!
+            .open();
+
+        if let Err(e) = &cap_res {
+            return Self::Error(e.to_string());
+        }
+
+        let cap = cap_res.unwrap();
+
+        if let Some(path) = pcap_path {
+            let savefile_res = cap.savefile(path);
+            if let Err(e) = savefile_res {
+                Self::Error(e.to_string())
+            } else {
+                Self::new_online_with_savefile(cap, savefile_res.unwrap())
+            }
+        } else {
+            Self::new_online(cap)
+        }
     }
 
-    pub fn new_online_with_savefile(cap: Capture<Active>, savefile: Savefile) -> CaptureContext {
-        CaptureContext::OnlineWithSavefile(OnlineWithSavefile {
+    fn new_online(cap: Capture<Active>) -> Self {
+        Self::Online(Online { cap })
+    }
+
+    fn new_online_with_savefile(cap: Capture<Active>, savefile: Savefile) -> Self {
+        Self::OnlineWithSavefile(OnlineWithSavefile {
             online: Online { cap },
             savefile,
         })
     }
 
-    pub fn error(&self) -> Option<String> {
+    pub fn error(&self) -> Option<&str> {
         match self {
-            CaptureContext::Error(e) => Some(e.clone()),
+            Self::Error(e) => Some(e),
             _ => None,
         }
     }
 
     pub fn consume(self) -> (Capture<Active>, Option<Savefile>) {
         match self {
-            CaptureContext::Online(o) => (o.cap, None),
-            CaptureContext::OnlineWithSavefile(ows) => (ows.online.cap, Some(ows.savefile)),
-            CaptureContext::Error(_) => panic!(),
+            Self::Online(o) => (o.cap, None),
+            Self::OnlineWithSavefile(ows) => (ows.online.cap, Some(ows.savefile)),
+            Self::Error(_) => panic!(),
         }
     }
 
-    pub fn my_link_type(&self) -> Option<MyLinkType> {
+    pub fn my_link_type(&self) -> MyLinkType {
         match self {
-            CaptureContext::Online(o) => {
-                Some(MyLinkType::from_pcap_link_type(o.cap.get_datalink()))
+            Self::Online(o) => MyLinkType::from_pcap_link_type(o.cap.get_datalink()),
+            Self::OnlineWithSavefile(ows) => {
+                MyLinkType::from_pcap_link_type(ows.online.cap.get_datalink())
             }
-            CaptureContext::OnlineWithSavefile(ows) => Some(MyLinkType::from_pcap_link_type(
-                ows.online.cap.get_datalink(),
-            )),
-            CaptureContext::Error(_) => None,
+            Self::Error(_) => MyLinkType::default(),
         }
     }
 }

--- a/src/networking/types/mod.rs
+++ b/src/networking/types/mod.rs
@@ -1,6 +1,7 @@
 pub mod address_port_pair;
 pub mod asn;
 pub mod byte_multiple;
+pub mod capture_context;
 pub mod data_info;
 pub mod data_info_host;
 pub mod filters;

--- a/src/networking/types/my_link_type.rs
+++ b/src/networking/types/my_link_type.rs
@@ -8,7 +8,7 @@ use crate::translations::translations_3::link_type_translation;
 use crate::{Language, StyleType};
 
 /// Currently supported link types
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 pub enum MyLinkType {
     Null(Linktype),
     Ethernet(Linktype),
@@ -17,6 +17,7 @@ pub enum MyLinkType {
     IPv4(Linktype),
     IPv6(Linktype),
     Unsupported(Linktype),
+    #[default]
     NotYetAssigned,
 }
 

--- a/src/secondary_threads/parse_packets.rs
+++ b/src/secondary_threads/parse_packets.rs
@@ -34,7 +34,7 @@ pub fn parse_packets(
     asn_mmdb_reader: &Arc<MmdbReader>,
     capture_context: CaptureContext,
 ) {
-    let my_link_type = capture_context.my_link_type().unwrap_or_default();
+    let my_link_type = capture_context.my_link_type();
     let (mut cap, mut savefile) = capture_context.consume();
 
     let capture_id = *current_capture_id.lock().unwrap();

--- a/src/secondary_threads/parse_packets.rs
+++ b/src/secondary_threads/parse_packets.rs
@@ -7,12 +7,13 @@ use std::thread;
 use etherparse::err::ip::{HeaderError, LaxHeaderSliceError};
 use etherparse::err::{Layer, LenError};
 use etherparse::{LaxPacketHeaders, LenSource};
-use pcap::{Active, Capture, Packet};
+use pcap::Packet;
 
 use crate::mmdb::types::mmdb_reader::MmdbReader;
 use crate::networking::manage_packets::{
     analyze_headers, get_address_to_lookup, modify_or_insert_in_map, reverse_dns_lookup,
 };
+use crate::networking::types::capture_context::CaptureContext;
 use crate::networking::types::data_info::DataInfo;
 use crate::networking::types::filters::Filters;
 use crate::networking::types::icmp_type::IcmpType;
@@ -27,22 +28,16 @@ use crate::InfoTraffic;
 pub fn parse_packets(
     current_capture_id: &Arc<Mutex<usize>>,
     device: &MyDevice,
-    mut cap: Capture<Active>,
     filters: &Filters,
     info_traffic_mutex: &Arc<Mutex<InfoTraffic>>,
     country_mmdb_reader: &Arc<MmdbReader>,
     asn_mmdb_reader: &Arc<MmdbReader>,
-    pcap_path: Option<String>,
+    capture_context: CaptureContext,
 ) {
+    let my_link_type = capture_context.my_link_type().unwrap_or_default();
+    let (mut cap, mut savefile) = capture_context.consume();
+
     let capture_id = *current_capture_id.lock().unwrap();
-
-    let my_link_type = MyLinkType::from_pcap_link_type(cap.get_datalink());
-
-    let mut output_opt = if let Some(path) = pcap_path {
-        cap.savefile(path).ok()
-    } else {
-        None
-    };
 
     loop {
         match cap.next_packet() {
@@ -79,8 +74,8 @@ pub fn parse_packets(
                     let passed_filters = filters.matches(&packet_filters_fields);
                     if passed_filters {
                         // save this packet to PCAP file
-                        if let Some(output) = output_opt.as_mut() {
-                            output.write(&packet);
+                        if let Some(file) = savefile.as_mut() {
+                            file.write(&packet);
                         }
                         // update the shared map
                         new_info = modify_or_insert_in_map(

--- a/src/secondary_threads/parse_packets.rs
+++ b/src/secondary_threads/parse_packets.rs
@@ -32,13 +32,17 @@ pub fn parse_packets(
     info_traffic_mutex: &Arc<Mutex<InfoTraffic>>,
     country_mmdb_reader: &Arc<MmdbReader>,
     asn_mmdb_reader: &Arc<MmdbReader>,
-    pcap_path: String,
+    pcap_path: Option<String>,
 ) {
     let capture_id = *current_capture_id.lock().unwrap();
 
     let my_link_type = MyLinkType::from_pcap_link_type(cap.get_datalink());
 
-    let mut output_opt = cap.savefile(pcap_path).ok();
+    let mut output_opt = if let Some(path) = pcap_path {
+        cap.savefile(path).ok()
+    } else {
+        None
+    };
 
     loop {
         match cap.next_packet() {

--- a/src/translations/translations_3.rs
+++ b/src/translations/translations_3.rs
@@ -152,3 +152,36 @@ pub fn service_translation(language: Language) -> &'static str {
         _ => "Service",
     }
 }
+
+pub fn export_capture_translation(language: Language) -> &'static str {
+    match language {
+        Language::EN => "Export capture file",
+        Language::IT => "Esporta file di cattura",
+        _ => "Export capture file",
+    }
+}
+
+// (a filesystem directory)
+pub fn directory_translation(language: Language) -> &'static str {
+    match language {
+        Language::EN => "Directory",
+        Language::IT => "Cartella",
+        _ => "Directory",
+    }
+}
+
+pub fn select_directory_translation(language: Language) -> &'static str {
+    match language {
+        Language::EN => "Select destination directory",
+        Language::IT => "Seleziona cartella di destinazione",
+        _ => "Select destination directory",
+    }
+}
+
+pub fn file_name_translation(language: Language) -> &'static str {
+    match language {
+        Language::EN => "File name",
+        Language::IT => "Nome del file",
+        _ => "File name",
+    }
+}

--- a/src/utils/formatted_strings.rs
+++ b/src/utils/formatted_strings.rs
@@ -11,8 +11,6 @@ use crate::Language;
 /// Application version number (to be displayed in gui footer)
 pub const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-// pub const PCAP_FILE_NAME: &str = "sniffnet.pcap";
-
 /// Computes the String representing the percentage of filtered bytes/packets
 pub fn get_percentage_string(observed: u128, filtered: u128) -> String {
     #[allow(clippy::cast_precision_loss)]
@@ -76,39 +74,6 @@ pub fn get_active_filters_string(filters: &Filters, language: Language) -> Strin
     }
     filters_string
 }
-
-// /// Returns the default report path
-// pub fn get_default_report_file_path() -> String {
-//     return if let Ok(mut config_path) = confy::get_configuration_file_path(SNIFFNET_LOWERCASE, "file") {
-//         config_path.pop();
-//         config_path.push(PCAP_FILE_NAME);
-//         config_path.to_string_lossy().to_string()
-//     } else {
-//         let mut path = PathBuf::from(std::env::var_os("HOME").unwrap());
-//         path.push(PCAP_FILE_NAME);
-//         path.to_string_lossy().to_string()
-//     };
-// }
-
-// /// Returns the file to use for the output PCAP report
-// /// It tries and fallbacks in the order: custom path, configs path, home directory path
-// // /// This function also updates the custom path text input TODO!
-// pub fn set_report_file_to_use(custom_path: &str) -> File {
-//     if let Ok(custom_file) = File::create(custom_path) {
-//         return custom_file;
-//     } else if let Ok(mut config_path) =
-//         confy::get_configuration_file_path(SNIFFNET_LOWERCASE, "file")
-//     {
-//         config_path.pop();
-//         config_path.push(PCAP_FILE_NAME);
-//         if let Ok(file) = File::create(config_path) {
-//             return file;
-//         }
-//     }
-//     let mut path = PathBuf::from(std::env::var_os("HOME").unwrap());
-//     path.push(PCAP_FILE_NAME);
-//     File::create(path).unwrap()
-// }
 
 pub fn print_cli_welcome_message() {
     print!(

--- a/src/utils/types/file_info.rs
+++ b/src/utils/types/file_info.rs
@@ -1,12 +1,13 @@
 use crate::translations::translations_3::{
-    database_from_file_translation, style_from_file_translation,
+    database_from_file_translation, select_directory_translation, style_from_file_translation,
 };
 use crate::translations::types::language::Language;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum FileInfo {
     Style,
     Database,
+    Directory,
 }
 
 impl FileInfo {
@@ -14,6 +15,7 @@ impl FileInfo {
         match self {
             FileInfo::Style => "toml",
             FileInfo::Database => "mmdb",
+            FileInfo::Directory => "",
         }
     }
 
@@ -21,6 +23,7 @@ impl FileInfo {
         match self {
             FileInfo::Style => style_from_file_translation(language),
             FileInfo::Database => database_from_file_translation(language),
+            FileInfo::Directory => select_directory_translation(language),
         }
     }
 }


### PR DESCRIPTION
This PR finally implements a feature requested for a long time: the **generation of packet capture files (PCAP)**.

The possibility to export such kind of file is a big step forward in making Sniffnet compatible with most of the existing network monitoring tools.

Users can choose whether they want to generate a capture file (disabled by default) and can set a custom path for it.

_Note: the introduction of this feature completely replaces the old textual report._

Fixes #162 and #291.