### PR TITLE
Create the new theme sniff_oled.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All Sniffnet releases with the relative changes are documented in this file.
 - Updated some of the existing translations to v1.3: 
   - Portuguese ([#690](https://github.com/GyulyVGC/sniffnet/pull/690))
   - Ukrainian ([#692](https://github.com/GyulyVGC/sniffnet/pull/692))
+- Added new themes _OLED (Night)_ and _OLED (Day)_ based on palettes optimized for OLED displays and users with visual impairments ([#708](https://github.com/GyulyVGC/sniffnet/pull/708))
 
 ## [1.3.2] - 2025-01-06
 - Dropdown menus for network host filters ([#659](https://github.com/GyulyVGC/sniffnet/pull/659) — fixes [#354](https://github.com/GyulyVGC/sniffnet/issues/354))

--- a/resources/themes/sniff_oled.toml
+++ b/resources/themes/sniff_oled.toml
@@ -1,0 +1,9 @@
+# OLED-optimized color scheme (v2.1)
+# Designed for deep blacks & high contrast
+
+primary = "#000000"          # Pure black (turns off OLED pixels)
+secondary = "#934900"        # Muted copper orange (+53% red component vs original)
+outgoing = "#F0F0F0"         # Soft white (7% brightness reduction for night use)
+text_body = "#fcfaf0"        # Warm paper white (RGB 252,250,240 - reduces eye strain)
+text_headers = "#E0E0E0"     # Ice gray (15% brighter than standard UI gray)
+starred = "#FFFF00"          # Pure signal yellow (alpha removed for cleaner rendering)

--- a/resources/themes/sniff_oled.toml
+++ b/resources/themes/sniff_oled.toml
@@ -1,9 +1,0 @@
-# OLED-optimized color scheme (v2.1)
-# Designed for deep blacks & high contrast
-
-primary = "#000000"          # Pure black (turns off OLED pixels)
-secondary = "#934900"        # Muted copper orange (+53% red component vs original)
-outgoing = "#F0F0F0"         # Soft white (7% brightness reduction for night use)
-text_body = "#fcfaf0"        # Warm paper white (RGB 252,250,240 - reduces eye strain)
-text_headers = "#E0E0E0"     # Ice gray (15% brighter than standard UI gray)
-starred = "#FFFF00"          # Pure signal yellow (alpha removed for cleaner rendering)

--- a/src/gui/styles/custom_themes/mod.rs
+++ b/src/gui/styles/custom_themes/mod.rs
@@ -1,4 +1,5 @@
 pub mod dracula;
 pub mod gruvbox;
 pub mod nord;
+pub mod oled;
 pub mod solarized;

--- a/src/gui/styles/custom_themes/oled.rs
+++ b/src/gui/styles/custom_themes/oled.rs
@@ -1,0 +1,34 @@
+#![allow(clippy::unreadable_literal)]
+
+//! Themes optimized for OLED displays and visually impaired users
+//! <https://github.com/GyulyVGC/sniffnet/pull/708>
+
+use iced::color;
+use once_cell::sync::Lazy;
+
+use crate::gui::styles::types::palette::Palette;
+use crate::gui::styles::types::palette_extension::PaletteExtension;
+
+pub static OLED_DARK_PALETTE: Lazy<Palette> = Lazy::new(|| Palette {
+    primary: color!(0x000000),
+    secondary: color!(0x934900),
+    outgoing: color!(0xF0F0F0),
+    starred: color!(0xFFFF00),
+    text_headers: color!(0xE0E0E0),
+    text_body: color!(0xfcfaf0),
+});
+
+pub static OLED_DARK_PALETTE_EXTENSION: Lazy<PaletteExtension> =
+    Lazy::new(|| OLED_DARK_PALETTE.generate_palette_extension());
+
+pub static OLED_LIGHT_PALETTE: Lazy<Palette> = Lazy::new(|| Palette {
+    primary: color!(0xFFFFFF),
+    secondary: color!(0x6CB6FF),
+    outgoing: color!(0x0F0F0F),
+    starred: color!(0x0000FF),
+    text_headers: color!(0x1F1F1F),
+    text_body: color!(0x03050F),
+});
+
+pub static OLED_LIGHT_PALETTE_EXTENSION: Lazy<PaletteExtension> =
+    Lazy::new(|| OLED_LIGHT_PALETTE.generate_palette_extension());

--- a/src/gui/styles/types/custom_palette.rs
+++ b/src/gui/styles/types/custom_palette.rs
@@ -15,6 +15,10 @@ use crate::gui::styles::custom_themes::nord::{
     NORD_DARK_PALETTE, NORD_DARK_PALETTE_EXTENSION, NORD_LIGHT_PALETTE,
     NORD_LIGHT_PALETTE_EXTENSION,
 };
+use crate::gui::styles::custom_themes::oled::{
+    OLED_DARK_PALETTE, OLED_DARK_PALETTE_EXTENSION, OLED_LIGHT_PALETTE,
+    OLED_LIGHT_PALETTE_EXTENSION,
+};
 use crate::gui::styles::custom_themes::solarized::{
     SOLARIZED_DARK_PALETTE, SOLARIZED_DARK_PALETTE_EXTENSION, SOLARIZED_LIGHT_PALETTE,
     SOLARIZED_LIGHT_PALETTE_EXTENSION,
@@ -51,6 +55,8 @@ pub enum ExtraStyles {
     NordLight,
     SolarizedDark,
     SolarizedLight,
+    OledDark,
+    OledLight,
     CustomToml(CustomPalette),
 }
 
@@ -66,6 +72,8 @@ impl ExtraStyles {
             ExtraStyles::NordLight => *NORD_LIGHT_PALETTE,
             ExtraStyles::SolarizedDark => *SOLARIZED_DARK_PALETTE,
             ExtraStyles::SolarizedLight => *SOLARIZED_LIGHT_PALETTE,
+            ExtraStyles::OledDark => *OLED_DARK_PALETTE,
+            ExtraStyles::OledLight => *OLED_LIGHT_PALETTE,
             ExtraStyles::CustomToml(custom_palette) => custom_palette.palette,
         }
     }
@@ -81,6 +89,8 @@ impl ExtraStyles {
             ExtraStyles::NordLight => *NORD_LIGHT_PALETTE_EXTENSION,
             ExtraStyles::SolarizedDark => *SOLARIZED_DARK_PALETTE_EXTENSION,
             ExtraStyles::SolarizedLight => *SOLARIZED_LIGHT_PALETTE_EXTENSION,
+            ExtraStyles::OledDark => *OLED_DARK_PALETTE_EXTENSION,
+            ExtraStyles::OledLight => *OLED_LIGHT_PALETTE_EXTENSION,
             ExtraStyles::CustomToml(custom_palette) => custom_palette.extension,
         }
     }
@@ -96,6 +106,8 @@ impl ExtraStyles {
             ExtraStyles::NordLight,
             ExtraStyles::SolarizedDark,
             ExtraStyles::SolarizedLight,
+            ExtraStyles::OledDark,
+            ExtraStyles::OledLight,
         ]
     }
 }
@@ -111,6 +123,8 @@ impl fmt::Display for ExtraStyles {
             ExtraStyles::NordDark => write!(f, "Nord (Night)"),
             ExtraStyles::SolarizedLight => write!(f, "Solarized (Day)"),
             ExtraStyles::SolarizedDark => write!(f, "Solarized (Night)"),
+            ExtraStyles::OledLight => write!(f, "OLED (Day)"),
+            ExtraStyles::OledDark => write!(f, "OLED (Night)"),
             // Custom style names aren't used anywhere so this shouldn't be reached
             ExtraStyles::CustomToml(_) => unreachable!(),
         }


### PR DESCRIPTION
Hello everyone,,
I have created a new theme for visually impaired people and at the same time compatible with OLED screens. I hope this will help to improve the usability of the program for visually impaired people (I am visually impaired myself).
![Bildschirmfoto_20250207_174319](https://github.com/user-attachments/assets/921eb739-1bf6-438c-86e2-274f09f32fd8)
