### PR TITLE
Fix crash when inserting characters longer than one byte in the text input for byte threshold notification setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All Sniffnet releases with the relative changes are documented in this file.
 - Added new themes _A11y (Night)_ and _A11y (Day)_ based on palettes optimized for OLED displays and users with visual impairments ([#708](https://github.com/GyulyVGC/sniffnet/pull/708))
 - Add icon to window title bar ([#719](https://github.com/GyulyVGC/sniffnet/pull/719) — fixes [#715](https://github.com/GyulyVGC/sniffnet/issues/715))
 - Fix _crates.io_ package for Windows ([#718](https://github.com/GyulyVGC/sniffnet/pull/718) — fixes [#681](https://github.com/GyulyVGC/sniffnet/issues/681))
+- Fix crash when inserting characters longer than one byte in the text input for byte threshold notification setting ([#747](https://github.com/GyulyVGC/sniffnet/pull/747) — fixes [#744](https://github.com/GyulyVGC/sniffnet/issues/744))
 - Remove pre-uninstall script on Linux (fixes [#644](https://github.com/GyulyVGC/sniffnet/issues/644))
 
 ## [1.3.2] - 2025-01-06

--- a/src/notifications/types/notifications.rs
+++ b/src/notifications/types/notifications.rs
@@ -101,16 +101,17 @@ impl BytesNotification {
         let default = existing.unwrap_or_default();
 
         let mut byte_multiple_inserted = ByteMultiple::B;
-        let new_threshold = if value.is_empty() {
+        let chars: Vec<char> = value.trim().chars().collect();
+        let new_threshold = if chars.is_empty() {
             0
-        } else if !value.trim().chars().map(char::is_numeric).any(|x| !x) {
+        } else if !chars.iter().map(|c| char::is_numeric(*c)).any(|x| !x) {
             // no multiple
             value.parse::<u64>().unwrap_or(default.previous_threshold)
         } else {
             // multiple
-            let last_char = value.chars().last().unwrap();
-            byte_multiple_inserted = ByteMultiple::from_char(last_char);
-            let without_multiple = value[0..value.len() - 1].trim().to_string();
+            let last_char = chars.last().unwrap();
+            byte_multiple_inserted = ByteMultiple::from_char(*last_char);
+            let without_multiple: String = chars[0..chars.len() - 1].iter().collect();
             if without_multiple.parse::<u64>().is_ok()
                 && TryInto::<u64>::try_into(
                     without_multiple.parse::<u128>().unwrap()
@@ -182,13 +183,11 @@ mod tests {
         previous_threshold: 123, threshold: Some(123), byte_multiple: ByteMultiple::B, ..BytesNotification::default() })]
     #[case("500k", BytesNotification {
         previous_threshold: 500_000, threshold: Some(500_000),byte_multiple: ByteMultiple::KB, ..BytesNotification::default() })]
-    #[case("420 m", BytesNotification {
+    #[case("420m", BytesNotification {
         previous_threshold: 420_000_000, threshold: Some(420_000_000),byte_multiple: ByteMultiple::MB, ..BytesNotification::default() })]
-    #[case("foob@r", BytesNotification{
-        threshold: Some(800000),
-        ..Default::default()
-    })]
-    #[case(" 888 g", BytesNotification {
+    #[case("744Ь", BytesNotification {
+    previous_threshold: 744, threshold: Some(744),byte_multiple: ByteMultiple::B, ..BytesNotification::default() })]
+    #[case("888g", BytesNotification {
         previous_threshold: 888_000_000_000, threshold: Some(888_000_000_000),byte_multiple: ByteMultiple::GB, ..BytesNotification::default() })]
     fn test_can_instantiate_bytes_notification_from_string(
         #[case] input: &str,


### PR DESCRIPTION
Fix crash when inserting characters longer than one byte in the text input for byte threshold notification setting.

Fixes #744.