### PR TITLE
Network host filters autocompletion via a dropdown menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All Sniffnet releases with the relative changes are documented in this file.
 
 ## [UNRELEASED]
+- Dropdown menus for network host filters ([#659](https://github.com/GyulyVGC/sniffnet/pull/659) — fixes [#354](https://github.com/GyulyVGC/sniffnet/issues/354))
 - Added CLI argument `--adapter [<NAME>]` to allow immediately starting the capture from a given network interface ([#643](https://github.com/GyulyVGC/sniffnet/pull/643) — fixes [#636](https://github.com/GyulyVGC/sniffnet/issues/636))
 - Added Vietnamese translation 🇻🇳 ([#577](https://github.com/GyulyVGC/sniffnet/pull/577))
 - Ask for quit confirmation before stopping an ongoing analysis ([#652](https://github.com/GyulyVGC/sniffnet/pull/652) — fixes [#570](https://github.com/GyulyVGC/sniffnet/issues/570))

--- a/src/gui/components/footer.rs
+++ b/src/gui/components/footer.rs
@@ -1,6 +1,6 @@
 //! GUI bottom footer
 
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
 use iced::widget::text::LineHeight;
 use iced::widget::tooltip::Position;
@@ -28,7 +28,7 @@ pub fn footer<'a>(
     color_gradient: GradientType,
     font: Font,
     font_footer: Font,
-    newer_release_available: &Arc<Mutex<Option<bool>>>,
+    newer_release_available: &Mutex<Option<bool>>,
 ) -> Container<'a, Message, StyleType> {
     if thumbnail {
         return thumbnail_footer();
@@ -136,7 +136,7 @@ fn get_release_details<'a>(
     language: Language,
     font: Font,
     font_footer: Font,
-    newer_release_available: &Arc<Mutex<Option<bool>>>,
+    newer_release_available: &Mutex<Option<bool>>,
 ) -> Row<'a, Message, StyleType> {
     let mut ret_val = Row::new()
         .align_y(Alignment::Center)

--- a/src/gui/pages/inspect_page.rs
+++ b/src/gui/pages/inspect_page.rs
@@ -21,6 +21,7 @@ use crate::gui::styles::text::TextType;
 use crate::gui::styles::text_input::TextInputType;
 use crate::gui::types::message::Message;
 use crate::networking::types::address_port_pair::AddressPortPair;
+use crate::networking::types::host_data_states::HostStates;
 use crate::networking::types::info_address_port_pair::InfoAddressPortPair;
 use crate::networking::types::traffic_direction::TrafficDirection;
 use crate::report::get_report_entries::get_searched_entries;
@@ -90,7 +91,7 @@ pub fn inspect_page(sniffer: &Sniffer) -> Container<Message, StyleType> {
         .push(
             Container::new(host_filters_col(
                 &sniffer.search,
-                &sniffer.combobox_states,
+                &sniffer.host_data_states.states,
                 font,
                 language,
             ))
@@ -315,7 +316,7 @@ fn row_report_entry<'a>(
 
 fn host_filters_col<'a>(
     search_params: &'a SearchParameters,
-    combobox_states: &'a combo_box::State<String>,
+    host_states: &'a HostStates,
     font: Font,
     language: Language,
 ) -> Column<'a, Message, StyleType> {
@@ -336,15 +337,27 @@ fn host_filters_col<'a>(
 
     let combobox_country = filter_combobox(
         FilterInputType::Country,
-        combobox_states,
+        &host_states.countries,
         search_params.clone(),
         font,
     )
     .width(95);
-    let combobox_domain =
-        filter_input(FilterInputType::Domain, search_params.clone(), font).width(190);
-    let combobox_as_name =
-        filter_input(FilterInputType::AsName, search_params.clone(), font).width(190);
+
+    let combobox_domain = filter_combobox(
+        FilterInputType::Domain,
+        &host_states.domains,
+        search_params.clone(),
+        font,
+    )
+    .width(190);
+
+    let combobox_as_name = filter_combobox(
+        FilterInputType::AsName,
+        &host_states.asns,
+        search_params.clone(),
+        font,
+    )
+    .width(190);
 
     let container_country = Row::new()
         .spacing(5)

--- a/src/gui/pages/inspect_page.rs
+++ b/src/gui/pages/inspect_page.rs
@@ -486,7 +486,7 @@ fn filter_combobox(
         move |new_value| Message::Search(filter_input_type.new_search(&search_params, new_value));
 
     let mut combobox = ComboBox::new(combo_box_state, "", Some(&filter_value), update_fn.clone())
-        .on_input(update_fn.clone())
+        .on_input(update_fn)
         .padding([2, 5])
         .size(FONT_SIZE_FOOTER)
         .font(font)

--- a/src/gui/pages/settings_general_page.rs
+++ b/src/gui/pages/settings_general_page.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use iced::widget::text::LineHeight;
 use iced::widget::tooltip::Position;
 use iced::widget::{
@@ -16,7 +14,7 @@ use crate::gui::styles::container::ContainerType;
 use crate::gui::styles::style_constants::FONT_SIZE_SUBTITLE;
 use crate::gui::styles::text::TextType;
 use crate::gui::types::message::Message;
-use crate::mmdb::types::mmdb_reader::MmdbReader;
+use crate::mmdb::types::mmdb_reader::{MmdbReader, MmdbReaders};
 use crate::translations::translations::language_translation;
 use crate::translations::translations_2::country_translation;
 use crate::translations::translations_3::{
@@ -91,8 +89,7 @@ fn column_all_general_setting(sniffer: &Sniffer, font: Font) -> Column<Message, 
         font,
         &mmdb_country,
         &mmdb_asn,
-        &sniffer.country_mmdb_reader,
-        &sniffer.asn_mmdb_reader,
+        &sniffer.mmdb_readers,
     ));
 
     column
@@ -249,8 +246,7 @@ fn mmdb_settings<'a>(
     font: Font,
     country_path: &str,
     asn_path: &str,
-    country_reader: &Arc<MmdbReader>,
-    asn_reader: &Arc<MmdbReader>,
+    mmdb_readers: &MmdbReaders,
 ) -> Column<'a, Message, StyleType> {
     Column::new()
         .spacing(5)
@@ -266,7 +262,7 @@ fn mmdb_settings<'a>(
             font,
             Message::CustomCountryDb,
             country_path,
-            country_reader,
+            &mmdb_readers.country,
             country_translation(language),
             language,
         ))
@@ -275,7 +271,7 @@ fn mmdb_settings<'a>(
             font,
             Message::CustomAsnDb,
             asn_path,
-            asn_reader,
+            &mmdb_readers.asn,
             "ASN",
             language,
         ))
@@ -286,14 +282,14 @@ fn mmdb_selection_row<'a>(
     font: Font,
     message: fn(String) -> Message,
     custom_path: &str,
-    mmdb_reader: &Arc<MmdbReader>,
+    mmdb_reader: &MmdbReader,
     caption: &str,
     language: Language,
 ) -> Row<'a, Message, StyleType> {
     let is_error = if custom_path.is_empty() {
         false
     } else {
-        match **mmdb_reader {
+        match *mmdb_reader {
             MmdbReader::Default(_) => true,
             MmdbReader::Custom(_) => false,
         }

--- a/src/gui/pages/thumbnail_page.rs
+++ b/src/gui/pages/thumbnail_page.rs
@@ -1,6 +1,6 @@
 use std::cmp::min;
 use std::net::IpAddr;
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
 use iced::widget::{lazy, vertical_space, Column, Container, Row, Rule, Space, Text};
 use iced::{Alignment, Font, Length};
@@ -61,7 +61,7 @@ pub fn thumbnail_page(sniffer: &Sniffer) -> Container<Message, StyleType> {
 }
 
 fn host_col<'a>(
-    info_traffic: &Arc<Mutex<InfoTraffic>>,
+    info_traffic: &Mutex<InfoTraffic>,
     chart_type: ChartType,
     font: Font,
 ) -> Column<'a, Message, StyleType> {
@@ -103,7 +103,7 @@ fn host_col<'a>(
 }
 
 fn service_col<'a>(
-    info_traffic: &Arc<Mutex<InfoTraffic>>,
+    info_traffic: &Mutex<InfoTraffic>,
     chart_type: ChartType,
     font: Font,
 ) -> Column<'a, Message, StyleType> {

--- a/src/gui/sniffer.rs
+++ b/src/gui/sniffer.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use iced::keyboard::key::Named;
 use iced::keyboard::{Event, Key, Modifiers};
 use iced::mouse::Event::ButtonPressed;
-use iced::widget::Column;
+use iced::widget::{combo_box, Column};
 use iced::window::{Id, Level};
 use iced::Event::{Keyboard, Window};
 use iced::{window, Element, Point, Size, Subscription, Task};
@@ -125,6 +125,8 @@ pub struct Sniffer {
     pub thumbnail: bool,
     /// Window id
     pub id: Option<Id>,
+    /// Combobox states for host filter dropdowns
+    pub combobox_states: combo_box::State<String>,
 }
 
 impl Sniffer {
@@ -167,6 +169,7 @@ impl Sniffer {
             export_pcap: ExportPcap::default(),
             thumbnail: false,
             id: None,
+            combobox_states: combo_box::State::new(vec!["IT".to_string(), "US".to_string()]),
         }
     }
 

--- a/src/gui/sniffer.rs
+++ b/src/gui/sniffer.rs
@@ -362,6 +362,14 @@ impl Sniffer {
             Message::ResetButtonPressed => return self.reset_button_pressed(),
             Message::CtrlDPressed => return self.shortcut_ctrl_d(),
             Message::Search(parameters) => {
+                // update comboboxes
+                let mut host_data = self.host_data_states.data.lock().unwrap();
+                host_data.countries.1 = self.search.country != parameters.country;
+                host_data.asns.1 = self.search.as_name != parameters.as_name;
+                host_data.domains.1 = self.search.domain != parameters.domain;
+                drop(host_data);
+                self.host_data_states.update_states(&parameters);
+
                 self.page_number = 1;
                 self.running_page = RunningPage::Inspect;
                 self.search = parameters;

--- a/src/gui/styles/combobox.rs
+++ b/src/gui/styles/combobox.rs
@@ -1,0 +1,9 @@
+//! Combobox style
+
+#![allow(clippy::module_name_repetitions)]
+
+use iced::widget::combo_box::Catalog;
+
+use crate::StyleType;
+
+impl Catalog for StyleType {}

--- a/src/gui/styles/mod.rs
+++ b/src/gui/styles/mod.rs
@@ -1,5 +1,6 @@
 pub mod button;
 pub mod checkbox;
+pub mod combobox;
 pub mod container;
 pub mod custom_themes;
 pub mod picklist;

--- a/src/mmdb/types/mmdb_reader.rs
+++ b/src/mmdb/types/mmdb_reader.rs
@@ -1,7 +1,14 @@
 use std::net::IpAddr;
+use std::sync::Arc;
 
 use maxminddb::{MaxMindDBError, Reader};
 use serde::Deserialize;
+
+#[derive(Clone)]
+pub struct MmdbReaders {
+    pub country: Arc<MmdbReader>,
+    pub asn: Arc<MmdbReader>,
+}
 
 pub enum MmdbReader {
     Default(Reader<&'static [u8]>),

--- a/src/networking/manage_packets.rs
+++ b/src/networking/manage_packets.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::str::FromStr;
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
 use chrono::Local;
 use dns_lookup::lookup_addr;
@@ -10,7 +10,7 @@ use pcap::{Address, Device};
 
 use crate::mmdb::asn::get_asn;
 use crate::mmdb::country::get_country;
-use crate::mmdb::types::mmdb_reader::MmdbReader;
+use crate::mmdb::types::mmdb_reader::MmdbReaders;
 use crate::networking::types::address_port_pair::AddressPortPair;
 use crate::networking::types::data_info_host::DataInfoHost;
 use crate::networking::types::host::Host;
@@ -211,7 +211,7 @@ pub fn get_service(key: &AddressPortPair, traffic_direction: TrafficDirection) -
 
 /// Function to insert the source and destination of a packet into the shared map containing the analyzed traffic.
 pub fn modify_or_insert_in_map(
-    info_traffic_mutex: &Arc<Mutex<InfoTraffic>>,
+    info_traffic_mutex: &Mutex<InfoTraffic>,
     key: &AddressPortPair,
     my_device: &MyDevice,
     mac_addresses: (Option<String>, Option<String>),
@@ -299,13 +299,12 @@ pub fn modify_or_insert_in_map(
 }
 
 pub fn reverse_dns_lookup(
-    info_traffic: &Arc<Mutex<InfoTraffic>>,
+    info_traffic: &Mutex<InfoTraffic>,
     key: &AddressPortPair,
     traffic_direction: TrafficDirection,
     my_device: &MyDevice,
-    country_db_reader: &Arc<MmdbReader>,
-    asn_db_reader: &Arc<MmdbReader>,
-    host_data: &Arc<Mutex<HostData>>,
+    mmdb_readers: &MmdbReaders,
+    host_data: &Mutex<HostData>,
 ) {
     let address_to_lookup = get_address_to_lookup(key, traffic_direction);
     let my_interface_addresses = my_device.addresses.lock().unwrap().clone();
@@ -321,8 +320,8 @@ pub fn reverse_dns_lookup(
     );
     let is_loopback = is_loopback(&address_to_lookup);
     let is_local = is_local_connection(&address_to_lookup, &my_interface_addresses);
-    let country = get_country(&address_to_lookup, country_db_reader);
-    let asn = get_asn(&address_to_lookup, asn_db_reader);
+    let country = get_country(&address_to_lookup, &mmdb_readers.country);
+    let asn = get_asn(&address_to_lookup, &mmdb_readers.asn);
     let r_dns = if let Ok(result) = lookup_result {
         if result.is_empty() {
             address_to_lookup.clone()

--- a/src/networking/manage_packets.rs
+++ b/src/networking/manage_packets.rs
@@ -14,6 +14,7 @@ use crate::mmdb::types::mmdb_reader::MmdbReader;
 use crate::networking::types::address_port_pair::AddressPortPair;
 use crate::networking::types::data_info_host::DataInfoHost;
 use crate::networking::types::host::Host;
+use crate::networking::types::host_data_states::HostData;
 use crate::networking::types::icmp_type::{IcmpType, IcmpTypeV4, IcmpTypeV6};
 use crate::networking::types::info_address_port_pair::InfoAddressPortPair;
 use crate::networking::types::my_device::MyDevice;
@@ -304,6 +305,7 @@ pub fn reverse_dns_lookup(
     my_device: &MyDevice,
     country_db_reader: &Arc<MmdbReader>,
     asn_db_reader: &Arc<MmdbReader>,
+    host_data: &Arc<Mutex<HostData>>,
 ) {
     let address_to_lookup = get_address_to_lookup(key, traffic_direction);
     let my_interface_addresses = my_device.addresses.lock().unwrap().clone();
@@ -359,6 +361,10 @@ pub fn reverse_dns_lookup(
             is_local,
             traffic_type,
         });
+
+    // update host data states including the new host
+    host_data.lock().unwrap().update(&new_host);
+
     // check if the newly resolved host was featured in the favorites (possible in case of already existing host)
     if info_traffic_lock.favorite_hosts.contains(&new_host) {
         info_traffic_lock.favorites_last_interval.insert(new_host);

--- a/src/networking/types/host_data_states.rs
+++ b/src/networking/types/host_data_states.rs
@@ -56,15 +56,16 @@ pub struct HostData {
 impl HostData {
     pub fn update(&mut self, host: &Host) {
         if !host.domain.is_empty() && host.domain.parse::<IpAddr>().is_err() {
-            self.domains.1 = self.domains.0.insert(host.domain.clone());
+            self.domains.1 = self.domains.0.insert(host.domain.clone()) || self.domains.1;
         }
 
         if !host.asn.name.is_empty() {
-            self.asns.1 = self.asns.0.insert(host.asn.name.clone());
+            self.asns.1 = self.asns.0.insert(host.asn.name.clone()) || self.asns.1;
         }
 
         if host.country != Country::ZZ {
-            self.countries.1 = self.countries.0.insert(host.country.to_string());
+            self.countries.1 =
+                self.countries.0.insert(host.country.to_string()) || self.countries.1;
         }
     }
 }

--- a/src/networking/types/host_data_states.rs
+++ b/src/networking/types/host_data_states.rs
@@ -1,0 +1,77 @@
+use crate::countries::types::country::Country;
+use crate::networking::types::host::Host;
+use crate::report::types::search_parameters::SearchParameters;
+use iced::widget::combo_box;
+use std::collections::BTreeSet;
+use std::net::IpAddr;
+use std::sync::{Arc, Mutex};
+
+/// Struct to contain all the sets of data related to network hosts
+///
+/// It also stores combobox states for the host-related filters
+#[derive(Default)]
+pub struct HostDataStates {
+    pub data: Arc<Mutex<HostData>>,
+    pub states: HostStates,
+}
+
+impl HostDataStates {
+    pub fn update_states(&mut self, search: &SearchParameters) {
+        let states = &mut self.states;
+        let mut data = self.data.lock().unwrap();
+
+        if data.domains.1 {
+            states.domains = combo_box::State::with_selection(
+                data.domains.0.iter().cloned().collect(),
+                Some(&search.domain),
+            );
+            data.domains.1 = false;
+        }
+
+        if data.asns.1 {
+            states.asns = combo_box::State::with_selection(
+                data.asns.0.iter().cloned().collect(),
+                Some(&search.as_name),
+            );
+            data.asns.1 = false;
+        }
+
+        if data.countries.1 {
+            states.countries = combo_box::State::with_selection(
+                data.countries.0.iter().cloned().collect(),
+                Some(&search.country),
+            );
+            data.countries.1 = false;
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct HostData {
+    pub domains: (BTreeSet<String>, bool),
+    pub asns: (BTreeSet<String>, bool),
+    pub countries: (BTreeSet<String>, bool),
+}
+
+impl HostData {
+    pub fn update(&mut self, host: &Host) {
+        if !host.domain.is_empty() && host.domain.parse::<IpAddr>().is_err() {
+            self.domains.1 = self.domains.0.insert(host.domain.clone());
+        }
+
+        if !host.asn.name.is_empty() {
+            self.asns.1 = self.asns.0.insert(host.asn.name.clone());
+        }
+
+        if host.country != Country::ZZ {
+            self.countries.1 = self.countries.0.insert(host.country.to_string());
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct HostStates {
+    pub domains: combo_box::State<String>,
+    pub asns: combo_box::State<String>,
+    pub countries: combo_box::State<String>,
+}

--- a/src/networking/types/mod.rs
+++ b/src/networking/types/mod.rs
@@ -6,6 +6,7 @@ pub mod data_info;
 pub mod data_info_host;
 pub mod filters;
 pub mod host;
+pub mod host_data_states;
 pub mod icmp_type;
 pub mod info_address_port_pair;
 pub mod info_traffic;

--- a/src/notifications/notify_and_log.rs
+++ b/src/notifications/notify_and_log.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
 use chrono::Local;
 
@@ -15,7 +15,7 @@ use crate::{InfoTraffic, RunTimeData};
 pub fn notify_and_log(
     runtime_data: &mut RunTimeData,
     notifications: Notifications,
-    info_traffic: &Arc<Mutex<InfoTraffic>>,
+    info_traffic: &Mutex<InfoTraffic>,
 ) -> usize {
     let mut already_emitted_sound = false;
     let mut emitted_notifications = 0;

--- a/src/report/get_report_entries.rs
+++ b/src/report/get_report_entries.rs
@@ -1,5 +1,5 @@
 use std::cmp::min;
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
 use crate::networking::manage_packets::get_address_to_lookup;
 use crate::networking::types::address_port_pair::AddressPortPair;
@@ -66,7 +66,7 @@ pub fn get_searched_entries(
 }
 
 pub fn get_host_entries(
-    info_traffic: &Arc<Mutex<InfoTraffic>>,
+    info_traffic: &Mutex<InfoTraffic>,
     chart_type: ChartType,
     sort_type: SortType,
 ) -> Vec<(Host, DataInfoHost)> {
@@ -83,7 +83,7 @@ pub fn get_host_entries(
 }
 
 pub fn get_service_entries(
-    info_traffic: &Arc<Mutex<InfoTraffic>>,
+    info_traffic: &Mutex<InfoTraffic>,
     chart_type: ChartType,
     sort_type: SortType,
 ) -> Vec<(Service, DataInfo)> {

--- a/src/secondary_threads/check_updates.rs
+++ b/src/secondary_threads/check_updates.rs
@@ -1,4 +1,4 @@
-use std::sync::{ Mutex};
+use std::sync::Mutex;
 use std::thread;
 use std::time::Duration;
 

--- a/src/secondary_threads/check_updates.rs
+++ b/src/secondary_threads/check_updates.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Mutex};
+use std::sync::{ Mutex};
 use std::thread;
 use std::time::Duration;
 
@@ -14,7 +14,7 @@ struct AppVersion {
 
 /// Calls a method to check if a newer release of Sniffnet is available on GitHub
 /// and updates application status accordingly
-pub fn set_newer_release_status(newer_release_available: &Arc<Mutex<Option<bool>>>) {
+pub fn set_newer_release_status(newer_release_available: &Mutex<Option<bool>>) {
     let result = is_newer_release_available(6, 30);
     *newer_release_available.lock().unwrap() = result;
 }

--- a/src/secondary_threads/parse_packets.rs
+++ b/src/secondary_threads/parse_packets.rs
@@ -9,7 +9,7 @@ use etherparse::err::{Layer, LenError};
 use etherparse::{LaxPacketHeaders, LenSource};
 use pcap::Packet;
 
-use crate::mmdb::types::mmdb_reader::MmdbReader;
+use crate::mmdb::types::mmdb_reader::MmdbReaders;
 use crate::networking::manage_packets::{
     analyze_headers, get_address_to_lookup, modify_or_insert_in_map, reverse_dns_lookup,
 };
@@ -27,12 +27,11 @@ use crate::InfoTraffic;
 /// The calling thread enters a loop in which it waits for network packets, parses them according
 /// to the user specified filters, and inserts them into the shared map variable.
 pub fn parse_packets(
-    current_capture_id: &Arc<Mutex<usize>>,
+    current_capture_id: &Mutex<usize>,
     device: &MyDevice,
     filters: &Filters,
     info_traffic_mutex: &Arc<Mutex<InfoTraffic>>,
-    country_mmdb_reader: &Arc<MmdbReader>,
-    asn_mmdb_reader: &Arc<MmdbReader>,
+    mmdb_readers: &MmdbReaders,
     capture_context: CaptureContext,
     host_data: &Arc<Mutex<HostData>>,
 ) {
@@ -135,8 +134,7 @@ pub fn parse_packets(
                                 let key2 = key.clone();
                                 let info_traffic2 = info_traffic_mutex.clone();
                                 let device2 = device.clone();
-                                let country_db_reader_2 = country_mmdb_reader.clone();
-                                let asn_db_reader_2 = asn_mmdb_reader.clone();
+                                let mmdb_readers_2 = mmdb_readers.clone();
                                 let host_data2 = host_data.clone();
                                 thread::Builder::new()
                                     .name("thread_reverse_dns_lookup".to_string())
@@ -146,8 +144,7 @@ pub fn parse_packets(
                                             &key2,
                                             new_info.traffic_direction,
                                             &device2,
-                                            &country_db_reader_2,
-                                            &asn_db_reader_2,
+                                            &mmdb_readers_2,
                                             &host_data2,
                                         );
                                     })

--- a/src/secondary_threads/parse_packets.rs
+++ b/src/secondary_threads/parse_packets.rs
@@ -16,6 +16,7 @@ use crate::networking::manage_packets::{
 use crate::networking::types::capture_context::CaptureContext;
 use crate::networking::types::data_info::DataInfo;
 use crate::networking::types::filters::Filters;
+use crate::networking::types::host_data_states::HostData;
 use crate::networking::types::icmp_type::IcmpType;
 use crate::networking::types::info_address_port_pair::InfoAddressPortPair;
 use crate::networking::types::my_device::MyDevice;
@@ -33,6 +34,7 @@ pub fn parse_packets(
     country_mmdb_reader: &Arc<MmdbReader>,
     asn_mmdb_reader: &Arc<MmdbReader>,
     capture_context: CaptureContext,
+    host_data: &Arc<Mutex<HostData>>,
 ) {
     let my_link_type = capture_context.my_link_type();
     let (mut cap, mut savefile) = capture_context.consume();
@@ -135,6 +137,7 @@ pub fn parse_packets(
                                 let device2 = device.clone();
                                 let country_db_reader_2 = country_mmdb_reader.clone();
                                 let asn_db_reader_2 = asn_mmdb_reader.clone();
+                                let host_data2 = host_data.clone();
                                 thread::Builder::new()
                                     .name("thread_reverse_dns_lookup".to_string())
                                     .spawn(move || {
@@ -145,6 +148,7 @@ pub fn parse_packets(
                                             &device2,
                                             &country_db_reader_2,
                                             &asn_db_reader_2,
+                                            &host_data2,
                                         );
                                     })
                                     .unwrap();


### PR DESCRIPTION
This PR implements network host filters autocompletion via a dropdown menu.

This way, it's now possible to preview featured countries, domains, and ASNs while typing in the respective text input in the _Inspect_ page.

https://github.com/user-attachments/assets/e060c70b-2a44-44bc-a2dc-ff7dc62fc68b

Fixes #354.