### PR TITLE
Add link to wiki in GUI footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All Sniffnet releases with the relative changes are documented in this file.
 - Add icon to window title bar ([#719](https://github.com/GyulyVGC/sniffnet/pull/719) — fixes [#715](https://github.com/GyulyVGC/sniffnet/issues/715))
 - Fix _crates.io_ package for Windows ([#718](https://github.com/GyulyVGC/sniffnet/pull/718) — fixes [#681](https://github.com/GyulyVGC/sniffnet/issues/681))
 - Remove pre-uninstall script on Linux (fixes [#644](https://github.com/GyulyVGC/sniffnet/issues/644))
+- Added link to the wiki on bottom left footer ([#553](https://github.com/GyulyVGC/sniffnet/issues/553))
 
 ## [1.3.2] - 2025-01-06
 - Dropdown menus for network host filters ([#659](https://github.com/GyulyVGC/sniffnet/pull/659) — fixes [#354](https://github.com/GyulyVGC/sniffnet/issues/354))

--- a/src/gui/components/footer.rs
+++ b/src/gui/components/footer.rs
@@ -175,6 +175,23 @@ fn get_release_details<'a>(
             ret_val = ret_val.push(Text::new(" ✔").size(FONT_SIZE_SUBTITLE).font(font_footer));
         }
     }
+
+    ret_val = ret_val
+        .push(Space::with_width(10))
+        .push(Column::new()
+            .push(
+                rich_text![
+                    span("wiki")
+                        .underline(true)
+                        .link(Message::OpenWebPage(WebPage::Wiki)),
+                ]
+                .size(FONT_SIZE_FOOTER)
+                .font(font_footer),
+            )
+            .width(Length::Fill)
+            .align_x(Alignment::Start),
+        );
+
     ret_val
 }
 


### PR DESCRIPTION
Just fiddling around with rust and saw your repo and this issue (https://github.com/GyulyVGC/sniffnet/issues/553).

Change I made should look like this: 
![image](https://github.com/user-attachments/assets/c8895625-aee4-47e2-be99-64afacd2f1bd)

Please let me know if there are any issues with where I placed the link (was unsure if it should've been a button instead, but thought text was alright) or if you wanted to proceed along another path. Thanks!