### PR TITLE
fix various typos

### DIFF
--- a/src/gui/styles/types/color_remote.rs
+++ b/src/gui/styles/types/color_remote.rs
@@ -1,4 +1,4 @@
-//! Remote implemention of [`serde::Deserialize`] and [`serde::Serialize`] for [`iced::Color`].
+//! Remote implementation of [`serde::Deserialize`] and [`serde::Serialize`] for [`iced::Color`].
 //!
 //! This implementation deserializes hexadecimal RGB(A) as string to float RGB(A) and back.
 //! NOTE: The alpha channel is optional and defaults to #ff or 1.0.
@@ -39,7 +39,7 @@ where
             })?
             // Iterating over bytes is safe because hex is ASCII.
             // If the hex is not ASCII or invalid hex, then the iterator will short circuit and fail on `from_str_radix`
-            // TODO: This can be cleaned up when `iter_array_chunks` is stablized (https://github.com/rust-lang/rust/issues/100450)
+            // TODO: This can be cleaned up when `iter_array_chunks` is stabilized (https://github.com/rust-lang/rust/issues/100450)
             .bytes()
             .step_by(2) // Step by every first hex char of the two char sequence
             .zip(hex.bytes().skip(2).step_by(2)) // Step by every second hex char

--- a/src/secondary_threads/parse_packets.rs
+++ b/src/secondary_threads/parse_packets.rs
@@ -239,7 +239,7 @@ fn from_null(packet: &[u8]) -> Result<LaxPacketHeaders, LaxHeaderSliceError> {
         let h = &packet[..4];
         let b = [h[0], h[1], h[2], h[3]];
         // check both big endian and little endian representations
-        // as some OS'es use native endianess and others use big endian
+        // as some OS'es use native endianness and others use big endian
         matches(u32::from_le_bytes(b)) || matches(u32::from_be_bytes(b))
     };
 


### PR DESCRIPTION
Found via `codespell -q 3 -S "*.pdf,*.rtf,./src/translations" -L aas,aci,daa,fo,ser`