### PR TITLE
Provide details about unassigned IPs (bogons)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All Sniffnet releases with the relative changes are documented in this file.
 
+## [UNRELEASED]
+- Identify and tag unassigned/reserved "bogon" IP addresses ([#678](https://github.com/GyulyVGC/sniffnet/pull/678) — fixes [#209](https://github.com/GyulyVGC/sniffnet/issues/209))
+
 ## [1.3.2] - 2025-01-06
 - Dropdown menus for network host filters ([#659](https://github.com/GyulyVGC/sniffnet/pull/659) — fixes [#354](https://github.com/GyulyVGC/sniffnet/issues/354))
 - Added CLI argument `--adapter [<NAME>]` to allow immediately starting the capture from a given network interface ([#643](https://github.com/GyulyVGC/sniffnet/pull/643) — fixes [#636](https://github.com/GyulyVGC/sniffnet/issues/636))

--- a/resources/countries_flags/4x3/zz-bogon.svg
+++ b/resources/countries_flags/4x3/zz-bogon.svg
@@ -2,27 +2,27 @@
 <!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
 
 <svg
-   fill="#000000"
-   height="600"
-   width="800"
-   id="Layer_1"
-   data-name="Layer 1"
-   viewBox="0 0 16 12"
-   version="1.1"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <defs
-     id="defs1" />
-  <path
-     class="cls-1"
-     d="m 6.5340712,9.4854392 h 2.92986 V 11.4 h -2.92986 z M 6.483959,0.60000024 6.8175262,8.2882052 h 2.364948 l 0.333567,-7.68820496 z"
-     id="path1"
-     style="stroke-width:0.9" />
-  <rect
-     style="font-variation-settings:'wght' 680;fill:#a0e8f0;fill-opacity:0;stroke:#000000;stroke-width:0.0991184;stroke-opacity:0"
-     id="rect1"
-     width="15.900882"
-     height="11.900882"
-     x="0.049559198"
-     y="0.049559355" />
-</svg>
+        fill="#000000"
+        height="855"
+        width="1140"
+        version="1.1"
+        id="Layer_1"
+        viewBox="0 0 470.24995 352.6875"
+        xml:space="preserve"
+        xmlns="http://www.w3.org/2000/svg"
+        xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs1" />
+    <g
+            id="XMLID_509_"
+            transform="translate(70.124961,11.343741)">
+	<path
+            id="XMLID_510_"
+            d="m 65,330 h 200 c 8.284,0 15,-6.716 15,-15 V 145 c 0,-8.284 -6.716,-15 -15,-15 H 250 V 85 C 250,38.131 211.869,0 165,0 118.131,0 80,38.131 80,85 v 45 H 65 c -8.284,0 -15,6.716 -15,15 v 170 c 0,8.284 6.716,15 15,15 z M 180,234.986 V 255 c 0,8.284 -6.716,15 -15,15 -8.284,0 -15,-6.716 -15,-15 v -20.014 c -6.068,-4.565 -10,-11.824 -10,-19.986 0,-13.785 11.215,-25 25,-25 13.785,0 25,11.215 25,25 0,8.162 -3.932,15.421 -10,19.986 z M 110,85 c 0,-30.327 24.673,-55 55,-55 30.327,0 55,24.673 55,55 v 45 H 110 Z"/>
+</g>
+    <rect
+            style="font-variation-settings:'wght' 680;fill:#a0e8f0;fill-opacity:0;stroke:#000000;stroke-width:2.18086;stroke-opacity:0"
+            id="rect1"
+            width="468.06906"
+            height="350.50662"
+            x="1.09043"
+            y="1.09043"/></svg>

--- a/resources/countries_flags/4x3/zz-bogon.svg
+++ b/resources/countries_flags/4x3/zz-bogon.svg
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+
+<svg
+   fill="#000000"
+   height="600"
+   width="800"
+   id="Layer_1"
+   data-name="Layer 1"
+   viewBox="0 0 16 12"
+   version="1.1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <path
+     class="cls-1"
+     d="m 6.5340712,9.4854392 h 2.92986 V 11.4 h -2.92986 z M 6.483959,0.60000024 6.8175262,8.2882052 h 2.364948 l 0.333567,-7.68820496 z"
+     id="path1"
+     style="stroke-width:0.9" />
+  <rect
+     style="font-variation-settings:'wght' 680;fill:#a0e8f0;fill-opacity:0;stroke:#000000;stroke-width:0.0991184;stroke-opacity:0"
+     id="rect1"
+     width="15.900882"
+     height="11.900882"
+     x="0.049559198"
+     y="0.049559355" />
+</svg>

--- a/src/countries/flags_pictures.rs
+++ b/src/countries/flags_pictures.rs
@@ -255,3 +255,4 @@ pub const MULTICAST: &[u8] = include_bytes!("../../resources/countries_flags/4x3
 pub const BROADCAST: &[u8] = include_bytes!("../../resources/countries_flags/4x3/zz-broadcast.svg");
 pub const UNKNOWN: &[u8] = include_bytes!("../../resources/countries_flags/4x3/zz-unknown.svg");
 pub const COMPUTER: &[u8] = include_bytes!("../../resources/countries_flags/4x3/zz-computer.svg");
+pub const BOGON: &[u8] = include_bytes!("../../resources/countries_flags/4x3/zz-bogon.svg");

--- a/src/gui/pages/connection_details_page.rs
+++ b/src/gui/pages/connection_details_page.rs
@@ -19,6 +19,7 @@ use crate::networking::manage_packets::{
     get_address_to_lookup, get_traffic_type, is_local_connection, is_my_address,
 };
 use crate::networking::types::address_port_pair::AddressPortPair;
+use crate::networking::types::bogon::is_bogon;
 use crate::networking::types::host::Host;
 use crate::networking::types::icmp_type::IcmpType;
 use crate::networking::types::info_address_port_pair::InfoAddressPortPair;
@@ -304,6 +305,7 @@ fn get_local_tooltip<'a>(
     get_computer_tooltip(
         is_my_address(local_address, my_interface_addresses),
         is_local_connection(local_address, my_interface_addresses),
+        is_bogon(local_address),
         get_traffic_type(
             if address_to_lookup.eq(&key.address1) {
                 &key.address2

--- a/src/networking/manage_packets.rs
+++ b/src/networking/manage_packets.rs
@@ -12,6 +12,7 @@ use crate::mmdb::asn::get_asn;
 use crate::mmdb::country::get_country;
 use crate::mmdb::types::mmdb_reader::MmdbReaders;
 use crate::networking::types::address_port_pair::AddressPortPair;
+use crate::networking::types::bogon::is_bogon;
 use crate::networking::types::data_info_host::DataInfoHost;
 use crate::networking::types::host::Host;
 use crate::networking::types::host_data_states::HostData;
@@ -320,6 +321,7 @@ pub fn reverse_dns_lookup(
     );
     let is_loopback = is_loopback(&address_to_lookup);
     let is_local = is_local_connection(&address_to_lookup, &my_interface_addresses);
+    let is_bogon = is_bogon(&address_to_lookup);
     let country = get_country(&address_to_lookup, &mmdb_readers.country);
     let asn = get_asn(&address_to_lookup, &mmdb_readers.asn);
     let r_dns = if let Ok(result) = lookup_result {
@@ -358,6 +360,7 @@ pub fn reverse_dns_lookup(
             is_favorite: false,
             is_loopback,
             is_local,
+            is_bogon,
             traffic_type,
         });
 

--- a/src/networking/types/bogon.rs
+++ b/src/networking/types/bogon.rs
@@ -168,6 +168,7 @@ mod tests {
     #[test]
     fn test_is_bogon_no() {
         assert_eq!(is_bogon("8.8.8.8"), None);
+        assert_eq!(is_bogon("2001:4860:4860::8888"), None);
     }
 
     #[test]
@@ -228,5 +229,56 @@ mod tests {
     #[test]
     fn test_is_bogon_future_use() {
         assert_eq!(is_bogon("240.0.0.0"), Some("future use"));
+    }
+
+    #[test]
+    fn test_node_scope_unspecified() {
+        assert_eq!(is_bogon("::"), Some("node-scope unicast unspecified"));
+    }
+
+    #[test]
+    fn test_node_scope_loopback() {
+        assert_eq!(is_bogon("::1"), Some("node-scope unicast loopback"));
+    }
+
+    #[test]
+    fn test_ipv4_mapped() {
+        assert_eq!(is_bogon("::ffff:8.8.8.8"), Some("IPv4-mapped"));
+    }
+
+    #[test]
+    fn test_ipv4_compatible() {
+        assert_eq!(is_bogon("::8.8.8.8"), Some("IPv4-compatible"));
+    }
+
+    #[test]
+    fn test_remotely_triggered() {
+        assert_eq!(is_bogon("100::beef"), Some("remotely triggered black hole"));
+    }
+
+    #[test]
+    fn test_orchid() {
+        assert_eq!(is_bogon("2001:10::feed"), Some("ORCHID"));
+    }
+
+    #[test]
+    fn test_documentation_prefix() {
+        assert_eq!(is_bogon("2001:db8::fe90"), Some("documentation prefix"));
+        assert_eq!(is_bogon("3fff::"), Some("documentation prefix"));
+    }
+
+    #[test]
+    fn test_ula() {
+        assert_eq!(is_bogon("fdff::"), Some("ULA"));
+    }
+
+    #[test]
+    fn test_link_local_unicast() {
+        assert_eq!(is_bogon("feaf::"), Some("link-local unicast"));
+    }
+
+    #[test]
+    fn test_site_local_unicast() {
+        assert_eq!(is_bogon("feea::1"), Some("site-local unicast"));
     }
 }

--- a/src/networking/types/bogon.rs
+++ b/src/networking/types/bogon.rs
@@ -1,0 +1,177 @@
+use crate::networking::types::ip_collection::AddressCollection;
+use once_cell::sync::Lazy;
+use std::net::IpAddr;
+use std::str::FromStr;
+
+pub struct Bogon {
+    pub range: AddressCollection,
+    pub description: &'static str,
+}
+
+// IPv4 bogons
+
+static THIS_NETWORK: Lazy<Bogon> = Lazy::new(|| Bogon {
+    range: AddressCollection::new("0.0.0.0-0.255.255.255").unwrap(),
+    description: "\"this\" network",
+});
+
+static PRIVATE_USE: Lazy<Bogon> = Lazy::new(|| Bogon {
+    range: AddressCollection::new(
+        "10.0.0.0-10.255.255.255, 172.16.0.0-172.31.255.255, 192.168.0.0-192.168.255.255",
+    )
+    .unwrap(),
+    description: "private-use networks",
+});
+
+static CARRIER_GRADE: Lazy<Bogon> = Lazy::new(|| Bogon {
+    range: AddressCollection::new("100.64.0.0-100.127.255.255").unwrap(),
+    description: "carrier-grade NAT",
+});
+
+static LOOPBACK: Lazy<Bogon> = Lazy::new(|| Bogon {
+    range: AddressCollection::new("127.0.0.0-127.255.255.255").unwrap(),
+    description: "loopback",
+});
+
+static LINK_LOCAL: Lazy<Bogon> = Lazy::new(|| Bogon {
+    range: AddressCollection::new("169.254.0.0-169.254.255.255").unwrap(),
+    description: "link local",
+});
+
+static IETF_PROTOCOL: Lazy<Bogon> = Lazy::new(|| Bogon {
+    range: AddressCollection::new("192.0.0.0-192.0.0.255").unwrap(),
+    description: "IETF protocol assignments",
+});
+
+static TEST_NET_1: Lazy<Bogon> = Lazy::new(|| Bogon {
+    range: AddressCollection::new("192.0.2.0-192.0.2.255").unwrap(),
+    description: "TEST-NET-1",
+});
+
+static NETWORK_INTERCONNECT: Lazy<Bogon> = Lazy::new(|| Bogon {
+    range: AddressCollection::new("198.18.0.0-198.19.255.255").unwrap(),
+    description: "network interconnect device benchmark testing",
+});
+
+static TEST_NET_2: Lazy<Bogon> = Lazy::new(|| Bogon {
+    range: AddressCollection::new("198.51.100.0-198.51.100.255").unwrap(),
+    description: "TEST-NET-2",
+});
+
+static TEST_NET_3: Lazy<Bogon> = Lazy::new(|| Bogon {
+    range: AddressCollection::new("203.0.113.0-203.0.113.255").unwrap(),
+    description: "TEST-NET-3",
+});
+
+static FUTURE_USE: Lazy<Bogon> = Lazy::new(|| Bogon {
+    range: AddressCollection::new("240.0.0.0-255.255.255.255").unwrap(),
+    description: "reserved for future use",
+});
+
+// IPv6 bogons
+
+static NODE_SCOPE_UNSPECIFIED: Lazy<Bogon> = Lazy::new(|| Bogon {
+    range: AddressCollection::new("::").unwrap(),
+    description: "node-scope unicast unspecified",
+});
+
+static NODE_SCOPE_LOOPBACK: Lazy<Bogon> = Lazy::new(|| Bogon {
+    range: AddressCollection::new("::1").unwrap(),
+    description: "node-scope unicast loopback",
+});
+
+static IPV4_MAPPED: Lazy<Bogon> = Lazy::new(|| Bogon {
+    range: AddressCollection::new("::ffff:0.0.0.0-::ffff:255.255.255.255").unwrap(),
+    description: "IPv4-mapped",
+});
+
+static IPV4_COMPATIBLE: Lazy<Bogon> = Lazy::new(|| Bogon {
+    range: AddressCollection::new("::-::255.255.255.255").unwrap(),
+    description: "IPv4-compatible",
+});
+
+static REMOTELY_TRIGGERED: Lazy<Bogon> = Lazy::new(|| Bogon {
+    range: AddressCollection::new("100::-100::ffff:ffff:ffff:ffff").unwrap(),
+    description: "remotely triggered black hole",
+});
+
+static ORCHID: Lazy<Bogon> = Lazy::new(|| Bogon {
+    range: AddressCollection::new("2001:10::-2001:1f:ffff:ffff:ffff:ffff:ffff:ffff").unwrap(),
+    description: "ORCHID",
+});
+
+static DOCUMENTATION_PREFIX: Lazy<Bogon> = Lazy::new(|| {
+    Bogon {
+    range: AddressCollection::new("2001:db8::-2001:db8:ffff:ffff:ffff:ffff:ffff:ffff, 3fff::-3fff:fff:ffff:ffff:ffff:ffff:ffff:ffff")
+        .unwrap(),
+    description: "documentation prefix",
+}
+});
+
+static ULA: Lazy<Bogon> = Lazy::new(|| Bogon {
+    range: AddressCollection::new("fc00::-fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff").unwrap(),
+    description: "ULA",
+});
+
+static LINK_LOCAL_UNICAST: Lazy<Bogon> = Lazy::new(|| Bogon {
+    range: AddressCollection::new("fe80::-febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff").unwrap(),
+    description: "link-local unicast",
+});
+
+static SITE_LOCAL_UNICAST: Lazy<Bogon> = Lazy::new(|| Bogon {
+    range: AddressCollection::new("fec0::-feff:ffff:ffff:ffff:ffff:ffff:ffff:ffff").unwrap(),
+    description: "site-local unicast",
+});
+
+// all bogons
+
+static BOGONS: Lazy<Vec<&'static Bogon>> = Lazy::new(|| {
+    vec![
+        &THIS_NETWORK,
+        &PRIVATE_USE,
+        &CARRIER_GRADE,
+        &LOOPBACK,
+        &LINK_LOCAL,
+        &IETF_PROTOCOL,
+        &TEST_NET_1,
+        &NETWORK_INTERCONNECT,
+        &TEST_NET_2,
+        &TEST_NET_3,
+        &FUTURE_USE,
+        &NODE_SCOPE_UNSPECIFIED,
+        &NODE_SCOPE_LOOPBACK,
+        &IPV4_MAPPED,
+        &IPV4_COMPATIBLE,
+        &REMOTELY_TRIGGERED,
+        &ORCHID,
+        &DOCUMENTATION_PREFIX,
+        &ULA,
+        &LINK_LOCAL_UNICAST,
+        &SITE_LOCAL_UNICAST,
+    ]
+});
+
+pub fn is_bogon(address: &str) -> Option<&'static str> {
+    let ip = IpAddr::from_str(address).ok()?;
+    for bogon in BOGONS.iter() {
+        if bogon.range.contains(&ip) {
+            return Some(bogon.description);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_bogon_no() {
+        assert_eq!(is_bogon("8.8.8.8"), None);
+    }
+
+    #[test]
+    fn test_is_bogon_this_network() {
+        assert_eq!(is_bogon("0.1.2.3"), Some("\"this\" network"));
+    }
+}

--- a/src/networking/types/bogon.rs
+++ b/src/networking/types/bogon.rs
@@ -20,7 +20,7 @@ static PRIVATE_USE: Lazy<Bogon> = Lazy::new(|| Bogon {
         "10.0.0.0-10.255.255.255, 172.16.0.0-172.31.255.255, 192.168.0.0-192.168.255.255",
     )
     .unwrap(),
-    description: "private-use networks",
+    description: "private-use",
 });
 
 static CARRIER_GRADE: Lazy<Bogon> = Lazy::new(|| Bogon {
@@ -65,7 +65,7 @@ static TEST_NET_3: Lazy<Bogon> = Lazy::new(|| Bogon {
 
 static FUTURE_USE: Lazy<Bogon> = Lazy::new(|| Bogon {
     range: AddressCollection::new("240.0.0.0-255.255.255.255").unwrap(),
-    description: "reserved for future use",
+    description: "future use",
 });
 
 // IPv6 bogons
@@ -173,5 +173,60 @@ mod tests {
     #[test]
     fn test_is_bogon_this_network() {
         assert_eq!(is_bogon("0.1.2.3"), Some("\"this\" network"));
+    }
+
+    #[test]
+    fn test_is_bogon_private_use_networks() {
+        assert_eq!(is_bogon("10.1.2.3"), Some("private-use"));
+        assert_eq!(is_bogon("172.22.2.3"), Some("private-use"));
+        assert_eq!(is_bogon("192.168.255.3"), Some("private-use"));
+    }
+
+    #[test]
+    fn test_is_bogon_carrier_grade() {
+        assert_eq!(is_bogon("100.99.2.1"), Some("carrier-grade NAT"));
+    }
+
+    #[test]
+    fn test_is_bogon_loopback() {
+        assert_eq!(is_bogon("127.99.2.1"), Some("loopback"));
+    }
+
+    #[test]
+    fn test_is_bogon_link_local() {
+        assert_eq!(is_bogon("169.254.0.0"), Some("link local"));
+    }
+
+    #[test]
+    fn test_is_bogon_ietf() {
+        assert_eq!(is_bogon("192.0.0.255"), Some("IETF protocol assignments"));
+    }
+
+    #[test]
+    fn test_is_bogon_test_net_1() {
+        assert_eq!(is_bogon("192.0.2.128"), Some("TEST-NET-1"));
+    }
+
+    #[test]
+    fn test_is_bogon_network_interconnect() {
+        assert_eq!(
+            is_bogon("198.18.2.128"),
+            Some("network interconnect device benchmark testing")
+        );
+    }
+
+    #[test]
+    fn test_is_bogon_test_net_2() {
+        assert_eq!(is_bogon("198.51.100.128"), Some("TEST-NET-2"));
+    }
+
+    #[test]
+    fn test_is_bogon_test_net_3() {
+        assert_eq!(is_bogon("203.0.113.128"), Some("TEST-NET-3"));
+    }
+
+    #[test]
+    fn test_is_bogon_future_use() {
+        assert_eq!(is_bogon("240.0.0.0"), Some("future use"));
     }
 }

--- a/src/networking/types/data_info_host.rs
+++ b/src/networking/types/data_info_host.rs
@@ -14,6 +14,8 @@ pub struct DataInfoHost {
     pub is_loopback: bool,
     /// Determine if the connection with this host is local
     pub is_local: bool,
+    /// Determine if the connection is with a bogon address
+    pub is_bogon: Option<&'static str>,
     /// Determine if the connection with this host is unicast, multicast, or broadcast
     pub traffic_type: TrafficType,
 }

--- a/src/networking/types/ip_collection.rs
+++ b/src/networking/types/ip_collection.rs
@@ -4,8 +4,8 @@ use std::str::FromStr;
 
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub(crate) struct AddressCollection {
-    pub(crate) ips: Vec<IpAddr>,
-    pub(crate) ranges: Vec<RangeInclusive<IpAddr>>,
+    ips: Vec<IpAddr>,
+    ranges: Vec<RangeInclusive<IpAddr>>,
 }
 
 impl AddressCollection {

--- a/src/networking/types/mod.rs
+++ b/src/networking/types/mod.rs
@@ -1,5 +1,6 @@
 pub mod address_port_pair;
 pub mod asn;
+pub mod bogon;
 pub mod byte_multiple;
 pub mod capture_context;
 pub mod data_info;

--- a/src/translations/mod.rs
+++ b/src/translations/mod.rs
@@ -2,4 +2,5 @@
 pub mod translations;
 pub mod translations_2;
 pub mod translations_3;
+pub mod translations_4;
 pub mod types;

--- a/src/translations/translations_4.rs
+++ b/src/translations/translations_4.rs
@@ -1,0 +1,11 @@
+#![allow(clippy::match_same_arms)]
+
+use crate::translations::types::language::Language;
+
+pub fn reserved_address_translation(language: Language, info: &str) -> String {
+    match language {
+        Language::EN => format!("Reserved address ({info})"),
+        Language::IT => format!("Indirizzo riservato ({info})"),
+        _ => format!("Reserved address ({info})"),
+    }
+}


### PR DESCRIPTION
Until today, Sniffnet tagged as 'Unknown location' all IP addresses for which it wasn't possible to determine the origin.
This PR adds support for tagging _bogon_ IPv4 and IPv6 addresses.

> [!NOTE]
> Some IP addresses and IP ranges are reserved for special use, such as for local or private networks, and should not appear on the public internet.
> These reserved ranges, along with other IP ranges that haven't yet been allocated and therefore also shouldn't appear on the public internet are sometimes known as bogons.

***

Sniffnet will now represent with a _lock_ icon that a connection was established with a bogon IP address, and hovering on it will show additional details about such IP.

![Screenshot 2025-01-19 at 17 53 20](https://github.com/user-attachments/assets/5d6cd57f-aa6a-4bbd-ae80-e07b142ab2d0)

Fixes #209.