### PR TITLE
Error handling to reduce the number of possible crash occurrences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All Sniffnet releases with the relative changes are documented in this file.
 - Avoid directory traversal when selecting file name for PCAP exports ([#776](https://github.com/GyulyVGC/sniffnet/pull/776) — fixes [#767](https://github.com/GyulyVGC/sniffnet/issues/767))
 - Add icon to window title bar ([#719](https://github.com/GyulyVGC/sniffnet/pull/719) — fixes [#715](https://github.com/GyulyVGC/sniffnet/issues/715))
 - Update footer buttons and links ([#755](https://github.com/GyulyVGC/sniffnet/pull/755) — fixes [#553](https://github.com/GyulyVGC/sniffnet/issues/553))
+- Handle errors to reduce the number of possible crash occurrences ([#784](https://github.com/GyulyVGC/sniffnet/pull/784))
 - Fix _crates.io_ package for Windows ([#718](https://github.com/GyulyVGC/sniffnet/pull/718) — fixes [#681](https://github.com/GyulyVGC/sniffnet/issues/681))
 - Fix crash when inserting characters longer than one byte in the text input for byte threshold notification setting ([#747](https://github.com/GyulyVGC/sniffnet/pull/747) — fixes [#744](https://github.com/GyulyVGC/sniffnet/issues/744))
 - Remove pre-uninstall script on Linux (fixes [#644](https://github.com/GyulyVGC/sniffnet/issues/644))

--- a/src/gui/pages/connection_details_page.rs
+++ b/src/gui/pages/connection_details_page.rs
@@ -66,7 +66,7 @@ fn page_content<'a>(sniffer: &Sniffer, key: &AddressPortPair) -> Container<'a, M
     let font_headers = style.get_extension().font_headers;
 
     let info_traffic_lock = sniffer.info_traffic.lock().unwrap();
-    let val = info_traffic_lock.map.get(key).unwrap().clone();
+    let val = info_traffic_lock.map.get(key).unwrap_or_default().clone();
     let address_to_lookup = get_address_to_lookup(key, val.traffic_direction);
     let host_option = info_traffic_lock
         .addresses_resolved
@@ -194,8 +194,14 @@ fn col_info<'a>(
             Row::new().spacing(5).push(Icon::Clock.to_text()).push(
                 Text::new(format!(
                     "{} - {}",
-                    val.initial_timestamp.to_string().get(11..19).unwrap(),
-                    val.final_timestamp.to_string().get(11..19).unwrap()
+                    val.initial_timestamp
+                        .to_string()
+                        .get(11..19)
+                        .unwrap_or_default(),
+                    val.final_timestamp
+                        .to_string()
+                        .get(11..19)
+                        .unwrap_or_default()
                 ))
                 .font(font),
             ),

--- a/src/gui/pages/connection_details_page.rs
+++ b/src/gui/pages/connection_details_page.rs
@@ -37,7 +37,7 @@ use crate::translations::translations_2::{
 use crate::translations::translations_3::{
     copy_translation, messages_translation, service_translation,
 };
-use crate::utils::formatted_strings::get_socket_address;
+use crate::utils::formatted_strings::{get_formatted_timestamp, get_socket_address};
 use crate::utils::types::icon::Icon;
 use crate::{ByteMultiple, ConfigSettings, Language, Protocol, Sniffer, StyleType};
 
@@ -198,14 +198,8 @@ fn col_info<'a>(
             Row::new().spacing(5).push(Icon::Clock.to_text()).push(
                 Text::new(format!(
                     "{} - {}",
-                    val.initial_timestamp
-                        .to_string()
-                        .get(11..19)
-                        .unwrap_or_default(),
-                    val.final_timestamp
-                        .to_string()
-                        .get(11..19)
-                        .unwrap_or_default()
+                    get_formatted_timestamp(val.initial_timestamp),
+                    get_formatted_timestamp(val.final_timestamp)
                 ))
                 .font(font),
             ),

--- a/src/gui/pages/connection_details_page.rs
+++ b/src/gui/pages/connection_details_page.rs
@@ -65,10 +65,7 @@ fn page_content<'a>(sniffer: &Sniffer, key: &AddressPortPair) -> Container<'a, M
     let font = style.get_extension().font;
     let font_headers = style.get_extension().font_headers;
 
-    let info_traffic_lock = sniffer
-        .info_traffic
-        .lock()
-        .expect("Error acquiring mutex\n\r");
+    let info_traffic_lock = sniffer.info_traffic.lock().unwrap();
     let val = info_traffic_lock.map.get(key).unwrap().clone();
     let address_to_lookup = get_address_to_lookup(key, val.traffic_direction);
     let host_option = info_traffic_lock

--- a/src/gui/pages/connection_details_page.rs
+++ b/src/gui/pages/connection_details_page.rs
@@ -66,7 +66,11 @@ fn page_content<'a>(sniffer: &Sniffer, key: &AddressPortPair) -> Container<'a, M
     let font_headers = style.get_extension().font_headers;
 
     let info_traffic_lock = sniffer.info_traffic.lock().unwrap();
-    let val = info_traffic_lock.map.get(key).unwrap_or_default().clone();
+    let val = info_traffic_lock
+        .map
+        .get(key)
+        .unwrap_or(&InfoAddressPortPair::default())
+        .clone();
     let address_to_lookup = get_address_to_lookup(key, val.traffic_direction);
     let host_option = info_traffic_lock
         .addresses_resolved

--- a/src/gui/pages/initial_page.rs
+++ b/src/gui/pages/initial_page.rs
@@ -36,10 +36,11 @@ use crate::translations::translations::{
 use crate::translations::translations_3::{
     directory_translation, export_capture_translation, file_name_translation, port_translation,
 };
+use crate::utils::error_logger::{ErrorLogger, Location};
 use crate::utils::formatted_strings::{get_invalid_filters_string, get_path_termination_string};
 use crate::utils::types::file_info::FileInfo;
 use crate::utils::types::icon::Icon;
-use crate::{ConfigSettings, IpVersion, Language, Protocol, StyleType};
+use crate::{ConfigSettings, IpVersion, Language, Protocol, StyleType, location};
 
 /// Computes the body of gui initial page
 pub fn initial_page(sniffer: &Sniffer) -> Container<Message, StyleType> {
@@ -294,7 +295,7 @@ fn get_col_adapter(sniffer: &Sniffer, font: Font) -> Column<Message, StyleType> 
     let ConfigSettings { language, .. } = sniffer.configs.lock().unwrap().settings;
 
     let mut dev_str_list = vec![];
-    for dev in Device::list().expect("Error retrieving device list\r\n") {
+    for dev in Device::list().log_err(location!()).unwrap_or_default() {
         let mut dev_str = String::new();
         let name = dev.name;
         match dev.desc {

--- a/src/gui/pages/overview_page.rs
+++ b/src/gui/pages/overview_page.rs
@@ -128,7 +128,7 @@ pub fn overview_page(sniffer: &Sniffer) -> Container<Message, StyleType> {
     } else {
         // pcap threw an ERROR!
         body = body_pcap_error(
-            sniffer.pcap_error.as_ref().unwrap(),
+            sniffer.pcap_error.as_ref().unwrap_or_default(),
             &sniffer.waiting,
             language,
             font,
@@ -218,7 +218,6 @@ fn body_pcap_error<'a>(
     language: Language,
     font: Font,
 ) -> Column<'a, Message, StyleType> {
-    // let err_string = pcap_error.clone().unwrap();
     let error_text = error_translation(language, pcap_error)
         .align_x(Alignment::Center)
         .font(font);

--- a/src/gui/pages/overview_page.rs
+++ b/src/gui/pages/overview_page.rs
@@ -61,7 +61,10 @@ pub fn overview_page(sniffer: &Sniffer) -> Container<Message, StyleType> {
     let mut body = Column::new();
     let mut tab_and_body = Column::new().height(Length::Fill);
 
-    if sniffer.pcap_error.is_none() {
+    if let Some(error) = sniffer.pcap_error.as_ref() {
+        // pcap threw an ERROR!
+        body = body_pcap_error(error, &sniffer.waiting, language, font);
+    } else {
         // NO pcap error detected
         let observed = sniffer.runtime_data.all_packets;
         let filtered = sniffer.runtime_data.tot_out_packets + sniffer.runtime_data.tot_in_packets;
@@ -125,14 +128,6 @@ pub fn overview_page(sniffer: &Sniffer) -> Container<Message, StyleType> {
                     .push(container_report);
             }
         }
-    } else {
-        // pcap threw an ERROR!
-        body = body_pcap_error(
-            sniffer.pcap_error.as_ref().unwrap_or_default(),
-            &sniffer.waiting,
-            language,
-            font,
-        );
     }
 
     Container::new(Column::new().push(tab_and_body.push(body))).height(Length::Fill)

--- a/src/gui/pages/settings_general_page.rs
+++ b/src/gui/pages/settings_general_page.rs
@@ -290,7 +290,7 @@ fn mmdb_selection_row<'a>(
         false
     } else {
         match *mmdb_reader {
-            MmdbReader::Default(_) => true,
+            MmdbReader::Default(_) | MmdbReader::Empty => true,
             MmdbReader::Custom(_) => false,
         }
     };

--- a/src/gui/pages/settings_notifications_page.rs
+++ b/src/gui/pages/settings_notifications_page.rs
@@ -253,7 +253,10 @@ fn input_group_packets<'a>(
     font: Font,
     language: Language,
 ) -> Container<'a, Message, StyleType> {
-    let curr_threshold_str = &packets_notification.threshold.unwrap().to_string();
+    let curr_threshold_str = &packets_notification
+        .threshold
+        .unwrap_or_default()
+        .to_string();
     let input_row = Row::new()
         .align_y(Alignment::Center)
         .spacing(5)
@@ -301,7 +304,7 @@ fn input_group_bytes<'a>(
         per_second_translation(language),
         specify_multiples_translation(language)
     );
-    let mut curr_threshold_str = (bytes_notification.threshold.unwrap()
+    let mut curr_threshold_str = (bytes_notification.threshold.unwrap_or_default()
         / bytes_notification.byte_multiple.multiplier())
     .to_string();
     curr_threshold_str.push_str(&bytes_notification.byte_multiple.get_char());

--- a/src/gui/sniffer.rs
+++ b/src/gui/sniffer.rs
@@ -689,12 +689,15 @@ impl Sniffer {
         #[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
         let cmd = "xdg-open";
 
-        std::process::Command::new(cmd)
+        let Ok(mut child) = std::process::Command::new(cmd)
             .arg(url)
             .spawn()
-            .unwrap_or_default()
-            .wait()
-            .unwrap_or_default();
+            .log_err(location!())
+        else {
+            return;
+        };
+
+        child.wait().unwrap_or_default();
     }
 
     fn start(&mut self) {
@@ -720,7 +723,7 @@ impl Sniffer {
             let mmdb_readers = self.mmdb_readers.clone();
             let host_data = self.host_data_states.data.clone();
             self.device.link_type = capture_context.my_link_type();
-            thread::Builder::new()
+            let _ = thread::Builder::new()
                 .name("thread_parse_packets".to_string())
                 .spawn(move || {
                     parse_packets(
@@ -733,7 +736,7 @@ impl Sniffer {
                         &host_data,
                     );
                 })
-                .unwrap_or_default();
+                .log_err(location!());
         }
     }
 

--- a/src/gui/sniffer.rs
+++ b/src/gui/sniffer.rs
@@ -381,7 +381,7 @@ impl Sniffer {
                 } else {
                     self.page_number.checked_sub(1)
                 }
-                .unwrap();
+                .unwrap_or_default();
                 self.page_number = new_page;
             }
             Message::ArrowPressed(increment) => {
@@ -405,7 +405,7 @@ impl Sniffer {
             Message::ChangeScaleFactor(slider_val) => {
                 let scale_factor_str = format!("{:.1}", 3.0_f64.powf(slider_val));
                 self.configs.lock().unwrap().settings.scale_factor =
-                    scale_factor_str.parse().unwrap();
+                    scale_factor_str.parse().unwrap_or_default();
             }
             Message::WindowMoved(x, y) => {
                 let scale_factor = self.configs.lock().unwrap().settings.scale_factor;
@@ -692,7 +692,7 @@ impl Sniffer {
         std::process::Command::new(cmd)
             .arg(url)
             .spawn()
-            .unwrap()
+            .unwrap_or_default()
             .wait()
             .unwrap_or_default();
     }
@@ -733,7 +733,7 @@ impl Sniffer {
                         &host_data,
                     );
                 })
-                .unwrap();
+                .unwrap_or_default();
         }
     }
 

--- a/src/gui/sniffer.rs
+++ b/src/gui/sniffer.rs
@@ -381,7 +381,7 @@ impl Sniffer {
                 } else {
                     self.page_number.checked_sub(1)
                 }
-                .unwrap_or_default();
+                .unwrap_or(1);
                 self.page_number = new_page;
             }
             Message::ArrowPressed(increment) => {
@@ -405,7 +405,7 @@ impl Sniffer {
             Message::ChangeScaleFactor(slider_val) => {
                 let scale_factor_str = format!("{:.1}", 3.0_f64.powf(slider_val));
                 self.configs.lock().unwrap().settings.scale_factor =
-                    scale_factor_str.parse().unwrap_or_default();
+                    scale_factor_str.parse().unwrap_or(1.0);
             }
             Message::WindowMoved(x, y) => {
                 let scale_factor = self.configs.lock().unwrap().settings.scale_factor;

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,7 @@ use crate::configs::types::configs::{CONFIGS, Configs};
 use crate::gui::sniffer::FONT_FAMILY_NAME;
 use crate::gui::styles::style_constants::{ICONS_BYTES, SARASA_MONO_BOLD_BYTES, SARASA_MONO_BYTES};
 use crate::secondary_threads::check_updates::set_newer_release_status;
+use crate::utils::error_logger::{ErrorLogger, Location};
 
 mod chart;
 mod cli;
@@ -91,12 +92,12 @@ pub fn main() -> iced::Result {
         process::exit(130);
     });
 
-    thread::Builder::new()
+    let _ = thread::Builder::new()
         .name("thread_check_updates".to_string())
         .spawn(move || {
             set_newer_release_status(&newer_release_available2);
         })
-        .unwrap();
+        .log_err(location!());
 
     print_cli_welcome_message();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,7 +90,8 @@ pub fn main() -> iced::Result {
     let _ = ctrlc::set_handler(move || {
         configs2.lock().unwrap().clone().store();
         process::exit(130);
-    });
+    })
+    .log_err(location!());
 
     let _ = thread::Builder::new()
         .name("thread_check_updates".to_string())

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,11 +86,10 @@ pub fn main() -> iced::Result {
     }));
 
     // gracefully close the app when receiving SIGINT, SIGTERM, or SIGHUP
-    ctrlc::set_handler(move || {
+    let _ = ctrlc::set_handler(move || {
         configs2.lock().unwrap().clone().store();
         process::exit(130);
-    })
-    .expect("Error setting Ctrl-C handler");
+    });
 
     thread::Builder::new()
         .name("thread_check_updates".to_string())

--- a/src/mmdb/types/mmdb_reader.rs
+++ b/src/mmdb/types/mmdb_reader.rs
@@ -1,6 +1,8 @@
 use std::net::IpAddr;
 use std::sync::Arc;
 
+use crate::location;
+use crate::utils::error_logger::{ErrorLogger, Location};
 use maxminddb::{MaxMindDbError, Reader};
 use serde::Deserialize;
 
@@ -13,6 +15,7 @@ pub struct MmdbReaders {
 pub enum MmdbReader {
     Default(Reader<&'static [u8]>),
     Custom(Reader<Vec<u8>>),
+    Empty,
 }
 
 impl MmdbReader {
@@ -20,8 +23,13 @@ impl MmdbReader {
         if let Ok(custom_reader) = maxminddb::Reader::open_readfile(mmdb_path) {
             return MmdbReader::Custom(custom_reader);
         }
-        let default_reader = maxminddb::Reader::from_source(default_mmdb).unwrap();
-        MmdbReader::Default(default_reader)
+        match maxminddb::Reader::from_source(default_mmdb) {
+            Ok(default_reader) => MmdbReader::Default(default_reader),
+            err_res => {
+                let _ = err_res.log_err(location!());
+                MmdbReader::Empty
+            }
+        }
     }
 
     pub fn lookup<'a, T: Deserialize<'a>>(
@@ -31,6 +39,7 @@ impl MmdbReader {
         match self {
             MmdbReader::Default(reader) => reader.lookup(ip),
             MmdbReader::Custom(reader) => reader.lookup(ip),
+            MmdbReader::Empty => Ok(None),
         }
     }
 }

--- a/src/networking/manage_packets.rs
+++ b/src/networking/manage_packets.rs
@@ -207,13 +207,16 @@ fn analyze_transport_header(
 }
 
 pub fn get_service(key: &AddressPortPair, traffic_direction: TrafficDirection) -> Service {
-    if key.port1.is_none()
-        || key.port2.is_none()
-        || key.protocol == Protocol::ICMP
-        || key.protocol == Protocol::ARP
-    {
+    if key.protocol == Protocol::ICMP || key.protocol == Protocol::ARP {
         return Service::NotApplicable;
     }
+
+    let Some(port1) = key.port1 else {
+        return Service::NotApplicable;
+    };
+    let Some(port2) = key.port2 else {
+        return Service::NotApplicable;
+    };
 
     // to return the service associated with the highest score:
     // score = service_is_some * (port_is_well_known + bonus_direction)
@@ -226,9 +229,6 @@ pub fn get_service(key: &AddressPortPair, traffic_direction: TrafficDirection) -
         let bonus_direction = u8::from(bonus_direction);
         service_is_some * (port_is_well_known + bonus_direction)
     };
-
-    let port1 = key.port1.unwrap();
-    let port2 = key.port2.unwrap();
 
     let unknown = Service::Unknown;
     let service1 = SERVICES

--- a/src/networking/manage_packets.rs
+++ b/src/networking/manage_packets.rs
@@ -24,8 +24,9 @@ use crate::networking::types::service::Service;
 use crate::networking::types::service_query::ServiceQuery;
 use crate::networking::types::traffic_direction::TrafficDirection;
 use crate::networking::types::traffic_type::TrafficType;
+use crate::utils::error_logger::{ErrorLogger, Location};
 use crate::utils::formatted_strings::get_domain_from_r_dns;
-use crate::{InfoTraffic, IpVersion, Protocol};
+use crate::{InfoTraffic, IpVersion, Protocol, location};
 use std::fmt::Write;
 
 include!(concat!(env!("OUT_DIR"), "/services.rs"));
@@ -274,7 +275,7 @@ pub fn modify_or_insert_in_map(
 
         // update device addresses
         let mut my_interface_addresses = Vec::new();
-        for dev in Device::list().expect("Error retrieving device list\r\n") {
+        for dev in Device::list().log_err(location!()).unwrap_or_default() {
             if dev.name.eq(&my_device.name) {
                 let mut my_interface_addresses_mutex = my_device.addresses.lock().unwrap();
                 my_interface_addresses_mutex.clone_from(&dev.addresses);
@@ -297,9 +298,7 @@ pub fn modify_or_insert_in_map(
         service = get_service(key, traffic_direction);
     }
 
-    let mut info_traffic = info_traffic_mutex
-        .lock()
-        .expect("Error acquiring mutex\n\r");
+    let mut info_traffic = info_traffic_mutex.lock().unwrap();
 
     let new_info: InfoAddressPortPair = info_traffic
         .map

--- a/src/networking/types/capture_context.rs
+++ b/src/networking/types/capture_context.rs
@@ -11,8 +11,12 @@ pub enum CaptureContext {
 
 impl CaptureContext {
     pub fn new(device: &MyDevice, pcap_path: Option<&String>) -> Self {
-        let cap_res = Capture::from_device(device.to_pcap_device())
-            .expect("Capture initialization error\n\r")
+        let inactive = match Capture::from_device(device.to_pcap_device()) {
+            Ok(c) => c,
+            Err(e) => return Self::Error(e.to_string()),
+        };
+
+        let cap_res = inactive
             .promisc(true)
             .snaplen(if pcap_path.is_some() {
                 i32::from(u16::MAX)
@@ -22,18 +26,16 @@ impl CaptureContext {
             .immediate_mode(true) //parse packets ASAP!
             .open();
 
-        if let Err(e) = &cap_res {
-            return Self::Error(e.to_string());
-        }
-
-        let cap = cap_res.unwrap();
+        let cap = match cap_res {
+            Ok(c) => c,
+            Err(e) => return Self::Error(e.to_string()),
+        };
 
         if let Some(path) = pcap_path {
             let savefile_res = cap.savefile(path);
-            if let Err(e) = savefile_res {
-                Self::Error(e.to_string())
-            } else {
-                Self::new_online_with_savefile(cap, savefile_res.unwrap())
+            match savefile_res {
+                Ok(s) => Self::new_online_with_savefile(cap, s),
+                Err(e) => Self::Error(e.to_string()),
             }
         } else {
             Self::new_online(cap)

--- a/src/networking/types/ip_collection.rs
+++ b/src/networking/types/ip_collection.rs
@@ -1,4 +1,4 @@
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::ops::RangeInclusive;
 use std::str::FromStr;
 
@@ -34,17 +34,17 @@ impl AddressCollection {
                     (subparts.next().unwrap_or(""), subparts.next().unwrap_or(""));
                 let lower_ip_res = IpAddr::from_str(lower_str);
                 let upper_ip_res = IpAddr::from_str(upper_str);
-                if lower_ip_res.is_ok() && upper_ip_res.is_ok() {
-                    let lower_ip = lower_ip_res.unwrap();
-                    let upper_ip = upper_ip_res.unwrap();
-                    let range = RangeInclusive::new(lower_ip, upper_ip);
-                    if range.is_empty() || lower_ip.is_ipv4() != upper_ip.is_ipv4() {
-                        return None;
-                    }
-                    ranges.push(range);
-                } else {
+                let Ok(lower_ip) = lower_ip_res else {
+                    return None;
+                };
+                let Ok(upper_ip) = upper_ip_res else {
+                    return None;
+                };
+                let range = RangeInclusive::new(lower_ip, upper_ip);
+                if range.is_empty() || lower_ip.is_ipv4() != upper_ip.is_ipv4() {
                     return None;
                 }
+                ranges.push(range);
             } else {
                 // individual IP
                 if let Ok(ip) = IpAddr::from_str(object) {
@@ -74,12 +74,15 @@ impl Default for AddressCollection {
             ips: vec![],
             ranges: vec![
                 RangeInclusive::new(
-                    IpAddr::from_str("0.0.0.0").unwrap(),
-                    IpAddr::from_str("255.255.255.255").unwrap(),
+                    IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+                    IpAddr::from([255, 255, 255, 255]),
                 ),
                 RangeInclusive::new(
-                    IpAddr::from_str("::").unwrap(),
-                    IpAddr::from_str("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff").unwrap(),
+                    IpAddr::V6(Ipv6Addr::UNSPECIFIED),
+                    IpAddr::from([
+                        255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+                        255,
+                    ]),
                 ),
             ],
         }

--- a/src/networking/types/my_link_type.rs
+++ b/src/networking/types/my_link_type.rs
@@ -51,7 +51,7 @@ impl MyLinkType {
                     "{}: {} ({})",
                     link_type_translation(language),
                     l.get_name().unwrap_or_else(|_| l.0.to_string()),
-                    l.get_description().unwrap_or(String::new())
+                    l.get_description().unwrap_or_else(|_| String::new())
                 )
             }
             Self::NotYetAssigned => String::new(),
@@ -74,7 +74,7 @@ impl MyLinkType {
                 let link_info = format!(
                     "{} ({})",
                     l.get_name().unwrap_or_else(|_| l.0.to_string()),
-                    l.get_description().unwrap_or(String::new())
+                    l.get_description().unwrap_or_else(|_| String::new())
                 );
                 TextType::highlighted_subtitle_with_desc(
                     link_type_translation(language),

--- a/src/networking/types/packet_filters_fields.rs
+++ b/src/networking/types/packet_filters_fields.rs
@@ -1,5 +1,4 @@
-use std::net::IpAddr;
-use std::str::FromStr;
+use std::net::{IpAddr, Ipv6Addr};
 
 use crate::{IpVersion, Protocol};
 
@@ -25,8 +24,8 @@ impl Default for PacketFiltersFields {
         Self {
             ip_version: IpVersion::IPv4,
             protocol: Protocol::ARP,
-            source: IpAddr::from_str("::").unwrap(),
-            dest: IpAddr::from_str("::").unwrap(),
+            source: IpAddr::V6(Ipv6Addr::UNSPECIFIED),
+            dest: IpAddr::V6(Ipv6Addr::UNSPECIFIED),
             sport: None,
             dport: None,
         }

--- a/src/networking/types/port_collection.rs
+++ b/src/networking/types/port_collection.rs
@@ -32,17 +32,17 @@ impl PortCollection {
                     (subparts.next().unwrap_or(""), subparts.next().unwrap_or(""));
                 let lower_port_res = u16::from_str(lower_str);
                 let upper_port_res = u16::from_str(upper_str);
-                if lower_port_res.is_ok() && upper_port_res.is_ok() {
-                    let lower_port = lower_port_res.unwrap_or_default();
-                    let upper_port = upper_port_res.unwrap_or_default();
-                    let range = RangeInclusive::new(lower_port, upper_port);
-                    if range.is_empty() {
-                        return None;
-                    }
-                    ranges.push(range);
-                } else {
+                let Ok(lower_port) = lower_port_res else {
+                    return None;
+                };
+                let Ok(upper_port) = upper_port_res else {
+                    return None;
+                };
+                let range = RangeInclusive::new(lower_port, upper_port);
+                if range.is_empty() {
                     return None;
                 }
+                ranges.push(range);
             } else {
                 // individual port
                 if let Ok(port) = u16::from_str(object) {

--- a/src/networking/types/port_collection.rs
+++ b/src/networking/types/port_collection.rs
@@ -33,8 +33,8 @@ impl PortCollection {
                 let lower_port_res = u16::from_str(lower_str);
                 let upper_port_res = u16::from_str(upper_str);
                 if lower_port_res.is_ok() && upper_port_res.is_ok() {
-                    let lower_port = lower_port_res.unwrap();
-                    let upper_port = upper_port_res.unwrap();
+                    let lower_port = lower_port_res.unwrap_or_default();
+                    let upper_port = upper_port_res.unwrap_or_default();
                     let range = RangeInclusive::new(lower_port, upper_port);
                     if range.is_empty() {
                         return None;
@@ -63,11 +63,11 @@ impl PortCollection {
         }
 
         for range in &self.ranges {
-            if range.contains(&port.unwrap()) {
+            if range.contains(&port.unwrap_or_default()) {
                 return true;
             }
         }
-        self.ports.contains(&port.unwrap())
+        self.ports.contains(&port.unwrap_or_default())
     }
 }
 

--- a/src/networking/types/port_collection.rs
+++ b/src/networking/types/port_collection.rs
@@ -57,17 +57,17 @@ impl PortCollection {
     }
 
     pub(crate) fn contains(&self, port: Option<u16>) -> bool {
-        // ignore port filter in case of ICMP
-        if port.is_none() {
+        // ignore port filter in case of ICMP or ARP
+        let Some(p) = port else {
             return true;
-        }
+        };
 
         for range in &self.ranges {
-            if range.contains(&port.unwrap_or_default()) {
+            if range.contains(&p) {
                 return true;
             }
         }
-        self.ports.contains(&port.unwrap_or_default())
+        self.ports.contains(&p)
     }
 }
 

--- a/src/notifications/notify_and_log.rs
+++ b/src/notifications/notify_and_log.rs
@@ -8,6 +8,7 @@ use crate::notifications::types::logged_notification::{
 };
 use crate::notifications::types::notifications::Notifications;
 use crate::notifications::types::sound::{Sound, play};
+use crate::utils::formatted_strings::get_formatted_timestamp;
 use crate::{InfoTraffic, RunTimeData};
 
 /// Checks if one or more notifications have to be emitted and logs them.
@@ -42,11 +43,7 @@ pub fn notify_and_log(
                     threshold: notifications.packets_notification.previous_threshold,
                     incoming: received_packets_entry.try_into().unwrap_or_default(),
                     outgoing: sent_packets_entry.try_into().unwrap_or_default(),
-                    timestamp: Local::now()
-                        .to_string()
-                        .get(11..19)
-                        .unwrap_or_default()
-                        .to_string(),
+                    timestamp: get_formatted_timestamp(Local::now()),
                 }),
             );
             if notifications.packets_notification.sound.ne(&Sound::None) {
@@ -81,11 +78,7 @@ pub fn notify_and_log(
                     threshold: notifications.bytes_notification.previous_threshold,
                     incoming: received_bytes_entry.try_into().unwrap_or_default(),
                     outgoing: sent_bytes_entry.try_into().unwrap_or_default(),
-                    timestamp: Local::now()
-                        .to_string()
-                        .get(11..19)
-                        .unwrap_or_default()
-                        .to_string(),
+                    timestamp: get_formatted_timestamp(Local::now()),
                 }),
             );
             if !already_emitted_sound && notifications.bytes_notification.sound.ne(&Sound::None) {
@@ -121,11 +114,7 @@ pub fn notify_and_log(
                     FavoriteTransmitted {
                         host,
                         data_info_host,
-                        timestamp: Local::now()
-                            .to_string()
-                            .get(11..19)
-                            .unwrap_or_default()
-                            .to_string(),
+                        timestamp: get_formatted_timestamp(Local::now()),
                     },
                 ));
         }

--- a/src/notifications/notify_and_log.rs
+++ b/src/notifications/notify_and_log.rs
@@ -2,6 +2,7 @@ use std::sync::Mutex;
 
 use chrono::Local;
 
+use crate::networking::types::data_info_host::DataInfoHost;
 use crate::notifications::types::logged_notification::{
     BytesThresholdExceeded, FavoriteTransmitted, LoggedNotification, PacketsThresholdExceeded,
 };
@@ -110,7 +111,10 @@ pub fn notify_and_log(
                 runtime_data.logged_notifications.pop_back();
             }
 
-            let data_info_host = *info_traffic_lock.hosts.get(&host).unwrap_or_default();
+            let data_info_host = *info_traffic_lock
+                .hosts
+                .get(&host)
+                .unwrap_or(&DataInfoHost::default());
             runtime_data
                 .logged_notifications
                 .push_front(LoggedNotification::FavoriteTransmitted(

--- a/src/notifications/notify_and_log.rs
+++ b/src/notifications/notify_and_log.rs
@@ -24,7 +24,12 @@ pub fn notify_and_log(
         let sent_packets_entry = runtime_data.tot_out_packets - runtime_data.tot_out_packets_prev;
         let received_packets_entry = runtime_data.tot_in_packets - runtime_data.tot_in_packets_prev;
         if received_packets_entry + sent_packets_entry
-            > u128::from(notifications.packets_notification.threshold.unwrap())
+            > u128::from(
+                notifications
+                    .packets_notification
+                    .threshold
+                    .unwrap_or_default(),
+            )
         {
             // log this notification
             emitted_notifications += 1;
@@ -34,9 +39,13 @@ pub fn notify_and_log(
             runtime_data.logged_notifications.push_front(
                 LoggedNotification::PacketsThresholdExceeded(PacketsThresholdExceeded {
                     threshold: notifications.packets_notification.previous_threshold,
-                    incoming: received_packets_entry.try_into().unwrap(),
-                    outgoing: sent_packets_entry.try_into().unwrap(),
-                    timestamp: Local::now().to_string().get(11..19).unwrap().to_string(),
+                    incoming: received_packets_entry.try_into().unwrap_or_default(),
+                    outgoing: sent_packets_entry.try_into().unwrap_or_default(),
+                    timestamp: Local::now()
+                        .to_string()
+                        .get(11..19)
+                        .unwrap_or_default()
+                        .to_string(),
                 }),
             );
             if notifications.packets_notification.sound.ne(&Sound::None) {
@@ -54,7 +63,12 @@ pub fn notify_and_log(
         let sent_bytes_entry = runtime_data.tot_out_bytes - runtime_data.tot_out_bytes_prev;
         let received_bytes_entry = runtime_data.tot_in_bytes - runtime_data.tot_in_bytes_prev;
         if received_bytes_entry + sent_bytes_entry
-            > u128::from(notifications.bytes_notification.threshold.unwrap())
+            > u128::from(
+                notifications
+                    .bytes_notification
+                    .threshold
+                    .unwrap_or_default(),
+            )
         {
             //log this notification
             emitted_notifications += 1;
@@ -64,9 +78,13 @@ pub fn notify_and_log(
             runtime_data.logged_notifications.push_front(
                 LoggedNotification::BytesThresholdExceeded(BytesThresholdExceeded {
                     threshold: notifications.bytes_notification.previous_threshold,
-                    incoming: received_bytes_entry.try_into().unwrap(),
-                    outgoing: sent_bytes_entry.try_into().unwrap(),
-                    timestamp: Local::now().to_string().get(11..19).unwrap().to_string(),
+                    incoming: received_bytes_entry.try_into().unwrap_or_default(),
+                    outgoing: sent_bytes_entry.try_into().unwrap_or_default(),
+                    timestamp: Local::now()
+                        .to_string()
+                        .get(11..19)
+                        .unwrap_or_default()
+                        .to_string(),
                 }),
             );
             if !already_emitted_sound && notifications.bytes_notification.sound.ne(&Sound::None) {
@@ -92,14 +110,18 @@ pub fn notify_and_log(
                 runtime_data.logged_notifications.pop_back();
             }
 
-            let data_info_host = *info_traffic_lock.hosts.get(&host).unwrap();
+            let data_info_host = *info_traffic_lock.hosts.get(&host).unwrap_or_default();
             runtime_data
                 .logged_notifications
                 .push_front(LoggedNotification::FavoriteTransmitted(
                     FavoriteTransmitted {
                         host,
                         data_info_host,
-                        timestamp: Local::now().to_string().get(11..19).unwrap().to_string(),
+                        timestamp: Local::now()
+                            .to_string()
+                            .get(11..19)
+                            .unwrap_or_default()
+                            .to_string(),
                     },
                 ));
         }

--- a/src/notifications/notify_and_log.rs
+++ b/src/notifications/notify_and_log.rs
@@ -22,17 +22,10 @@ pub fn notify_and_log(
     let mut already_emitted_sound = false;
     let mut emitted_notifications = 0;
     // packets threshold
-    if notifications.packets_notification.threshold.is_some() {
+    if let Some(threshold) = notifications.packets_notification.threshold {
         let sent_packets_entry = runtime_data.tot_out_packets - runtime_data.tot_out_packets_prev;
         let received_packets_entry = runtime_data.tot_in_packets - runtime_data.tot_in_packets_prev;
-        if received_packets_entry + sent_packets_entry
-            > u128::from(
-                notifications
-                    .packets_notification
-                    .threshold
-                    .unwrap_or_default(),
-            )
-        {
+        if received_packets_entry + sent_packets_entry > u128::from(threshold) {
             // log this notification
             emitted_notifications += 1;
             if runtime_data.logged_notifications.len() >= 30 {
@@ -57,17 +50,10 @@ pub fn notify_and_log(
         }
     }
     // bytes threshold
-    if notifications.bytes_notification.threshold.is_some() {
+    if let Some(threshold) = notifications.bytes_notification.threshold {
         let sent_bytes_entry = runtime_data.tot_out_bytes - runtime_data.tot_out_bytes_prev;
         let received_bytes_entry = runtime_data.tot_in_bytes - runtime_data.tot_in_bytes_prev;
-        if received_bytes_entry + sent_bytes_entry
-            > u128::from(
-                notifications
-                    .bytes_notification
-                    .threshold
-                    .unwrap_or_default(),
-            )
-        {
+        if received_bytes_entry + sent_bytes_entry > u128::from(threshold) {
             //log this notification
             emitted_notifications += 1;
             if runtime_data.logged_notifications.len() >= 30 {

--- a/src/notifications/types/notifications.rs
+++ b/src/notifications/types/notifications.rs
@@ -109,7 +109,7 @@ impl BytesNotification {
             value.parse::<u64>().unwrap_or(default.previous_threshold)
         } else {
             // multiple
-            let last_char = chars.last().unwrap_or_default();
+            let last_char = chars.last().unwrap_or(&' ');
             byte_multiple_inserted = ByteMultiple::from_char(*last_char);
             let without_multiple: String = chars[0..chars.len() - 1].iter().collect();
             if without_multiple.parse::<u64>().is_ok()
@@ -180,16 +180,26 @@ mod tests {
     use super::*;
 
     #[rstest]
-    #[case("123", BytesNotification {
-        previous_threshold: 123, threshold: Some(123), byte_multiple: ByteMultiple::B, ..BytesNotification::default() })]
-    #[case("500k", BytesNotification {
-        previous_threshold: 500_000, threshold: Some(500_000),byte_multiple: ByteMultiple::KB, ..BytesNotification::default() })]
-    #[case("420m", BytesNotification {
-        previous_threshold: 420_000_000, threshold: Some(420_000_000),byte_multiple: ByteMultiple::MB, ..BytesNotification::default() })]
-    #[case("744ь", BytesNotification {
-    previous_threshold: 744, threshold: Some(744),byte_multiple: ByteMultiple::B, ..BytesNotification::default() })]
-    #[case("888g", BytesNotification {
-        previous_threshold: 888_000_000_000, threshold: Some(888_000_000_000),byte_multiple: ByteMultiple::GB, ..BytesNotification::default() })]
+    #[case("123",
+        BytesNotification{
+        previous_threshold: 123, threshold: Some(123), byte_multiple: ByteMultiple::B, ..BytesNotification::default() }
+    )]
+    #[case("500k",
+        BytesNotification{
+        previous_threshold: 500_000, threshold: Some(500_000),byte_multiple: ByteMultiple::KB, ..BytesNotification::default() }
+    )]
+    #[case("420m",
+        BytesNotification{
+        previous_threshold: 420_000_000, threshold: Some(420_000_000),byte_multiple: ByteMultiple::MB, ..BytesNotification::default() }
+    )]
+    #[case("744ь",
+        BytesNotification{
+    previous_threshold: 744, threshold: Some(744),byte_multiple: ByteMultiple::B, ..BytesNotification::default() }
+    )]
+    #[case("888g",
+        BytesNotification{
+        previous_threshold: 888_000_000_000, threshold: Some(888_000_000_000),byte_multiple: ByteMultiple::GB, ..BytesNotification::default() }
+    )]
     fn test_can_instantiate_bytes_notification_from_string(
         #[case] input: &str,
         #[case] expected: BytesNotification,
@@ -251,18 +261,18 @@ mod tests {
     }
 
     #[rstest]
-    #[case("123", PacketsNotification {
+    #[case("123", PacketsNotification{
         previous_threshold: 123,
         threshold: Some(123),
         ..PacketsNotification::default() })]
-    #[case("8888", PacketsNotification {
+    #[case("8888", PacketsNotification{
         previous_threshold: 8888,
         threshold: Some(8888),
         ..PacketsNotification::default() })]
-    #[case("420 m", PacketsNotification {
+    #[case("420 m", PacketsNotification{
         threshold: Some(750),
         ..PacketsNotification::default() })]
-    #[case("foob@r", PacketsNotification {
+    #[case("foob@r", PacketsNotification{
         threshold: Some(750),
         ..PacketsNotification::default() })]
     fn test_can_instantiate_packet_notification_from_string(

--- a/src/notifications/types/notifications.rs
+++ b/src/notifications/types/notifications.rs
@@ -109,17 +109,18 @@ impl BytesNotification {
             value.parse::<u64>().unwrap_or(default.previous_threshold)
         } else {
             // multiple
-            let last_char = chars.last().unwrap();
+            let last_char = chars.last().unwrap_or_default();
             byte_multiple_inserted = ByteMultiple::from_char(*last_char);
             let without_multiple: String = chars[0..chars.len() - 1].iter().collect();
             if without_multiple.parse::<u64>().is_ok()
                 && TryInto::<u64>::try_into(
-                    without_multiple.parse::<u128>().unwrap()
+                    without_multiple.parse::<u128>().unwrap_or_default()
                         * u128::from(byte_multiple_inserted.multiplier()),
                 )
                 .is_ok()
             {
-                without_multiple.parse::<u64>().unwrap() * byte_multiple_inserted.multiplier()
+                without_multiple.parse::<u64>().unwrap_or_default()
+                    * byte_multiple_inserted.multiplier()
             } else if without_multiple.is_empty() {
                 byte_multiple_inserted = ByteMultiple::B;
                 0

--- a/src/notifications/types/sound.rs
+++ b/src/notifications/types/sound.rs
@@ -66,7 +66,8 @@ pub fn play(sound: Sound, volume: u8) {
         .name("thread_play_sound".to_string())
         .spawn(move || {
             // Get an output stream handle to the default physical sound device
-            let Ok((_, stream_handle)) = OutputStream::try_default().log_err(location!()) else {
+            let Ok((_stream, stream_handle)) = OutputStream::try_default().log_err(location!())
+            else {
                 return;
             };
             let Ok(sink) = Sink::try_new(&stream_handle).log_err(location!()) else {

--- a/src/notifications/types/sound.rs
+++ b/src/notifications/types/sound.rs
@@ -6,10 +6,11 @@ use iced::{Alignment, Font, Length};
 use rodio::{Decoder, OutputStream, Sink};
 use serde::{Deserialize, Serialize};
 
-use crate::StyleType;
 use crate::gui::styles::style_constants::FONT_SIZE_FOOTER;
 use crate::notifications::types::sound::Sound::{Gulp, Pop, Swhoosh};
+use crate::utils::error_logger::{ErrorLogger, Location};
 use crate::utils::types::icon::Icon;
+use crate::{StyleType, location};
 
 /// Enum representing the possible notification sounds.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -61,16 +62,22 @@ pub fn play(sound: Sound, volume: u8) {
         return;
     }
     let mp3_sound = sound.mp3_sound();
-    thread::Builder::new()
+    let _ = thread::Builder::new()
         .name("thread_play_sound".to_string())
         .spawn(move || {
-            // Get a output stream handle to the default physical sound device
-            let (_stream, stream_handle) = OutputStream::try_default().unwrap();
-            let sink = Sink::try_new(&stream_handle).unwrap();
+            // Get an output stream handle to the default physical sound device
+            let Ok((_, stream_handle)) = OutputStream::try_default().log_err(location!()) else {
+                return;
+            };
+            let Ok(sink) = Sink::try_new(&stream_handle).log_err(location!()) else {
+                return;
+            };
             //load data
             let data = std::io::Cursor::new(mp3_sound);
             // Decode that sound file into a source
-            let source = Decoder::new(data).unwrap();
+            let Ok(source) = Decoder::new(data).log_err(location!()) else {
+                return;
+            };
             // Play the sound directly on the device
             sink.set_volume(f32::from(volume) / 200.0); // set the desired volume
             sink.append(source);
@@ -78,5 +85,5 @@ pub fn play(sound: Sound, volume: u8) {
             // has finished playing all its queued sounds.
             sink.sleep_until_end();
         })
-        .unwrap();
+        .log_err(location!());
 }

--- a/src/report/get_report_entries.rs
+++ b/src/report/get_report_entries.rs
@@ -28,7 +28,7 @@ pub fn get_searched_entries(
                 info_traffic_lock
                     .hosts
                     .get(&e.1)
-                    .unwrap_or_default()
+                    .unwrap_or(&DataInfoHost::default())
                     .is_favorite
             } else {
                 false

--- a/src/report/get_report_entries.rs
+++ b/src/report/get_report_entries.rs
@@ -68,7 +68,7 @@ pub fn get_searched_entries(
     (
         all_results
             .get((sniffer.page_number - 1) * 20..upper_bound)
-            .unwrap_or(&Vec::new())
+            .unwrap_or_default()
             .iter()
             .map(|&(key, val)| (key.to_owned(), val.to_owned()))
             .collect(),

--- a/src/report/get_report_entries.rs
+++ b/src/report/get_report_entries.rs
@@ -25,7 +25,11 @@ pub fn get_searched_entries(
             let address_to_lookup = &get_address_to_lookup(key, value.traffic_direction);
             let r_dns_host = info_traffic_lock.addresses_resolved.get(address_to_lookup);
             let is_favorite = if let Some(e) = r_dns_host {
-                info_traffic_lock.hosts.get(&e.1).unwrap().is_favorite
+                info_traffic_lock
+                    .hosts
+                    .get(&e.1)
+                    .unwrap_or_default()
+                    .is_favorite
             } else {
                 false
             };

--- a/src/report/types/search_parameters.rs
+++ b/src/report/types/search_parameters.rs
@@ -182,9 +182,21 @@ impl FilterInputType {
             }
             FilterInputType::Proto => key.protocol.to_string(),
             FilterInputType::Service => value.service.to_string(),
-            FilterInputType::Country => r_dns_host.unwrap().1.country.to_string(),
-            FilterInputType::Domain => r_dns_host.unwrap().0.to_string(),
-            FilterInputType::AsName => r_dns_host.unwrap().1.asn.name.to_string(),
+            FilterInputType::Country => r_dns_host
+                .unwrap_or(&(String::new(), Host::default()))
+                .1
+                .country
+                .to_string(),
+            FilterInputType::Domain => r_dns_host
+                .unwrap_or(&(String::new(), Host::default()))
+                .0
+                .to_string(),
+            FilterInputType::AsName => r_dns_host
+                .unwrap_or(&(String::new(), Host::default()))
+                .1
+                .asn
+                .name
+                .to_string(),
         }
     }
 

--- a/src/secondary_threads/parse_packets.rs
+++ b/src/secondary_threads/parse_packets.rs
@@ -72,7 +72,7 @@ pub fn parse_packets(
                         continue;
                     }
 
-                    let key = key_option.unwrap();
+                    let key = key_option.unwrap_or_default();
                     let mut new_info = InfoAddressPortPair::default();
 
                     let passed_filters = filters.matches(&packet_filters_fields);
@@ -150,7 +150,7 @@ pub fn parse_packets(
                                             &host_data2,
                                         );
                                     })
-                                    .unwrap();
+                                    .unwrap_or_default();
                             }
                             (true, false) => {
                                 // waiting for a previously requested rDNS resolution
@@ -171,7 +171,7 @@ pub fn parse_packets(
                                 let host = info_traffic
                                     .addresses_resolved
                                     .get(&address_to_lookup)
-                                    .unwrap()
+                                    .unwrap_or_default()
                                     .1
                                     .clone();
                                 info_traffic.hosts.entry(host).and_modify(|data_info_host| {

--- a/src/secondary_threads/parse_packets.rs
+++ b/src/secondary_threads/parse_packets.rs
@@ -93,9 +93,7 @@ pub fn parse_packets(
                         );
                     }
 
-                    let mut info_traffic = info_traffic_mutex
-                        .lock()
-                        .expect("Error acquiring mutex\n\r");
+                    let mut info_traffic = info_traffic_mutex.lock().unwrap();
                     //increment number of sniffed packets and bytes
                     info_traffic.all_packets += 1;
                     info_traffic.all_bytes += exchanged_bytes;

--- a/src/utils/error_logger.rs
+++ b/src/utils/error_logger.rs
@@ -13,11 +13,8 @@ impl<T, E: Display> ErrorLogger<T, E> for Result<T, E> {
             let file = location.file;
             let line = location.line;
             eprintln!("Sniffnet error at [{file}:{line}]: {e}");
-        }
-
-        // In debug mode, panic on error
-        if cfg!(debug_assertions) {
-            panic!();
+            // in debug mode, panic on error
+            assert!(!cfg!(debug_assertions));
         }
 
         self
@@ -46,11 +43,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_error_logger() {
+    #[should_panic]
+    fn test_error_logger_panics_on_err_in_debug_mode() {
         let err_result: Result<usize, &str> = Err("test_error");
-        let err_handled = err_result.log_err(location!());
-        assert_eq!(err_handled, err_result);
+        let _err_handled = err_result.log_err(location!());
+        // assert_eq!(_err_handled, err_result); // true in release mode
+    }
 
+    #[test]
+    fn test_error_logger_ok() {
         let ok_result: Result<usize, &str> = Ok(2);
         let ok_handled = ok_result.log_err(location!());
         assert_eq!(ok_handled, ok_result);

--- a/src/utils/error_logger.rs
+++ b/src/utils/error_logger.rs
@@ -9,9 +9,18 @@ pub trait ErrorLogger<T, E> {
 
 impl<T, E: Display> ErrorLogger<T, E> for Result<T, E> {
     fn log_err(self, location: Location) -> Result<T, E> {
-        self.inspect_err(|e| {
-            eprintln!("[{}:{}] {e}", location.file, location.line);
-        })
+        if let Err(e) = &self {
+            let file = location.file;
+            let line = location.line;
+            eprintln!("Sniffnet error at [{file}:{line}]: {e}");
+        }
+
+        // In debug mode, panic on error
+        if cfg!(debug_assertions) {
+            panic!();
+        }
+
+        self
     }
 }
 

--- a/src/utils/error_logger.rs
+++ b/src/utils/error_logger.rs
@@ -1,0 +1,49 @@
+use std::fmt::Display;
+
+/// Trait for logging errors in a unified way
+pub trait ErrorLogger<T, E> {
+    /// Log the error and its location
+    #[allow(clippy::missing_errors_doc)]
+    fn log_err(self, loc: Location) -> Result<T, E>;
+}
+
+impl<T, E: Display> ErrorLogger<T, E> for Result<T, E> {
+    fn log_err(self, location: Location) -> Result<T, E> {
+        self.inspect_err(|e| {
+            eprintln!("[{}:{}] {e}", location.file, location.line);
+        })
+    }
+}
+
+/// Struct to store the location in the code (file and line)
+pub struct Location {
+    pub file: &'static str,
+    pub line: u32,
+}
+
+#[macro_export]
+/// Macro to get the current location in the code (file and line)
+macro_rules! location {
+    () => {
+        Location {
+            file: file!(),
+            line: line!(),
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_logger() {
+        let err_result: Result<usize, &str> = Err("test_error");
+        let err_handled = err_result.log_err(location!());
+        assert_eq!(err_handled, err_result);
+
+        let ok_result: Result<usize, &str> = Ok(2);
+        let ok_handled = ok_result.log_err(location!());
+        assert_eq!(ok_handled, ok_result);
+    }
+}

--- a/src/utils/formatted_strings.rs
+++ b/src/utils/formatted_strings.rs
@@ -7,7 +7,9 @@ use crate::translations::translations::{
     address_translation, ip_version_translation, protocol_translation,
 };
 use crate::translations::translations_3::{invalid_filters_translation, port_translation};
+use chrono::{DateTime, Local};
 use std::fmt::Write;
+
 /// Application version number (to be displayed in gui footer)
 pub const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -172,6 +174,10 @@ pub fn get_formatted_num_seconds(num_seconds: u128) -> String {
     }
 }
 
+pub fn get_formatted_timestamp(t: DateTime<Local>) -> String {
+    t.format("%H:%M:%S").to_string()
+}
+
 #[allow(dead_code)]
 #[cfg(windows)]
 pub fn get_logs_file_path() -> Option<String> {
@@ -230,6 +236,14 @@ mod tests {
             get_formatted_num_seconds(u128::MAX),
             "94522879700260684295381835397713392:04:15"
         );
+    }
+
+    #[test]
+    fn test_formatted_timestamp() {
+        let now = Local::now();
+        let formatted = get_formatted_timestamp(now);
+        let expected = now.to_string().get(11..19).unwrap().to_string();
+        assert_eq!(formatted, expected);
     }
 
     #[cfg(windows)]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,2 +1,3 @@
+pub mod error_logger;
 pub mod formatted_strings;
 pub mod types;


### PR DESCRIPTION
Properly handle errors when possible, instead of calling `unwrap`/`expect`.

A new trait `ErrorLogger` has been introduced to log errors to `stderr` in production, allowing to get information about the error kind and its location in the code without panicking (in development builds it will also panic, to easily allow spotting errors when coding).