### PR TITLE
clippy: apply missing_const_for_fn lint

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: clippy
         if:  matrix.os != 'windows' || github.event_name != 'pull_request'
-        run: cargo clippy -- -D warnings
+        run: cargo clippy -- -W clippy::all -D clippy::missing_const_for_fn -D warnings
 
       - name: test
         if: matrix.os != 'windows' || github.event_name != 'pull_request'

--- a/src/chart/types/chart_type.rs
+++ b/src/chart/types/chart_type.rs
@@ -11,7 +11,7 @@ pub enum ChartType {
 impl ChartType {
     pub(crate) const ALL: [ChartType; 2] = [ChartType::Bytes, ChartType::Packets];
 
-    pub fn get_label(&self, language: Language) -> &str {
+    pub const fn get_label(&self, language: Language) -> &str {
         match self {
             ChartType::Packets => packets_translation(language),
             ChartType::Bytes => bytes_translation(language),

--- a/src/chart/types/traffic_chart.rs
+++ b/src/chart/types/traffic_chart.rs
@@ -100,7 +100,7 @@ impl TrafficChart {
         }
     }
 
-    fn x_axis_range(&self) -> Range<f32> {
+    const fn x_axis_range(&self) -> Range<f32> {
         let first_time_displayed = if self.ticks > 30 { self.ticks - 30 } else { 0 };
         let tot_seconds = self.ticks - 1;
         #[allow(clippy::cast_precision_loss)]
@@ -125,7 +125,7 @@ impl TrafficChart {
             .color(&to_rgb_color(self.style.get_palette().text_body))
     }
 
-    fn spline_to_plot(&self, direction: TrafficDirection) -> &Spline<f32, f32> {
+    const fn spline_to_plot(&self, direction: TrafficDirection) -> &Spline<f32, f32> {
         match self.chart_type {
             ChartType::Packets => match direction {
                 TrafficDirection::Incoming => &self.in_packets,
@@ -138,7 +138,7 @@ impl TrafficChart {
         }
     }
 
-    fn series_label(&self, direction: TrafficDirection) -> &str {
+    const fn series_label(&self, direction: TrafficDirection) -> &str {
         match direction {
             TrafficDirection::Incoming => incoming_translation(self.language),
             TrafficDirection::Outgoing => outgoing_translation(self.language),

--- a/src/gui/pages/overview_page.rs
+++ b/src/gui/pages/overview_page.rs
@@ -616,7 +616,7 @@ fn col_bytes_packets(
             of_total_translation(language, &get_percentage_string(total, u128::from(dropped)))
         )
     } else {
-        none_translation(language).to_string()
+        none_translation(language)
     };
     let bytes_value = if dropped > 0 {
         ByteMultiple::formatted_string(filtered_bytes)

--- a/src/gui/pages/types/running_page.rs
+++ b/src/gui/pages/types/running_page.rs
@@ -24,7 +24,7 @@ impl RunningPage {
         RunningPage::Notifications,
     ];
 
-    pub fn get_tab_label(&self, language: Language) -> &str {
+    pub const fn get_tab_label(&self, language: Language) -> &str {
         match self {
             RunningPage::Overview => overview_translation(language),
             RunningPage::Inspect => inspect_translation(language),
@@ -33,7 +33,7 @@ impl RunningPage {
         }
     }
 
-    pub fn next(self) -> Self {
+    pub const fn next(self) -> Self {
         match self {
             RunningPage::Overview => RunningPage::Inspect,
             RunningPage::Inspect => RunningPage::Notifications,
@@ -42,7 +42,7 @@ impl RunningPage {
         }
     }
 
-    pub fn previous(self) -> Self {
+    pub const fn previous(self) -> Self {
         match self {
             RunningPage::Overview => RunningPage::Notifications,
             RunningPage::Inspect => RunningPage::Overview,
@@ -61,7 +61,7 @@ impl RunningPage {
         .to_text()
     }
 
-    pub fn action(self) -> Message {
+    pub const fn action(self) -> Message {
         Message::ChangeRunningPage(self)
     }
 }

--- a/src/gui/pages/types/settings_page.rs
+++ b/src/gui/pages/types/settings_page.rs
@@ -22,7 +22,7 @@ impl SettingsPage {
         SettingsPage::General,
     ];
 
-    pub fn get_tab_label(&self, language: Language) -> &str {
+    pub const fn get_tab_label(&self, language: Language) -> &str {
         match self {
             SettingsPage::Notifications => notifications_translation(language),
             SettingsPage::Appearance => style_translation(language),
@@ -30,7 +30,7 @@ impl SettingsPage {
         }
     }
 
-    pub fn next(self) -> Self {
+    pub const fn next(self) -> Self {
         match self {
             SettingsPage::Notifications => SettingsPage::Appearance,
             SettingsPage::Appearance => SettingsPage::General,
@@ -38,7 +38,7 @@ impl SettingsPage {
         }
     }
 
-    pub fn previous(self) -> Self {
+    pub const fn previous(self) -> Self {
         match self {
             SettingsPage::Notifications => SettingsPage::General,
             SettingsPage::Appearance => SettingsPage::Notifications,
@@ -55,7 +55,7 @@ impl SettingsPage {
         .to_text()
     }
 
-    pub fn action(self) -> Message {
+    pub const fn action(self) -> Message {
         Message::OpenSettings(self)
     }
 }

--- a/src/gui/types/export_pcap.rs
+++ b/src/gui/types/export_pcap.rs
@@ -21,7 +21,7 @@ impl ExportPcap {
         self.directory = directory;
     }
 
-    pub fn enabled(&self) -> bool {
+    pub const fn enabled(&self) -> bool {
         self.enabled
     }
 

--- a/src/networking/types/address_port_pair.rs
+++ b/src/networking/types/address_port_pair.rs
@@ -25,7 +25,7 @@ impl AddressPortPair {
     /// * `address` - A string representing the network layer IPv4 or IPv6 address.
     ///
     /// * `port` - An integer representing the transport layer port number (in the range 0..=65535).
-    pub fn new(
+    pub const fn new(
         address1: String,
         port1: Option<u16>,
         address2: String,

--- a/src/networking/types/byte_multiple.rs
+++ b/src/networking/types/byte_multiple.rs
@@ -26,7 +26,7 @@ impl fmt::Display for ByteMultiple {
 }
 
 impl ByteMultiple {
-    pub fn multiplier(self) -> u64 {
+    pub const fn multiplier(self) -> u64 {
         match self {
             ByteMultiple::B => 1,
             ByteMultiple::KB => 1_000,
@@ -77,7 +77,7 @@ impl ByteMultiple {
             .to_owned()
     }
 
-    pub fn from_char(ch: char) -> Self {
+    pub const fn from_char(ch: char) -> Self {
         match ch.to_ascii_uppercase() {
             'K' => ByteMultiple::KB,
             'M' => ByteMultiple::MB,

--- a/src/networking/types/data_info.rs
+++ b/src/networking/types/data_info.rs
@@ -26,27 +26,27 @@ pub struct DataInfo {
 }
 
 impl DataInfo {
-    pub fn incoming_packets(&self) -> u128 {
+    pub const fn incoming_packets(&self) -> u128 {
         self.incoming_packets
     }
 
-    pub fn outgoing_packets(&self) -> u128 {
+    pub const fn outgoing_packets(&self) -> u128 {
         self.outgoing_packets
     }
 
-    pub fn incoming_bytes(&self) -> u128 {
+    pub const fn incoming_bytes(&self) -> u128 {
         self.incoming_bytes
     }
 
-    pub fn outgoing_bytes(&self) -> u128 {
+    pub const fn outgoing_bytes(&self) -> u128 {
         self.outgoing_bytes
     }
 
-    pub fn tot_packets(&self) -> u128 {
+    pub const fn tot_packets(&self) -> u128 {
         self.incoming_packets + self.outgoing_packets
     }
 
-    pub fn tot_bytes(&self) -> u128 {
+    pub const fn tot_bytes(&self) -> u128 {
         self.incoming_bytes + self.outgoing_bytes
     }
 

--- a/src/networking/types/icmp_type.rs
+++ b/src/networking/types/icmp_type.rs
@@ -83,7 +83,7 @@ pub enum IcmpTypeV4 {
 }
 
 impl IcmpTypeV4 {
-    pub fn from_etherparse(icmpv4type: &Icmpv4Type) -> IcmpType {
+    pub const fn from_etherparse(icmpv4type: &Icmpv4Type) -> IcmpType {
         IcmpType::V4(match icmpv4type {
             Icmpv4Type::EchoReply(_) => Self::EchoReply,
             Icmpv4Type::DestinationUnreachable(_) => Self::DestinationUnreachable,
@@ -207,7 +207,7 @@ pub enum IcmpTypeV6 {
 }
 
 impl IcmpTypeV6 {
-    pub fn from_etherparse(icmpv6type: &Icmpv6Type) -> IcmpType {
+    pub const fn from_etherparse(icmpv6type: &Icmpv6Type) -> IcmpType {
         IcmpType::V6(match icmpv6type {
             Icmpv6Type::DestinationUnreachable(_) => Self::DestinationUnreachable,
             Icmpv6Type::PacketTooBig { .. } => Self::PacketTooBig,

--- a/src/networking/types/my_link_type.rs
+++ b/src/networking/types/my_link_type.rs
@@ -22,11 +22,11 @@ pub enum MyLinkType {
 }
 
 impl MyLinkType {
-    pub fn is_supported(self) -> bool {
+    pub const fn is_supported(self) -> bool {
         !matches!(self, Self::Unsupported(_) | Self::NotYetAssigned)
     }
 
-    pub fn from_pcap_link_type(link_type: Linktype) -> Self {
+    pub const fn from_pcap_link_type(link_type: Linktype) -> Self {
         match link_type {
             Linktype::NULL => Self::Null(link_type),
             Linktype::ETHERNET => Self::Ethernet(link_type),

--- a/src/notifications/types/notifications.rs
+++ b/src/notifications/types/notifications.rs
@@ -155,7 +155,7 @@ impl Default for FavoriteNotification {
 
 impl FavoriteNotification {
     /// Constructor when the notification is in use
-    pub fn on(sound: Sound) -> Self {
+    pub const fn on(sound: Sound) -> Self {
         FavoriteNotification {
             notify_on_favorite: true,
             sound,
@@ -163,7 +163,7 @@ impl FavoriteNotification {
     }
 
     /// Constructor when the notification is not in use. Note that sound is used here for caching, although it won't actively be used.
-    pub fn off(sound: Sound) -> Self {
+    pub const fn off(sound: Sound) -> Self {
         FavoriteNotification {
             notify_on_favorite: false,
             sound,

--- a/src/notifications/types/sound.rs
+++ b/src/notifications/types/sound.rs
@@ -34,7 +34,7 @@ impl fmt::Display for Sound {
 impl Sound {
     pub(crate) const ALL: [Sound; 4] = [Gulp, Pop, Swhoosh, Sound::None];
 
-    fn mp3_sound(self) -> &'static [u8] {
+    const fn mp3_sound(self) -> &'static [u8] {
         match self {
             Gulp => GULP,
             Pop => POP,

--- a/src/report/types/report_col.rs
+++ b/src/report/types/report_col.rs
@@ -95,7 +95,7 @@ impl ReportCol {
         }
     }
 
-    pub(crate) fn get_width(&self) -> f32 {
+    pub(crate) const fn get_width(&self) -> f32 {
         match self {
             ReportCol::SrcIp | ReportCol::DstIp => LARGE_COL_WIDTH,
             _ => SMALL_COL_WIDTH,
@@ -116,7 +116,7 @@ impl ReportCol {
         }
     }
 
-    pub(crate) fn get_filter_input_type(&self) -> FilterInputType {
+    pub(crate) const fn get_filter_input_type(&self) -> FilterInputType {
         match self {
             ReportCol::SrcIp => FilterInputType::AddressSrc,
             ReportCol::DstIp => FilterInputType::AddressDst,

--- a/src/report/types/report_sort_type.rs
+++ b/src/report/types/report_sort_type.rs
@@ -38,7 +38,7 @@ impl ReportSortType {
         }
     }
 
-    pub fn button_type(self, report_col: &ReportCol) -> ButtonType {
+    pub const fn button_type(self, report_col: &ReportCol) -> ButtonType {
         match report_col {
             ReportCol::Bytes => self.byte_sort.button_type(),
             ReportCol::Packets => self.packet_sort.button_type(),

--- a/src/report/types/sort_type.rs
+++ b/src/report/types/sort_type.rs
@@ -13,7 +13,7 @@ pub enum SortType {
 }
 
 impl SortType {
-    pub fn next_sort(self) -> Self {
+    pub const fn next_sort(self) -> Self {
         match self {
             SortType::Ascending => SortType::Neutral,
             SortType::Descending => SortType::Ascending,
@@ -35,7 +35,7 @@ impl SortType {
         .size(size)
     }
 
-    pub fn button_type(self) -> ButtonType {
+    pub const fn button_type(self) -> ButtonType {
         match self {
             SortType::Ascending | SortType::Descending => ButtonType::SortArrowActive,
             SortType::Neutral => ButtonType::SortArrows,

--- a/src/secondary_threads/parse_packets.rs
+++ b/src/secondary_threads/parse_packets.rs
@@ -227,7 +227,7 @@ fn from_null(packet: &[u8]) -> Result<LaxPacketHeaders, LaxHeaderSliceError> {
 
     let is_valid_af_inet = {
         // based on https://wiki.wireshark.org/NullLoopback.md (2023-12-31)
-        fn matches(value: u32) -> bool {
+        const fn matches(value: u32) -> bool {
             match value {
                 // 2 = IPv4 on all platforms
                 // 24, 28, or 30 = IPv6 depending on platform

--- a/src/translations/translations.rs
+++ b/src/translations/translations.rs
@@ -235,7 +235,7 @@ pub fn traffic_rate_translation(language: Language) -> Text<'static, StyleType> 
     })
 }
 
-// pub const fn relevant_connections_translation(language: Language) -> Text<'static, StyleType> {
+// pub fn relevant_connections_translation(language: Language) -> Text<'static, StyleType> {
 //     Text::new(match language {
 //         Language::EN => "Relevant connections:",
 //         Language::IT => "Connessioni rilevanti:",
@@ -725,7 +725,7 @@ pub fn of_total_translation(language: Language, percentage: &str) -> String {
     }
 }
 
-// pub const fn filtered_application_translation(language: Language) -> Text<'static,StyleType> {
+// pub fn filtered_application_translation(language: Language) -> Text<'static,StyleType> {
 //     Text::new(match language {
 //         Language::EN => "Filtered packets per application protocol:",
 //         Language::IT => "Pacchetti filtrati per protocollo applicativo:",
@@ -747,7 +747,7 @@ pub fn of_total_translation(language: Language, percentage: &str) -> String {
 //     })
 // }
 
-// pub const fn no_favorites_translation(language: Language) -> Text<'static, StyleType> {
+// pub fn no_favorites_translation(language: Language) -> Text<'static, StyleType> {
 //     Text::new(match language {
 //         Language::EN => "Nothing to show at the moment.\n\
 //                          To add a connection to your favorites, click on the star symbol near the connection.",

--- a/src/translations/translations.rs
+++ b/src/translations/translations.rs
@@ -29,7 +29,7 @@ pub fn choose_adapters_translation(language: Language) -> Text<'static, StyleTyp
     })
 }
 
-// pub fn application_protocol_translation(language: Language) -> &'static str {
+// pub const fn application_protocol_translation(language: Language) -> &'static str {
 //     match language {
 //         Language::EN => "Application protocol",
 //         Language::IT => "Protocollo applicativo",
@@ -77,7 +77,7 @@ pub fn select_filters_translation(language: Language) -> Text<'static, StyleType
     })
 }
 
-pub fn start_translation(language: Language) -> &'static str {
+pub const fn start_translation(language: Language) -> &'static str {
     match language {
         Language::EN | Language::DE | Language::RO | Language::KO => "Start!",
         Language::IT => "Avvia!",
@@ -98,7 +98,7 @@ pub fn start_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn address_translation(language: Language) -> &'static str {
+pub const fn address_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Address",
         Language::IT => "Indirizzo",
@@ -120,7 +120,7 @@ pub fn address_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn addresses_translation(language: Language) -> &'static str {
+pub const fn addresses_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Addresses",
         Language::IT => "Indirizzi",
@@ -144,7 +144,7 @@ pub fn addresses_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn ip_version_translation(language: Language) -> &'static str {
+pub const fn ip_version_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "IP version",
         Language::IT => "Versione IP",
@@ -168,7 +168,7 @@ pub fn ip_version_translation(language: Language) -> &'static str {
     }
 }
 
-// pub fn transport_protocol_translation(language: Language) -> &'static str {
+// pub const fn transport_protocol_translation(language: Language) -> &'static str {
 //     match language {
 //         Language::EN => "Transport protocol",
 //         Language::IT => "Protocollo di trasporto",
@@ -191,7 +191,7 @@ pub fn ip_version_translation(language: Language) -> &'static str {
 //     }
 // }
 
-pub fn protocol_translation(language: Language) -> &'static str {
+pub const fn protocol_translation(language: Language) -> &'static str {
     match language {
         Language::EN | Language::RO => "Protocol",
         Language::IT => "Protocollo",
@@ -235,7 +235,7 @@ pub fn traffic_rate_translation(language: Language) -> Text<'static, StyleType> 
     })
 }
 
-// pub fn relevant_connections_translation(language: Language) -> Text<'static, StyleType> {
+// pub const fn relevant_connections_translation(language: Language) -> Text<'static, StyleType> {
 //     Text::new(match language {
 //         Language::EN => "Relevant connections:",
 //         Language::IT => "Connessioni rilevanti:",
@@ -257,7 +257,7 @@ pub fn traffic_rate_translation(language: Language) -> Text<'static, StyleType> 
 //     })
 // }
 
-pub fn settings_translation(language: Language) -> &'static str {
+pub const fn settings_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Settings",
         Language::IT => "Impostazioni",
@@ -330,26 +330,27 @@ pub fn ask_quit_translation(language: Language) -> Text<'static, StyleType> {
 
 pub fn quit_analysis_translation(language: Language) -> String {
     match language {
-        Language::EN => "Quit analysis".to_string(),
-        Language::IT => "Interrompi analisi".to_string(),
-        Language::FR => "Quitter l'analyse".to_string(),
-        Language::ES => "Quitar el análisis".to_string(),
-        Language::PL => "Zakończ analize".to_string(),
-        Language::DE => "Analyse beenden".to_string(),
-        Language::UK => "Закінчити аналіз".to_string(),
-        Language::ZH => "退出监控".to_string(),
-        Language::RO => "Renunță la analiză".to_string(),
-        Language::KO => "분석종료".to_string(),
-        Language::TR => "Analizden çık".to_string(),
-        Language::RU => "Закончить анализ".to_string(),
-        Language::PT => "Sair da análise".to_string(),
-        Language::EL => "Έξοδος ανάλυσης".to_string(),
-        // Language::FA => "خروج از تحلیل".to_string(),
-        Language::SV => "Avsluta analys".to_string(),
-        Language::FI => "Lopeta analyysi".to_string(),
-        Language::JA => "分析の終了".to_string(),
-        Language::UZ => "Tahlildan chiqish".to_string(),
+        Language::EN => "Quit analysis",
+        Language::IT => "Interrompi analisi",
+        Language::FR => "Quitter l'analyse",
+        Language::ES => "Quitar el análisis",
+        Language::PL => "Zakończ analize",
+        Language::DE => "Analyse beenden",
+        Language::UK => "Закінчити аналіз",
+        Language::ZH => "退出监控",
+        Language::RO => "Renunță la analiză",
+        Language::KO => "분석종료",
+        Language::TR => "Analizden çık",
+        Language::RU => "Закончить анализ",
+        Language::PT => "Sair da análise",
+        Language::EL => "Έξοδος ανάλυσης",
+        // Language::FA => "خروج از تحلیل",
+        Language::SV => "Avsluta analys",
+        Language::FI => "Lopeta analyysi",
+        Language::JA => "分析の終了",
+        Language::UZ => "Tahlildan chiqish",
     }
+    .to_string()
 }
 
 pub fn ask_clear_all_translation(language: Language) -> Text<'static, StyleType> {
@@ -378,29 +379,30 @@ pub fn ask_clear_all_translation(language: Language) -> Text<'static, StyleType>
 
 pub fn clear_all_translation(language: Language) -> String {
     match language {
-        Language::EN => "Clear all".to_string(),
-        Language::IT => "Elimina tutto".to_string(),
-        Language::FR => "Tout effacer".to_string(),
-        Language::ES => "Borrar todo".to_string(),
-        Language::PL => "Wyczyść wszystko".to_string(),
-        Language::DE => "Alle löschen".to_string(),
-        Language::UK => "Видалити все".to_string(),
-        Language::ZH => "清除所有".to_string(),
-        Language::RO => "Ștergeți tot".to_string(),
-        Language::KO => "모두 지우기".to_string(),
-        Language::TR => "Hepsini temizle".to_string(),
-        Language::RU => "Очистить всё".to_string(),
-        Language::PT => "Limpar tudo".to_string(),
-        Language::EL => "Εκκαθάριση όλων".to_string(),
-        // Language::FA => "پاک کردن همه".to_string(),
-        Language::SV => "Radera alla".to_string(),
-        Language::FI => "Tyhjennä kaikki".to_string(),
-        Language::JA => "すべて削除".to_string(),
-        Language::UZ => "Barchasini tozalash".to_string(),
+        Language::EN => "Clear all",
+        Language::IT => "Elimina tutto",
+        Language::FR => "Tout effacer",
+        Language::ES => "Borrar todo",
+        Language::PL => "Wyczyść wszystko",
+        Language::DE => "Alle löschen",
+        Language::UK => "Видалити все",
+        Language::ZH => "清除所有",
+        Language::RO => "Ștergeți tot",
+        Language::KO => "모두 지우기",
+        Language::TR => "Hepsini temizle",
+        Language::RU => "Очистить всё",
+        Language::PT => "Limpar tudo",
+        Language::EL => "Εκκαθάριση όλων",
+        // Language::FA => "پاک کردن همه",
+        Language::SV => "Radera alla",
+        Language::FI => "Tyhjennä kaikki",
+        Language::JA => "すべて削除",
+        Language::UZ => "Barchasini tozalash",
     }
+    .to_string()
 }
 
-pub fn hide_translation(language: Language) -> &'static str {
+pub const fn hide_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Hide",
         Language::IT => "Nascondi",
@@ -424,7 +426,7 @@ pub fn hide_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn network_adapter_translation(language: Language) -> &'static str {
+pub const fn network_adapter_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Network adapter",
         Language::IT => "Adattatore di rete",
@@ -638,7 +640,7 @@ pub fn some_observed_translation(language: Language, observed: u128) -> Text<'st
     })
 }
 
-pub fn filtered_packets_translation(language: Language) -> &'static str {
+pub const fn filtered_packets_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Filtered packets",
         Language::IT => "Pacchetti filtrati",
@@ -662,7 +664,7 @@ pub fn filtered_packets_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn filtered_bytes_translation(language: Language) -> &'static str {
+pub const fn filtered_bytes_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Filtered bytes",
         Language::IT => "Byte filtrati",
@@ -723,7 +725,7 @@ pub fn of_total_translation(language: Language, percentage: &str) -> String {
     }
 }
 
-// pub fn filtered_application_translation(language: Language) -> Text<'static,StyleType> {
+// pub const fn filtered_application_translation(language: Language) -> Text<'static,StyleType> {
 //     Text::new(match language {
 //         Language::EN => "Filtered packets per application protocol:",
 //         Language::IT => "Pacchetti filtrati per protocollo applicativo:",
@@ -745,7 +747,7 @@ pub fn of_total_translation(language: Language, percentage: &str) -> String {
 //     })
 // }
 
-// pub fn no_favorites_translation(language: Language) -> Text<'static, StyleType> {
+// pub const fn no_favorites_translation(language: Language) -> Text<'static, StyleType> {
 //     Text::new(match language {
 //         Language::EN => "Nothing to show at the moment.\n\
 //                          To add a connection to your favorites, click on the star symbol near the connection.",
@@ -865,7 +867,7 @@ pub fn error_translation(language: Language, error: &str) -> Text<'static, Style
     })
 }
 
-// pub fn both_translation(language: Language) -> &'static str {
+// pub const fn both_translation(language: Language) -> &'static str {
 //     match language {
 //         Language::EN => "both",
 //         Language::IT => "entrambi",
@@ -888,7 +890,7 @@ pub fn error_translation(language: Language, error: &str) -> Text<'static, Style
 //     }
 // }
 
-// pub fn all_protocols_translation(language: Language) -> &'static str {
+// pub const fn all_protocols_translation(language: Language) -> &'static str {
 //     match language {
 //         Language::EN => "All protocols",
 //         Language::IT => "Tutti i protocolli",
@@ -903,7 +905,7 @@ pub fn error_translation(language: Language, error: &str) -> Text<'static, Style
 //     }
 // }
 
-// pub fn all_translation(language: Language) -> &'static str {
+// pub const fn all_translation(language: Language) -> &'static str {
 //     match language {
 //         Language::EN => "All",
 //         Language::IT => "Tutti",
@@ -926,7 +928,7 @@ pub fn error_translation(language: Language, error: &str) -> Text<'static, Style
 //     }
 // }
 
-pub fn packets_translation(language: Language) -> &'static str {
+pub const fn packets_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "packets",
         Language::IT => "pacchetti",
@@ -949,7 +951,7 @@ pub fn packets_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn packets_chart_translation(language: Language) -> &'static str {
+pub const fn packets_chart_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "packets per second",
         Language::IT => "pacchetti al secondo",
@@ -973,7 +975,7 @@ pub fn packets_chart_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn bytes_translation(language: Language) -> &'static str {
+pub const fn bytes_translation(language: Language) -> &'static str {
     match language {
         Language::EN | Language::ES | Language::PT | Language::EL | Language::SV => "bytes",
         Language::DE => "Bytes",
@@ -992,7 +994,7 @@ pub fn bytes_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn bytes_chart_translation(language: Language) -> &'static str {
+pub const fn bytes_chart_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "bytes per second",
         Language::IT => "byte al secondo",
@@ -1015,7 +1017,7 @@ pub fn bytes_chart_translation(language: Language) -> &'static str {
     }
 }
 
-// pub fn recent_report_translation(language: Language) -> &'static str {
+// pub const fn recent_report_translation(language: Language) -> &'static str {
 //     match language {
 //         Language::EN => "most recent",
 //         Language::IT => "più recenti",
@@ -1039,7 +1041,7 @@ pub fn bytes_chart_translation(language: Language) -> &'static str {
 //     }
 // }
 
-// pub fn packets_report_translation(language: Language) -> &'static str {
+// pub const fn packets_report_translation(language: Language) -> &'static str {
 //     match language {
 //         Language::EN => "most packets",
 //         Language::IT => "più pacchetti",
@@ -1063,7 +1065,7 @@ pub fn bytes_chart_translation(language: Language) -> &'static str {
 //     }
 // }
 
-// pub fn bytes_report_translation(language: Language) -> &'static str {
+// pub const fn bytes_report_translation(language: Language) -> &'static str {
 //     match language {
 //         Language::EN => "most bytes",
 //         Language::IT => "più byte",
@@ -1087,7 +1089,7 @@ pub fn bytes_chart_translation(language: Language) -> &'static str {
 //     }
 // }
 
-// pub fn favorite_report_translation(language: Language) -> &'static str {
+// pub const fn favorite_report_translation(language: Language) -> &'static str {
 //     match language {
 //         Language::EN => "favorites",
 //         Language::IT => "preferiti",
@@ -1156,7 +1158,7 @@ pub fn appearance_title_translation(language: Language) -> Text<'static, StyleTy
     })
 }
 
-pub fn active_filters_translation(language: Language) -> &'static str {
+pub const fn active_filters_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Active filters",
         Language::IT => "Filtri attivi",
@@ -1205,7 +1207,7 @@ pub fn none_translation(language: Language) -> String {
     .to_string()
 }
 
-pub fn yeti_night_translation(language: Language) -> &'static str {
+pub const fn yeti_night_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Sniffnet's original dark theme",
         Language::IT => "Il tema scuro originale di Sniffnet",
@@ -1229,7 +1231,7 @@ pub fn yeti_night_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn yeti_day_translation(language: Language) -> &'static str {
+pub const fn yeti_day_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Sniffnet's original light theme",
         Language::IT => "Il tema chiaro originale di Sniffnet",
@@ -1252,7 +1254,7 @@ pub fn yeti_day_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn deep_sea_translation(language: Language) -> &'static str {
+pub const fn deep_sea_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "To dive into network traffic",
         Language::IT => "Per immergersi nel traffico di rete",
@@ -1276,7 +1278,7 @@ pub fn deep_sea_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn mon_amour_translation(language: Language) -> &'static str {
+pub const fn mon_amour_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Lovely theme made for dreamers",
         Language::IT => "Tema incantevole fatto per i sognatori",
@@ -1300,7 +1302,7 @@ pub fn mon_amour_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn incoming_translation(language: Language) -> &'static str {
+pub const fn incoming_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Incoming",
         Language::IT => "In entrata",
@@ -1324,7 +1326,7 @@ pub fn incoming_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn outgoing_translation(language: Language) -> &'static str {
+pub const fn outgoing_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Outgoing",
         Language::IT => "In uscita",
@@ -1348,7 +1350,7 @@ pub fn outgoing_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn notifications_translation(language: Language) -> &'static str {
+pub const fn notifications_translation(language: Language) -> &'static str {
     match language {
         Language::EN | Language::FR => "Notifications",
         Language::IT => "Notifiche",
@@ -1370,7 +1372,7 @@ pub fn notifications_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn style_translation(language: Language) -> &'static str {
+pub const fn style_translation(language: Language) -> &'static str {
     match language {
         Language::EN | Language::FR => "Style",
         Language::IT => "Stile",
@@ -1389,7 +1391,7 @@ pub fn style_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn language_translation(language: Language) -> &'static str {
+pub const fn language_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Language",
         Language::IT => "Lingua",
@@ -1413,7 +1415,7 @@ pub fn language_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn overview_translation(language: Language) -> &'static str {
+pub const fn overview_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Overview",
         Language::IT => "Panoramica",
@@ -1437,7 +1439,7 @@ pub fn overview_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn packets_threshold_translation(language: Language) -> &'static str {
+pub const fn packets_threshold_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Notify me when a packets threshold is exceeded",
         Language::IT => "Notificami quando una soglia di pacchetti è superata",
@@ -1461,7 +1463,7 @@ pub fn packets_threshold_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn bytes_threshold_translation(language: Language) -> &'static str {
+pub const fn bytes_threshold_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Notify me when a bytes threshold is exceeded",
         Language::IT => "Notificami quando una soglia di byte è superata",
@@ -1485,7 +1487,7 @@ pub fn bytes_threshold_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn per_second_translation(language: Language) -> &'static str {
+pub const fn per_second_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "(per second)",
         Language::IT => "(al secondo)",
@@ -1507,7 +1509,7 @@ pub fn per_second_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn specify_multiples_translation(language: Language) -> &'static str {
+pub const fn specify_multiples_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "you can also specify 'K', 'M' and 'G'",
         Language::IT => "puoi anche specificare 'K', 'M' e 'G'",
@@ -1531,7 +1533,7 @@ pub fn specify_multiples_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn favorite_notification_translation(language: Language) -> &'static str {
+pub const fn favorite_notification_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Notify me when new data are exchanged from my favorites",
         Language::IT => "Notificami quando nuovi dati sono scambiati dai miei preferiti",
@@ -1559,29 +1561,30 @@ pub fn favorite_notification_translation(language: Language) -> &'static str {
 
 pub fn threshold_translation(language: Language) -> String {
     match language {
-        Language::EN => "Threshold".to_string(),
-        Language::IT => "Soglia".to_string(),
-        Language::FR => "Seuil".to_string(),
-        Language::ES => "Límite".to_string(),
-        Language::PL => "Próg".to_string(),
-        Language::DE => "Schwellenwert".to_string(),
-        Language::UK => "Ліміт".to_string(),
-        Language::ZH => "阈值".to_string(),
-        Language::RO => "Prag".to_string(),
-        Language::KO => "임계값".to_string(),
-        Language::TR => "Eşik".to_string(),
-        Language::RU => "Порог".to_string(),
-        Language::PT => "Limite".to_string(),
-        Language::EL => "όριο".to_string(),
-        // Language::FA => "آستانه".to_string(),
-        Language::SV => "Gräns".to_string(),
-        Language::FI => "Raja".to_string(),
-        Language::JA => "閾値".to_string(),
-        Language::UZ => "Eshik".to_string(),
+        Language::EN => "Threshold",
+        Language::IT => "Soglia",
+        Language::FR => "Seuil",
+        Language::ES => "Límite",
+        Language::PL => "Próg",
+        Language::DE => "Schwellenwert",
+        Language::UK => "Ліміт",
+        Language::ZH => "阈值",
+        Language::RO => "Prag",
+        Language::KO => "임계값",
+        Language::TR => "Eşik",
+        Language::RU => "Порог",
+        Language::PT => "Limite",
+        Language::EL => "όριο",
+        // Language::FA => "آستانه",
+        Language::SV => "Gräns",
+        Language::FI => "Raja",
+        Language::JA => "閾値",
+        Language::UZ => "Eshik",
     }
+    .to_string()
 }
 
-pub fn volume_translation(language: Language) -> &'static str {
+pub const fn volume_translation(language: Language) -> &'static str {
     match language {
         Language::EN | Language::IT | Language::FR | Language::PT => "Volume",
         Language::ES => "Volumen",
@@ -1601,7 +1604,7 @@ pub fn volume_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn sound_translation(language: Language) -> &'static str {
+pub const fn sound_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Sound",
         Language::IT => "Suono",
@@ -1623,7 +1626,7 @@ pub fn sound_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn bytes_exceeded_translation(language: Language) -> &'static str {
+pub const fn bytes_exceeded_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Bytes threshold exceeded!",
         Language::IT => "Soglia di Byte superata!",
@@ -1671,7 +1674,7 @@ pub fn bytes_exceeded_value_translation(language: Language, value: &str) -> Stri
     }
 }
 
-pub fn packets_exceeded_translation(language: Language) -> &'static str {
+pub const fn packets_exceeded_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Packets threshold exceeded!",
         Language::IT => "Soglia di pacchetti superata!",
@@ -1743,7 +1746,7 @@ pub fn packets_exceeded_value_translation(language: Language, value: u32) -> Str
     }
 }
 
-pub fn favorite_transmitted_translation(language: Language) -> &'static str {
+pub const fn favorite_transmitted_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "New data exchanged from favorites!",
         Language::IT => "Nuovi dati scambiati dai preferiti!",
@@ -1910,7 +1913,7 @@ pub fn no_notifications_received_translation(language: Language) -> Text<'static
     })
 }
 
-pub fn only_last_30_translation(language: Language) -> &'static str {
+pub const fn only_last_30_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Only the last 30 notifications are displayed",
         Language::IT => "Solo le ultime 30 notifiche sono mostrate",

--- a/src/translations/translations_2.rs
+++ b/src/translations/translations_2.rs
@@ -2,7 +2,7 @@
 
 use crate::Language;
 
-pub fn new_version_available_translation(language: Language) -> &'static str {
+pub const fn new_version_available_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "A newer version is available!",
         Language::IT => "Una versione più recente è disponibile!",
@@ -26,7 +26,7 @@ pub fn new_version_available_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn inspect_translation(language: Language) -> &'static str {
+pub const fn inspect_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Inspect",
         Language::IT => "Ispeziona",
@@ -50,7 +50,7 @@ pub fn inspect_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn connection_details_translation(language: Language) -> &'static str {
+pub const fn connection_details_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Connection details",
         Language::IT => "Dettagli della connessione",
@@ -74,7 +74,7 @@ pub fn connection_details_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn dropped_packets_translation(language: Language) -> &'static str {
+pub const fn dropped_packets_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Dropped packets",
         Language::IT => "Pacchetti mancati",
@@ -98,7 +98,7 @@ pub fn dropped_packets_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn data_representation_translation(language: Language) -> &'static str {
+pub const fn data_representation_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Data representation",
         Language::IT => "Rappresentazione dei dati",
@@ -122,7 +122,7 @@ pub fn data_representation_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn host_translation(language: Language) -> &'static str {
+pub const fn host_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Network host",
         Language::IT => "Host di rete",
@@ -146,7 +146,7 @@ pub fn host_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn only_top_30_items_translation(language: Language) -> &'static str {
+pub const fn only_top_30_items_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Only the top 30 items are displayed here",
         Language::IT => "Solo i 30 maggiori elementi sono mostrati qui",
@@ -170,7 +170,7 @@ pub fn only_top_30_items_translation(language: Language) -> &'static str {
     }
 }
 
-// pub fn sort_by_translation(language: Language) -> &'static str {
+// pub fn const sort_by_translation(language: Language) -> &'static str {
 //     match language {
 //         Language::EN => "Sort by",
 //         Language::IT => "Ordina per",
@@ -268,7 +268,7 @@ pub fn your_network_adapter_translation(language: Language) -> String {
     .to_string()
 }
 
-pub fn socket_address_translation(language: Language) -> &'static str {
+pub const fn socket_address_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Socket address",
         Language::IT => "Indirizzo del socket",
@@ -292,7 +292,7 @@ pub fn socket_address_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn mac_address_translation(language: Language) -> &'static str {
+pub const fn mac_address_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "MAC address",
         Language::IT => "Indirizzo MAC",
@@ -316,7 +316,7 @@ pub fn mac_address_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn source_translation(language: Language) -> &'static str {
+pub const fn source_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Source",
         Language::IT => "Sorgente",
@@ -340,7 +340,7 @@ pub fn source_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn destination_translation(language: Language) -> &'static str {
+pub const fn destination_translation(language: Language) -> &'static str {
     match language {
         Language::EN | Language::SV => "Destination",
         Language::IT => "Destinazione",
@@ -362,7 +362,7 @@ pub fn destination_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn fqdn_translation(language: Language) -> &'static str {
+pub const fn fqdn_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Fully qualified domain name",
         Language::IT => "Nome di dominio completo",
@@ -385,7 +385,7 @@ pub fn fqdn_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn administrative_entity_translation(language: Language) -> &'static str {
+pub const fn administrative_entity_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Autonomous System name",
         Language::IT => "Nome del sistema autonomo",
@@ -409,7 +409,7 @@ pub fn administrative_entity_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn transmitted_data_translation(language: Language) -> &'static str {
+pub const fn transmitted_data_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Transmitted data",
         Language::IT => "Dati trasmessi",
@@ -433,7 +433,7 @@ pub fn transmitted_data_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn country_translation(language: Language) -> &'static str {
+pub const fn country_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Country",
         Language::IT => "Paese",
@@ -456,7 +456,7 @@ pub fn country_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn domain_name_translation(language: Language) -> &'static str {
+pub const fn domain_name_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Domain name",
         Language::IT => "Nome di dominio",
@@ -480,7 +480,7 @@ pub fn domain_name_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn only_show_favorites_translation(language: Language) -> &'static str {
+pub const fn only_show_favorites_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Only show favorites",
         Language::IT => "Mostra solo i preferiti",
@@ -504,7 +504,7 @@ pub fn only_show_favorites_translation(language: Language) -> &'static str {
     }
 }
 
-// pub fn search_filters_translation(language: Language) -> &'static str {
+// pub const fn search_filters_translation(language: Language) -> &'static str {
 //     match language {
 //         Language::EN => "Search filters",
 //         Language::IT => "Filtri di ricerca",
@@ -528,7 +528,7 @@ pub fn only_show_favorites_translation(language: Language) -> &'static str {
 //     }
 // }
 
-pub fn no_search_results_translation(language: Language) -> &'static str {
+pub const fn no_search_results_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "No result available according to the specified search filters",
         Language::IT => "Nessun risultato disponibile secondo i filtri di ricerca specificati",
@@ -582,7 +582,7 @@ pub fn showing_results_translation(
 }
 
 #[allow(dead_code)]
-pub fn color_gradients_translation(language: Language) -> &'static str {
+pub const fn color_gradients_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Apply color gradients",
         Language::IT => "Applica sfumature di colore",

--- a/src/translations/translations_3.rs
+++ b/src/translations/translations_3.rs
@@ -6,7 +6,7 @@ use crate::translations::translations::network_adapter_translation;
 use crate::{Language, StyleType};
 
 // This is referred to settings (General settings)
-pub fn general_translation(language: Language) -> &'static str {
+pub const fn general_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "General",
         Language::ES => "Generales",
@@ -19,7 +19,7 @@ pub fn general_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn zoom_translation(language: Language) -> &'static str {
+pub const fn zoom_translation(language: Language) -> &'static str {
     match language {
         Language::EN | Language::IT | Language::ES | Language::FR | Language::DE => "Zoom",
         Language::PL => "Powiększenie",
@@ -28,7 +28,7 @@ pub fn zoom_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn mmdb_files_translation(language: Language) -> &'static str {
+pub const fn mmdb_files_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Database files",
         Language::ES => "Archivos de la base de datos",
@@ -41,7 +41,7 @@ pub fn mmdb_files_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn params_not_editable_translation(language: Language) -> &'static str {
+pub const fn params_not_editable_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "The following parameters can't be modified during the analysis",
         Language::ES => "Los siguientes parámetros no pueden modificarse durante el análisis",
@@ -54,7 +54,7 @@ pub fn params_not_editable_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn custom_style_translation(language: Language) -> &'static str {
+pub const fn custom_style_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Custom style",
         Language::ES => "Estilo personalizado",
@@ -67,7 +67,7 @@ pub fn custom_style_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn copy_translation(language: Language) -> &'static str {
+pub const fn copy_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Copy",
         Language::IT | Language::ES => "Copia",
@@ -79,7 +79,7 @@ pub fn copy_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn port_translation(language: Language) -> &'static str {
+pub const fn port_translation(language: Language) -> &'static str {
     match language {
         Language::EN | Language::FR | Language::DE | Language::PL => "Port",
         Language::ES => "Puerto",
@@ -89,7 +89,7 @@ pub fn port_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn invalid_filters_translation(language: Language) -> &'static str {
+pub const fn invalid_filters_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Invalid filters",
         Language::ES => "Filtros inválidos",
@@ -102,7 +102,7 @@ pub fn invalid_filters_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn messages_translation(language: Language) -> &'static str {
+pub const fn messages_translation(language: Language) -> &'static str {
     match language {
         Language::EN | Language::FR => "Messages",
         Language::ES => "Mensajes",
@@ -114,7 +114,7 @@ pub fn messages_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn link_type_translation(language: Language) -> &'static str {
+pub const fn link_type_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Link type",
         Language::ES => "Tipo de conexión",
@@ -147,7 +147,7 @@ pub fn unsupported_link_type_translation(
     Text::new(string)
 }
 
-pub fn style_from_file_translation(language: Language) -> &'static str {
+pub const fn style_from_file_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Select style from a file",
         Language::ES => "Selecciona el estilo desde un archivo",
@@ -160,7 +160,7 @@ pub fn style_from_file_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn database_from_file_translation(language: Language) -> &'static str {
+pub const fn database_from_file_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Select database file",
         Language::ES => "Selecciona un archivo de base de datos",
@@ -173,7 +173,7 @@ pub fn database_from_file_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn filter_by_host_translation(language: Language) -> &'static str {
+pub const fn filter_by_host_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Filter by network host",
         Language::ES => "Filtra por host de red",
@@ -186,7 +186,7 @@ pub fn filter_by_host_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn service_translation(language: Language) -> &'static str {
+pub const fn service_translation(language: Language) -> &'static str {
     match language {
         Language::EN | Language::FR | Language::DE => "Service",
         Language::ES => "Servicio",
@@ -197,7 +197,7 @@ pub fn service_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn export_capture_translation(language: Language) -> &'static str {
+pub const fn export_capture_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Export capture file",
         Language::IT => "Esporta file di cattura",
@@ -210,7 +210,7 @@ pub fn export_capture_translation(language: Language) -> &'static str {
 }
 
 // (a filesystem directory)
-pub fn directory_translation(language: Language) -> &'static str {
+pub const fn directory_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Directory",
         Language::IT => "Cartella",
@@ -222,7 +222,7 @@ pub fn directory_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn select_directory_translation(language: Language) -> &'static str {
+pub const fn select_directory_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Select destination directory",
         Language::IT => "Seleziona cartella di destinazione",
@@ -234,7 +234,7 @@ pub fn select_directory_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn file_name_translation(language: Language) -> &'static str {
+pub const fn file_name_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "File name",
         Language::IT => "Nome del file",
@@ -246,7 +246,7 @@ pub fn file_name_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn thumbnail_mode_translation(language: Language) -> &'static str {
+pub const fn thumbnail_mode_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Thumbnail mode",
         Language::IT => "Modalità miniatura",
@@ -258,7 +258,7 @@ pub fn thumbnail_mode_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn learn_more_translation(language: Language) -> &'static str {
+pub const fn learn_more_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Do you want to learn more?",
         Language::IT => "Vuoi saperne di più?",

--- a/src/translations/types/language.rs
+++ b/src/translations/types/language.rs
@@ -105,7 +105,7 @@ impl Language {
         .width(FLAGS_WIDTH_BIG)
     }
 
-    pub fn is_up_to_date(self) -> bool {
+    pub const fn is_up_to_date(self) -> bool {
         matches!(
             self,
             Language::FR | Language::EN | Language::IT | Language::DE | Language::PL | Language::RU

--- a/src/utils/types/file_info.rs
+++ b/src/utils/types/file_info.rs
@@ -11,7 +11,7 @@ pub enum FileInfo {
 }
 
 impl FileInfo {
-    pub fn get_extension(&self) -> &'static str {
+    pub const fn get_extension(&self) -> &'static str {
         match self {
             FileInfo::Style => "toml",
             FileInfo::Database => "mmdb",
@@ -19,7 +19,7 @@ impl FileInfo {
         }
     }
 
-    pub fn action_info(&self, language: Language) -> &'static str {
+    pub const fn action_info(&self, language: Language) -> &'static str {
         match self {
             FileInfo::Style => style_from_file_translation(language),
             FileInfo::Database => database_from_file_translation(language),

--- a/src/utils/types/icon.rs
+++ b/src/utils/types/icon.rs
@@ -47,7 +47,7 @@ pub enum Icon {
 }
 
 impl Icon {
-    pub fn codepoint(&self) -> char {
+    pub const fn codepoint(&self) -> char {
         match self {
             Icon::ArrowBack => 'C',
             Icon::ArrowLeft => 'i',

--- a/src/utils/types/web_page.rs
+++ b/src/utils/types/web_page.rs
@@ -16,7 +16,7 @@ pub enum WebPage {
 }
 
 impl WebPage {
-    pub fn get_url(&self) -> &str {
+    pub const fn get_url(&self) -> &str {
         match self {
             WebPage::Repo => "https://github.com/GyulyVGC/sniffnet",
             WebPage::Website => "https://www.sniffnet.net",


### PR DESCRIPTION
This PR applies the [missing_const_for_fn](https://rust-lang.github.io/rust-clippy/master/index.html#/missing_const_for_fn) lint and also adds it to the CI.

Technically the majority of them should be already optimized away, but if they can be const, should they be const?

I also found 3 instances of translations functions having per item `.to_string()` instead of on the entire match block and a single translation function call that was cloned unnecessarily.