### PR TITLE
Add ARP support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All Sniffnet releases with the relative changes are documented in this file.
 
 ## [UNRELEASED]
+- Added support for ARP protocol ([#759](https://github.com/GyulyVGC/sniffnet/pull/759) — fixes [#680](https://github.com/GyulyVGC/sniffnet/issues/680))
 - Identify and tag unassigned/reserved "bogon" IP addresses ([#678](https://github.com/GyulyVGC/sniffnet/pull/678) — fixes [#209](https://github.com/GyulyVGC/sniffnet/issues/209))
 - Show data agglomerates in _Inspect_ page table ([#684](https://github.com/GyulyVGC/sniffnet/pull/684) — fixes [#601](https://github.com/GyulyVGC/sniffnet/issues/601))
 - Updated some of the existing translations to v1.3: 

--- a/src/gui/pages/connection_details_page.rs
+++ b/src/gui/pages/connection_details_page.rs
@@ -19,6 +19,7 @@ use crate::networking::manage_packets::{
     get_address_to_lookup, get_traffic_type, is_local_connection, is_my_address,
 };
 use crate::networking::types::address_port_pair::AddressPortPair;
+use crate::networking::types::arp_type::ArpType;
 use crate::networking::types::bogon::is_bogon;
 use crate::networking::types::host::Host;
 use crate::networking::types::icmp_type::IcmpType;
@@ -185,6 +186,7 @@ fn col_info<'a>(
     language: Language,
 ) -> Column<'a, Message, StyleType> {
     let is_icmp = key.protocol.eq(&Protocol::ICMP);
+    let is_arp = key.protocol.eq(&Protocol::ARP);
 
     let mut ret_val = Column::new()
         .spacing(10)
@@ -207,7 +209,7 @@ fn col_info<'a>(
             font,
         ));
 
-    if !is_icmp {
+    if !is_icmp || !is_arp {
         ret_val = ret_val.push(TextType::highlighted_subtitle_with_desc(
             service_translation(language),
             &val.service.to_string(),
@@ -234,7 +236,7 @@ fn col_info<'a>(
         font,
     ));
 
-    if is_icmp {
+    if is_icmp || is_arp {
         ret_val = ret_val.push(
             Column::new()
                 .push(
@@ -245,7 +247,12 @@ fn col_info<'a>(
                 .push(Scrollable::with_direction(
                     Column::new()
                         .padding(Padding::ZERO.right(10).bottom(10))
-                        .push(Text::new(IcmpType::pretty_print_types(&val.icmp_types)).font(font)),
+                        .push(Text::new(if is_icmp {
+                            IcmpType::pretty_print_types(&val.icmp_types)
+                        } else {
+                            ArpType::pretty_print_types(&val.arp_types)
+                        }
+                    ).font(font)),
                     Direction::Both {
                         vertical: ScrollbarType::properties(),
                         horizontal: ScrollbarType::properties(),

--- a/src/gui/pages/connection_details_page.rs
+++ b/src/gui/pages/connection_details_page.rs
@@ -209,7 +209,7 @@ fn col_info<'a>(
             font,
         ));
 
-    if !is_icmp || !is_arp {
+    if !is_icmp && !is_arp {
         ret_val = ret_val.push(TextType::highlighted_subtitle_with_desc(
             service_translation(language),
             &val.service.to_string(),

--- a/src/gui/pages/connection_details_page.rs
+++ b/src/gui/pages/connection_details_page.rs
@@ -247,12 +247,14 @@ fn col_info<'a>(
                 .push(Scrollable::with_direction(
                     Column::new()
                         .padding(Padding::ZERO.right(10).bottom(10))
-                        .push(Text::new(if is_icmp {
-                            IcmpType::pretty_print_types(&val.icmp_types)
-                        } else {
-                            ArpType::pretty_print_types(&val.arp_types)
-                        }
-                    ).font(font)),
+                        .push(
+                            Text::new(if is_icmp {
+                                IcmpType::pretty_print_types(&val.icmp_types)
+                            } else {
+                                ArpType::pretty_print_types(&val.arp_types)
+                            })
+                            .font(font),
+                        ),
                     Direction::Both {
                         vertical: ScrollbarType::properties(),
                         horizontal: ScrollbarType::properties(),

--- a/src/gui/pages/initial_page.rs
+++ b/src/gui/pages/initial_page.rs
@@ -131,7 +131,7 @@ fn col_ip_buttons(
                     .align_y(Alignment::Center)
                     .font(font),
             )
-            .width(90)
+            .width(80)
             .height(35)
             .class(if is_active {
                 ButtonType::BorderedRoundSelected
@@ -170,7 +170,7 @@ fn col_protocol_buttons(
                     .align_y(Alignment::Center)
                     .font(font),
             )
-            .width(90)
+            .width(80)
             .height(35)
             .class(if is_active {
                 ButtonType::BorderedRoundSelected

--- a/src/gui/sniffer.rs
+++ b/src/gui/sniffer.rs
@@ -1056,11 +1056,13 @@ mod tests {
         sniffer.update(Message::ProtocolSelection(Protocol::UDP, false));
         assert_eq!(
             sniffer.filters.protocols,
-            HashSet::from([Protocol::TCP, Protocol::ICMP])
+            HashSet::from([Protocol::TCP, Protocol::ICMP, Protocol::ARP])
         );
         sniffer.update(Message::ProtocolSelection(Protocol::TCP, false));
-        assert_eq!(sniffer.filters.protocols, HashSet::from([Protocol::ICMP]));
+        assert_eq!(sniffer.filters.protocols, HashSet::from([Protocol::ICMP, Protocol::ARP]));
         sniffer.update(Message::ProtocolSelection(Protocol::ICMP, false));
+        assert_eq!(sniffer.filters.protocols, HashSet::from([Protocol::ARP]));
+        sniffer.update(Message::ProtocolSelection(Protocol::ARP, false));
         assert_eq!(sniffer.filters.protocols, HashSet::new());
         sniffer.update(Message::ProtocolSelection(Protocol::UDP, true));
         assert_eq!(sniffer.filters.protocols, HashSet::from([Protocol::UDP]));

--- a/src/gui/sniffer.rs
+++ b/src/gui/sniffer.rs
@@ -1059,7 +1059,10 @@ mod tests {
             HashSet::from([Protocol::TCP, Protocol::ICMP, Protocol::ARP])
         );
         sniffer.update(Message::ProtocolSelection(Protocol::TCP, false));
-        assert_eq!(sniffer.filters.protocols, HashSet::from([Protocol::ICMP, Protocol::ARP]));
+        assert_eq!(
+            sniffer.filters.protocols,
+            HashSet::from([Protocol::ICMP, Protocol::ARP])
+        );
         sniffer.update(Message::ProtocolSelection(Protocol::ICMP, false));
         assert_eq!(sniffer.filters.protocols, HashSet::from([Protocol::ARP]));
         sniffer.update(Message::ProtocolSelection(Protocol::ARP, false));

--- a/src/networking/manage_packets.rs
+++ b/src/networking/manage_packets.rs
@@ -153,7 +153,6 @@ fn analyze_transport_header(
     protocol: &mut Protocol,
     icmp_type: &mut IcmpType,
 ) -> bool {
-    println!("{:?}", transport_header);
     match transport_header {
         Some(TransportHeader::Udp(udp_header)) => {
             *port1 = Some(udp_header.source_port);

--- a/src/networking/manage_packets.rs
+++ b/src/networking/manage_packets.rs
@@ -1288,7 +1288,8 @@ mod tests {
                         Protocol::TCP => Service::Name("netstat"),
                         Protocol::UDP => Service::Unknown,
                         Protocol::ICMP => panic!(),
-                        Protocol::ARP => panic!(),                    }
+                        Protocol::ARP => panic!(),
+                    }
                 );
 
                 let key =
@@ -1299,7 +1300,8 @@ mod tests {
                         Protocol::TCP => Service::Unknown,
                         Protocol::UDP => Service::Name("murmur"),
                         Protocol::ICMP => panic!(),
-                        Protocol::ARP => panic!(),                    }
+                        Protocol::ARP => panic!(),
+                    }
                 );
 
                 for (p1, p2) in [(Some(5353), Some(53)), (Some(53), Some(5353))] {

--- a/src/networking/manage_packets.rs
+++ b/src/networking/manage_packets.rs
@@ -206,7 +206,7 @@ fn analyze_transport_header(
 }
 
 pub fn get_service(key: &AddressPortPair, traffic_direction: TrafficDirection) -> Service {
-    if key.port1.is_none() || key.port2.is_none() || key.protocol == Protocol::ICMP {
+    if key.port1.is_none() || key.port2.is_none() || key.protocol == Protocol::ICMP || key.protocol == Protocol::ARP {
         return Service::NotApplicable;
     }
 
@@ -1292,8 +1292,7 @@ mod tests {
                     Service::Name(match p {
                         Protocol::TCP => "mdns",
                         Protocol::UDP => "zeroconf",
-                        Protocol::ICMP => panic!(),
-                        Protocol::ARP => panic!(),
+                        _ => panic!(),
                     })
                 );
 
@@ -1303,8 +1302,7 @@ mod tests {
                     match p {
                         Protocol::TCP => Service::Name("netstat"),
                         Protocol::UDP => Service::Unknown,
-                        Protocol::ICMP => panic!(),
-                        Protocol::ARP => panic!(),
+                        _ => panic!(),
                     }
                 );
 
@@ -1315,8 +1313,7 @@ mod tests {
                     match p {
                         Protocol::TCP => Service::Unknown,
                         Protocol::UDP => Service::Name("murmur"),
-                        Protocol::ICMP => panic!(),
-                        Protocol::ARP => panic!(),
+                        _ => panic!(),
                     }
                 );
 

--- a/src/networking/manage_packets.rs
+++ b/src/networking/manage_packets.rs
@@ -48,10 +48,7 @@ pub fn analyze_headers(
         exchanged_bytes,
     );
 
-    let is_arp: bool = match &headers.net {
-        Some(NetHeaders::Arp(_)) => true,
-        _ => false,
-    };
+    let is_arp = matches!(&headers.net, Some(NetHeaders::Arp(_)));
 
     if !analyze_network_header(
         headers.net,
@@ -64,16 +61,16 @@ pub fn analyze_headers(
         return None;
     }
 
-    if !is_arp {
-        if !analyze_transport_header(
+    if !is_arp
+        && !analyze_transport_header(
             headers.transport,
             &mut packet_filters_fields.sport,
             &mut packet_filters_fields.dport,
             &mut packet_filters_fields.protocol,
             icmp_type,
-        ) {
-            return None;
-        }
+        )
+    {
+        return None;
     }
 
     Some(AddressPortPair::new(
@@ -161,7 +158,7 @@ fn analyze_network_header(
                 _ => return false,
             }
             *exchanged_bytes += arp_packet.packet_len() as u128;
-            *arp_type = ArpType::from_etherparse(&arp_packet.operation);
+            *arp_type = ArpType::from_etherparse(arp_packet.operation);
             true
         }
         _ => false,

--- a/src/networking/manage_packets.rs
+++ b/src/networking/manage_packets.rs
@@ -113,7 +113,7 @@ fn analyze_network_header(
     network_protocol: &mut IpVersion,
     address1: &mut IpAddr,
     address2: &mut IpAddr,
-    arp_type: &mut ArpType
+    arp_type: &mut ArpType,
 ) -> bool {
     match network_header {
         Some(NetHeaders::Ipv4(ipv4header, _)) => {
@@ -134,27 +134,31 @@ fn analyze_network_header(
             match arp_packet.proto_addr_type {
                 EtherType::IPV4 => {
                     *network_protocol = IpVersion::IPv4;
-                    *address1 = match TryInto::<[u8; 4]>::try_into(arp_packet.sender_protocol_addr()) {
-                        Ok(source) => IpAddr::from(source),
-                        Err(_) => return false
-                    };
-                    *address2 = match TryInto::<[u8; 4]>::try_into(arp_packet.target_protocol_addr()) {
-                        Ok(destination) => IpAddr::from(destination),
-                        Err(_) => return false
-                    };
+                    *address1 =
+                        match TryInto::<[u8; 4]>::try_into(arp_packet.sender_protocol_addr()) {
+                            Ok(source) => IpAddr::from(source),
+                            Err(_) => return false,
+                        };
+                    *address2 =
+                        match TryInto::<[u8; 4]>::try_into(arp_packet.target_protocol_addr()) {
+                            Ok(destination) => IpAddr::from(destination),
+                            Err(_) => return false,
+                        };
                 }
                 EtherType::IPV6 => {
                     *network_protocol = IpVersion::IPv6;
-                    *address1 = match TryInto::<[u8; 16]>::try_into(arp_packet.sender_protocol_addr()) {
-                        Ok(source) => IpAddr::from(source),
-                        Err(_) => return false
-                    };
-                    *address2 = match TryInto::<[u8; 16]>::try_into(arp_packet.target_protocol_addr()) {
-                        Ok(destination) => IpAddr::from(destination),
-                        Err(_) => return false
-                    };
+                    *address1 =
+                        match TryInto::<[u8; 16]>::try_into(arp_packet.sender_protocol_addr()) {
+                            Ok(source) => IpAddr::from(source),
+                            Err(_) => return false,
+                        };
+                    *address2 =
+                        match TryInto::<[u8; 16]>::try_into(arp_packet.target_protocol_addr()) {
+                            Ok(destination) => IpAddr::from(destination),
+                            Err(_) => return false,
+                        };
                 }
-                _ => return false
+                _ => return false,
             }
             *exchanged_bytes += arp_packet.packet_len() as u128;
             *arp_type = ArpType::from_etherparse(&arp_packet.operation);
@@ -206,7 +210,11 @@ fn analyze_transport_header(
 }
 
 pub fn get_service(key: &AddressPortPair, traffic_direction: TrafficDirection) -> Service {
-    if key.port1.is_none() || key.port2.is_none() || key.protocol == Protocol::ICMP || key.protocol == Protocol::ARP {
+    if key.port1.is_none()
+        || key.port2.is_none()
+        || key.protocol == Protocol::ICMP
+        || key.protocol == Protocol::ARP
+    {
         return Service::NotApplicable;
     }
 

--- a/src/networking/manage_packets.rs
+++ b/src/networking/manage_packets.rs
@@ -127,7 +127,6 @@ fn analyze_network_header(
             true
         }
         Some(NetHeaders::Arp(arppacket)) => {
-            println!("Arp");
             *network_protocol = match arppacket.proto_addr_type {
                 EtherType::IPV4 => IpVersion::IPv4,
                 EtherType::IPV6 => IpVersion::IPv6,

--- a/src/networking/types/arp_type.rs
+++ b/src/networking/types/arp_type.rs
@@ -22,22 +22,24 @@ impl ArpType {
     }
 
     pub fn pretty_print_types(map: &HashMap<ArpType, usize>) -> String {
-            let mut ret_val = String::new();
-    
-            let mut vec: Vec<(&ArpType, &usize)> = map.iter().collect();
-            vec.sort_by(|(_, a), (_, b)| b.cmp(a));
-    
-            for (arp_type, n) in vec {
-                ret_val.push_str(&format!("   {arp_type} ({n})\n"));
-            }
-            ret_val
+        let mut ret_val = String::new();
+
+        let mut vec: Vec<(&ArpType, &usize)> = map.iter().collect();
+        vec.sort_by(|(_, a), (_, b)| b.cmp(a));
+
+        for (arp_type, n) in vec {
+            ret_val.push_str(&format!("   {arp_type} ({n})\n"));
+        }
+        ret_val
     }
 }
 
 impl Display for ArpType {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
-            f, "{}", match self {
+            f,
+            "{}",
+            match self {
                 ArpType::Request => "Request",
                 ArpType::Reply => "Reply",
                 ArpType::Unknown => "?",

--- a/src/networking/types/arp_type.rs
+++ b/src/networking/types/arp_type.rs
@@ -4,7 +4,6 @@ use std::fmt::{Display, Formatter};
 use etherparse::ArpOperation;
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Default)]
-#[allow(clippy::module_name_repetitions)]
 pub enum ArpType {
     Request,
     Reply,
@@ -13,7 +12,7 @@ pub enum ArpType {
 }
 
 impl ArpType {
-    pub fn from_etherparse(arp_operation: &ArpOperation) -> ArpType {
+    pub fn from_etherparse(arp_operation: ArpOperation) -> ArpType {
         match arp_operation {
             ArpOperation(1) => Self::Request,
             ArpOperation(2) => Self::Reply,

--- a/src/networking/types/arp_type.rs
+++ b/src/networking/types/arp_type.rs
@@ -1,0 +1,34 @@
+use std::fmt::{Display, Formatter};
+
+use etherparse::ArpOperation;
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Default)]
+#[allow(clippy::module_name_repetitions)]
+pub enum ArpType {
+    Request,
+    Reply,
+    #[default]
+    Unknown,
+}
+
+impl ArpType {
+    pub fn from_etherparse(arp_operation: &ArpOperation) -> ArpType {
+        match arp_operation {
+            ArpOperation(1) => Self::Request,
+            ArpOperation(2) => Self::Reply,
+            ArpOperation(_) => Self::Unknown,
+        }
+    }
+}
+
+impl Display for ArpType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f, "{}", match self {
+                ArpType::Request => "Request",
+                ArpType::Reply => "Reply",
+                ArpType::Unknown => "?",
+            }
+        )
+    }
+}

--- a/src/networking/types/arp_type.rs
+++ b/src/networking/types/arp_type.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 
 use etherparse::ArpOperation;
@@ -18,6 +19,18 @@ impl ArpType {
             ArpOperation(2) => Self::Reply,
             ArpOperation(_) => Self::Unknown,
         }
+    }
+
+    pub fn pretty_print_types(map: &HashMap<ArpType, usize>) -> String {
+            let mut ret_val = String::new();
+    
+            let mut vec: Vec<(&ArpType, &usize)> = map.iter().collect();
+            vec.sort_by(|(_, a), (_, b)| b.cmp(a));
+    
+            for (arp_type, n) in vec {
+                ret_val.push_str(&format!("   {arp_type} ({n})\n"));
+            }
+            ret_val
     }
 }
 

--- a/src/networking/types/info_address_port_pair.rs
+++ b/src/networking/types/info_address_port_pair.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 use chrono::{DateTime, Local};
 
 use crate::networking::types::icmp_type::IcmpType;
+use crate::networking::types::arp_type::ArpType;
 use crate::networking::types::traffic_direction::TrafficDirection;
 use crate::Service;
 
@@ -32,4 +33,6 @@ pub struct InfoAddressPortPair {
     pub traffic_direction: TrafficDirection,
     /// Types of the ICMP messages exchanged, with the relative count (this is empty if not ICMP)
     pub icmp_types: HashMap<IcmpType, usize>,
+    /// Types of the ARP operations, with the relative count (this is empty if not ARP)
+    pub arp_types: HashMap<ArpType, usize>
 }

--- a/src/networking/types/info_address_port_pair.rs
+++ b/src/networking/types/info_address_port_pair.rs
@@ -5,8 +5,8 @@ use std::collections::HashMap;
 
 use chrono::{DateTime, Local};
 
-use crate::networking::types::icmp_type::IcmpType;
 use crate::networking::types::arp_type::ArpType;
+use crate::networking::types::icmp_type::IcmpType;
 use crate::networking::types::traffic_direction::TrafficDirection;
 use crate::Service;
 
@@ -34,5 +34,5 @@ pub struct InfoAddressPortPair {
     /// Types of the ICMP messages exchanged, with the relative count (this is empty if not ICMP)
     pub icmp_types: HashMap<IcmpType, usize>,
     /// Types of the ARP operations, with the relative count (this is empty if not ARP)
-    pub arp_types: HashMap<ArpType, usize>
+    pub arp_types: HashMap<ArpType, usize>,
 }

--- a/src/networking/types/mod.rs
+++ b/src/networking/types/mod.rs
@@ -1,4 +1,5 @@
 pub mod address_port_pair;
+pub mod arp_type;
 pub mod asn;
 pub mod bogon;
 pub mod byte_multiple;

--- a/src/networking/types/packet_filters_fields.rs
+++ b/src/networking/types/packet_filters_fields.rs
@@ -24,7 +24,7 @@ impl Default for PacketFiltersFields {
     fn default() -> Self {
         Self {
             ip_version: IpVersion::IPv4,
-            protocol: Protocol::TCP,
+            protocol: Protocol::ARP,
             source: IpAddr::from_str("::").unwrap(),
             dest: IpAddr::from_str("::").unwrap(),
             sport: None,

--- a/src/networking/types/protocol.rs
+++ b/src/networking/types/protocol.rs
@@ -10,6 +10,8 @@ pub enum Protocol {
     UDP,
     /// Internet Control Message Protocol
     ICMP,
+    /// Address Resolution Protocol
+    ARP,
 }
 
 impl std::fmt::Display for Protocol {
@@ -19,7 +21,7 @@ impl std::fmt::Display for Protocol {
 }
 
 impl Protocol {
-    pub const ALL: [Protocol; 3] = [Protocol::TCP, Protocol::UDP, Protocol::ICMP];
+    pub const ALL: [Protocol; 4] = [Protocol::TCP, Protocol::UDP, Protocol::ICMP, Protocol::ARP];
 }
 
 #[cfg(test)]
@@ -33,6 +35,7 @@ mod tests {
                 Protocol::TCP => assert_eq!(protocol.to_string(), "TCP"),
                 Protocol::UDP => assert_eq!(protocol.to_string(), "UDP"),
                 Protocol::ICMP => assert_eq!(protocol.to_string(), "ICMP"),
+                Protocol::ARP => assert_eq!(protocol.to_string(), "ARP"),
             }
         }
     }
@@ -43,5 +46,6 @@ mod tests {
         assert_eq!(Protocol::ALL.get(0).unwrap(), &Protocol::TCP);
         assert_eq!(Protocol::ALL.get(1).unwrap(), &Protocol::UDP);
         assert_eq!(Protocol::ALL.get(2).unwrap(), &Protocol::ICMP);
+        assert_eq!(Protocol::ALL.get(3).unwrap(), &Protocol::ARP);
     }
 }

--- a/src/networking/types/protocol.rs
+++ b/src/networking/types/protocol.rs
@@ -42,7 +42,7 @@ mod tests {
 
     #[test]
     fn test_all_protocols_collection() {
-        assert_eq!(Protocol::ALL.len(), 3);
+        assert_eq!(Protocol::ALL.len(), 4);
         assert_eq!(Protocol::ALL.get(0).unwrap(), &Protocol::TCP);
         assert_eq!(Protocol::ALL.get(1).unwrap(), &Protocol::UDP);
         assert_eq!(Protocol::ALL.get(2).unwrap(), &Protocol::ICMP);

--- a/src/secondary_threads/parse_packets.rs
+++ b/src/secondary_threads/parse_packets.rs
@@ -13,6 +13,7 @@ use crate::mmdb::types::mmdb_reader::MmdbReaders;
 use crate::networking::manage_packets::{
     analyze_headers, get_address_to_lookup, modify_or_insert_in_map, reverse_dns_lookup,
 };
+use crate::networking::types::arp_type::ArpType;
 use crate::networking::types::capture_context::CaptureContext;
 use crate::networking::types::data_info::DataInfo;
 use crate::networking::types::filters::Filters;
@@ -56,6 +57,7 @@ pub fn parse_packets(
                     let mut exchanged_bytes = 0;
                     let mut mac_addresses = (None, None);
                     let mut icmp_type = IcmpType::default();
+                    let mut arp_type = ArpType::default();
                     let mut packet_filters_fields = PacketFiltersFields::default();
 
                     let key_option = analyze_headers(
@@ -63,6 +65,7 @@ pub fn parse_packets(
                         &mut mac_addresses,
                         &mut exchanged_bytes,
                         &mut icmp_type,
+                        &mut arp_type,
                         &mut packet_filters_fields,
                     );
 
@@ -86,6 +89,7 @@ pub fn parse_packets(
                             device,
                             mac_addresses,
                             icmp_type,
+                            arp_type,
                             exchanged_bytes,
                         );
                     }

--- a/src/secondary_threads/parse_packets.rs
+++ b/src/secondary_threads/parse_packets.rs
@@ -65,7 +65,7 @@ pub fn parse_packets(
                         &mut icmp_type,
                         &mut packet_filters_fields,
                     );
-                    println!("{:?}", key_option);
+
                     if key_option.is_none() {
                         continue;
                     }

--- a/src/secondary_threads/parse_packets.rs
+++ b/src/secondary_threads/parse_packets.rs
@@ -65,6 +65,7 @@ pub fn parse_packets(
                         &mut icmp_type,
                         &mut packet_filters_fields,
                     );
+                    println!("{:?}", key_option);
                     if key_option.is_none() {
                         continue;
                     }


### PR DESCRIPTION
Hello!
I'm shu-kitamura.

I took on the challenge #680.

ARP is listed in the protocol list in the menu.

<img width="944" alt="image" src="https://github.com/user-attachments/assets/b388b518-2109-41fa-ab38-18f529011407" />

ARP is also shown in the Inspect table.

![image](https://github.com/user-attachments/assets/f122425a-a98a-4615-97e8-32b3518e00a2)

When I click on the ARP row in the Inspect page table, the type of ARP operation is displayed.

<img width="941" alt="image" src="https://github.com/user-attachments/assets/3abca932-ceaa-4927-bebb-99f2e5585895" />