### PR TITLE
Improve color contrast on hover

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -72,16 +72,16 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Check crate
+        if: matrix.os == 'macos' || matrix.os == 'windows' || matrix.os == 'ubuntu' && matrix.arch == 'amd64'
+        run: cargo publish --dry-run --target ${{ matrix.target }}
+
       - name: Clippy (release mode)
         run: cargo clippy --release -- -D warnings
 
       - name: Test (release mode)
-        run: cargo test --release --verbose -- --nocapture
-
-      - name: Check crate
-        if: matrix.os == 'macos' || matrix.os == 'windows' || matrix.os == 'ubuntu' && matrix.arch == 'amd64'
         run: |
-          cargo publish --dry-run --target ${{ matrix.target }} &&
+          cargo test --release --verbose -- --nocapture &&
           cargo clean
 
       - name: Install Cross

--- a/src/gui/styles/button.rs
+++ b/src/gui/styles/button.rs
@@ -147,6 +147,7 @@ impl ButtonType {
                 ButtonType::Gradient(gradient_type) => Background::Gradient(
                     get_gradient_hovered_buttons(&colors, *gradient_type, ext.is_nightly),
                 ),
+                ButtonType::BorderedRoundSelected => Background::Color(ext.buttons_color),
                 _ => Background::Color(mix_colors(colors.primary, ext.buttons_color)),
             }),
             border: Border {


### PR DESCRIPTION
Improve color contrast on hover of some UI elements as suggested by the Accessibility Audit.

It was pretty straightforward to identify the elements signaled as problematic since they were all buttons of the same kind (`BorderedRoundSelected`).

Fixes https://github.com/GyulyVGC/sniffnet/issues/788.

See https://github.com/GyulyVGC/sniffnet/issues/760 for more info about other Accessibility problems.