### PR TITLE
Add new themes optimised for Accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All Sniffnet releases with the relative changes are documented in this file.
   - Portuguese ([#690](https://github.com/GyulyVGC/sniffnet/pull/690))
   - Ukrainian ([#692](https://github.com/GyulyVGC/sniffnet/pull/692))
 - Show more information when domain name is short ([#720](https://github.com/GyulyVGC/sniffnet/pull/720) — fixes [#696](https://github.com/GyulyVGC/sniffnet/issues/696))
-- Added new themes _A11y (Night)_ and _A11y (Day)_ based on palettes optimized for OLED displays and users with visual impairments ([#708](https://github.com/GyulyVGC/sniffnet/pull/708))
+- Added new themes _A11y (Night)_ and _A11y (Day)_ based on palettes optimized for Accessibility ([#785](https://github.com/GyulyVGC/sniffnet/pull/785))
 - Avoid directory traversal when selecting file name for PCAP exports ([#776](https://github.com/GyulyVGC/sniffnet/pull/776) — fixes [#767](https://github.com/GyulyVGC/sniffnet/issues/767))
 - Add icon to window title bar ([#719](https://github.com/GyulyVGC/sniffnet/pull/719) — fixes [#715](https://github.com/GyulyVGC/sniffnet/issues/715))
 - Update footer buttons and links ([#755](https://github.com/GyulyVGC/sniffnet/pull/755) — fixes [#553](https://github.com/GyulyVGC/sniffnet/issues/553))

--- a/resources/themes/sniffnet_rebrand.toml
+++ b/resources/themes/sniffnet_rebrand.toml
@@ -1,6 +1,0 @@
-primary = "#0f1e3c"
-secondary = "#faaa0f"
-outgoing = "#0faafa"
-text_body = "#dddddd"
-text_headers = "#0f1e3c"
-starred = "#faaa0faa"

--- a/src/configs/types/config_device.rs
+++ b/src/configs/types/config_device.rs
@@ -3,13 +3,14 @@
 
 use std::sync::{Arc, Mutex};
 
-use pcap::{Device, DeviceFlags};
-use serde::{Deserialize, Serialize};
-
-#[cfg(not(test))]
-use crate::SNIFFNET_LOWERCASE;
 use crate::networking::types::my_device::MyDevice;
 use crate::networking::types::my_link_type::MyLinkType;
+#[cfg(not(test))]
+use crate::utils::error_logger::{ErrorLogger, Location};
+#[cfg(not(test))]
+use crate::{SNIFFNET_LOWERCASE, location};
+use pcap::{Device, DeviceFlags};
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
 pub struct ConfigDevice {
@@ -40,15 +41,15 @@ impl ConfigDevice {
         if let Ok(device) = confy::load::<ConfigDevice>(SNIFFNET_LOWERCASE, Self::FILE_NAME) {
             device
         } else {
-            confy::store(SNIFFNET_LOWERCASE, Self::FILE_NAME, ConfigDevice::default())
-                .unwrap_or(());
+            let _ = confy::store(SNIFFNET_LOWERCASE, Self::FILE_NAME, ConfigDevice::default())
+                .log_err(location!());
             ConfigDevice::default()
         }
     }
 
     #[cfg(not(test))]
     pub fn store(self) {
-        confy::store(SNIFFNET_LOWERCASE, Self::FILE_NAME, self).unwrap_or(());
+        let _ = confy::store(SNIFFNET_LOWERCASE, Self::FILE_NAME, self).log_err(location!());
     }
 
     pub fn to_my_device(&self) -> MyDevice {

--- a/src/configs/types/config_settings.rs
+++ b/src/configs/types/config_settings.rs
@@ -3,11 +3,13 @@
 
 use serde::{Deserialize, Serialize};
 
-#[cfg(not(test))]
-use crate::SNIFFNET_LOWERCASE;
 use crate::gui::styles::types::gradient_type::GradientType;
 use crate::notifications::types::notifications::Notifications;
+#[cfg(not(test))]
+use crate::utils::error_logger::{ErrorLogger, Location};
 use crate::{Language, StyleType};
+#[cfg(not(test))]
+use crate::{SNIFFNET_LOWERCASE, location};
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
 pub struct ConfigSettings {
@@ -30,19 +32,19 @@ impl ConfigSettings {
         if let Ok(settings) = confy::load::<ConfigSettings>(SNIFFNET_LOWERCASE, Self::FILE_NAME) {
             settings
         } else {
-            confy::store(
+            let _ = confy::store(
                 SNIFFNET_LOWERCASE,
                 Self::FILE_NAME,
                 ConfigSettings::default(),
             )
-            .unwrap_or(());
+            .log_err(location!());
             ConfigSettings::default()
         }
     }
 
     #[cfg(not(test))]
     pub fn store(self) {
-        confy::store(SNIFFNET_LOWERCASE, Self::FILE_NAME, self).unwrap_or(());
+        let _ = confy::store(SNIFFNET_LOWERCASE, Self::FILE_NAME, self).log_err(location!());
     }
 }
 

--- a/src/configs/types/config_window.rs
+++ b/src/configs/types/config_window.rs
@@ -1,9 +1,10 @@
+#[cfg(not(test))]
+use crate::utils::error_logger::{ErrorLogger, Location};
+#[cfg(not(test))]
+use crate::{SNIFFNET_LOWERCASE, location};
 use iced::window::Position;
 use iced::{Point, Size};
 use serde::{Deserialize, Serialize};
-
-#[cfg(not(test))]
-use crate::SNIFFNET_LOWERCASE;
 
 #[derive(Serialize, Deserialize, Copy, Clone, PartialEq, Debug)]
 pub struct PositionTuple(pub f32, pub f32);
@@ -35,15 +36,15 @@ impl ConfigWindow {
         if let Ok(window) = confy::load::<ConfigWindow>(SNIFFNET_LOWERCASE, Self::FILE_NAME) {
             window
         } else {
-            confy::store(SNIFFNET_LOWERCASE, Self::FILE_NAME, ConfigWindow::default())
-                .unwrap_or(());
+            let _ = confy::store(SNIFFNET_LOWERCASE, Self::FILE_NAME, ConfigWindow::default())
+                .log_err(location!());
             ConfigWindow::default()
         }
     }
 
     #[cfg(not(test))]
     pub fn store(self) {
-        confy::store(SNIFFNET_LOWERCASE, Self::FILE_NAME, self).unwrap_or(());
+        let _ = confy::store(SNIFFNET_LOWERCASE, Self::FILE_NAME, self).log_err(location!());
     }
 
     pub fn thumbnail_size(factor: f64) -> SizeTuple {

--- a/src/gui/sniffer.rs
+++ b/src/gui/sniffer.rs
@@ -1953,7 +1953,7 @@ mod tests {
                     bytes_notification: Default::default(),
                     favorite_notification: Default::default()
                 },
-                style: StyleType::Night
+                style: StyleType::Custom(ExtraStyles::A11yDark)
             }
         );
 

--- a/src/gui/styles/container.rs
+++ b/src/gui/styles/container.rs
@@ -58,7 +58,7 @@ impl ContainerType {
                     Background::Color(Color::TRANSPARENT)
                 }
                 ContainerType::ModalBackground => Background::Color(Color {
-                    a: 0.8,
+                    a: 0.9,
                     ..Color::BLACK
                 }),
             }),
@@ -75,7 +75,7 @@ impl ContainerType {
                 },
                 width: match self {
                     ContainerType::Standard
-                    | ContainerType::Modal
+                    | ContainerType::ModalBackground
                     | ContainerType::Gradient(_)
                     | ContainerType::HighlightedOnHeader
                     | ContainerType::Highlighted => 0.0,
@@ -86,6 +86,7 @@ impl ContainerType {
                 color: match self {
                     ContainerType::Palette => Color::BLACK,
                     ContainerType::BadgeInfo => colors.secondary,
+                    ContainerType::Modal => ext.buttons_color,
                     _ => Color {
                         a: ext.alpha_round_borders,
                         ..ext.buttons_color

--- a/src/gui/styles/custom_themes/a11y.rs
+++ b/src/gui/styles/custom_themes/a11y.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::unreadable_literal)]
 
-//! Themes optimized for OLED displays and visually impaired users
-//! <https://github.com/GyulyVGC/sniffnet/pull/708>
+//! Themes optimized for Accessibility
+//! <https://github.com/GyulyVGC/sniffnet/pull/785>
 
 use iced::color;
 
@@ -9,12 +9,12 @@ use crate::gui::styles::types::palette::Palette;
 use crate::gui::styles::types::palette_extension::PaletteExtension;
 
 pub static A11Y_DARK_PALETTE: std::sync::LazyLock<Palette> = std::sync::LazyLock::new(|| Palette {
-    primary: color!(0x000000),
-    secondary: color!(0x934900),
-    outgoing: color!(0xF0F0F0),
-    starred: color!(0xFFFF00),
-    text_headers: color!(0xE0E0E0),
-    text_body: color!(0xfcfaf0),
+    primary: color!(0x0f1e3c),
+    secondary: color!(0xFCB608),
+    outgoing: color!(0x0BB1FC),
+    starred: color!(0xFBFF0F),
+    text_headers: color!(0x081020),
+    text_body: color!(0xdddddd),
 });
 
 pub static A11Y_DARK_PALETTE_EXTENSION: std::sync::LazyLock<PaletteExtension> =
@@ -23,11 +23,11 @@ pub static A11Y_DARK_PALETTE_EXTENSION: std::sync::LazyLock<PaletteExtension> =
 pub static A11Y_LIGHT_PALETTE: std::sync::LazyLock<Palette> =
     std::sync::LazyLock::new(|| Palette {
         primary: color!(0xFFFFFF),
-        secondary: color!(0x6CB6FF),
-        outgoing: color!(0x0F0F0F),
-        starred: color!(0x0000FF),
-        text_headers: color!(0x1F1F1F),
-        text_body: color!(0x03050F),
+        secondary: color!(0xB30000),
+        outgoing: color!(0x004ECC),
+        starred: color!(0xC25E00),
+        text_headers: color!(0xFFFFFF),
+        text_body: color!(0x081020),
     });
 
 pub static A11Y_LIGHT_PALETTE_EXTENSION: std::sync::LazyLock<PaletteExtension> =

--- a/src/gui/styles/types/style_type.rs
+++ b/src/gui/styles/types/style_type.rs
@@ -24,7 +24,7 @@ pub enum StyleType {
 
 impl Default for StyleType {
     fn default() -> Self {
-        Self::Night
+        Self::Custom(ExtraStyles::A11yDark)
     }
 }
 


### PR DESCRIPTION
Add new themes optimised for Accessibility, as suggested as part of NLnet's Accessibility Audit.

The new dark theme will also be used as default palette for the application from now on, since it also reflects the colours of Sniffnet icon and official website.

Fixes #786.

See #760 for more info about other Accessibility problems.

<div align=center>
<img width=47% src="https://github.com/user-attachments/assets/7e449d40-9b75-4115-9681-90d37deae10e">&nbsp;
<img width=47% src="https://github.com/user-attachments/assets/15c40962-8318-4047-8094-9fb21727135e">
</div>
