### PR TITLE
Import PCAP files

### DIFF
--- a/src/gui/pages/connection_details_page.rs
+++ b/src/gui/pages/connection_details_page.rs
@@ -311,10 +311,11 @@ fn get_local_tooltip<'a>(
     } else {
         &key.address1
     };
-    let my_interface_addresses = &*sniffer.device.addresses.lock().unwrap();
+    let my_interface_addresses_lock = sniffer.capture_source.get_addresses();
+    let my_interface_addresses = my_interface_addresses_lock.lock().unwrap();
     get_computer_tooltip(
-        is_my_address(local_address, my_interface_addresses),
-        is_local_connection(local_address, my_interface_addresses),
+        is_my_address(local_address, &*my_interface_addresses),
+        is_local_connection(local_address, &*my_interface_addresses),
         is_bogon(local_address),
         get_traffic_type(
             if address_to_lookup.eq(&key.address1) {
@@ -322,7 +323,7 @@ fn get_local_tooltip<'a>(
             } else {
                 &key.address1
             },
-            my_interface_addresses,
+            &*my_interface_addresses,
             TrafficDirection::Outgoing,
         ),
         language,

--- a/src/gui/pages/initial_page.rs
+++ b/src/gui/pages/initial_page.rs
@@ -54,6 +54,13 @@ pub fn initial_page(sniffer: &Sniffer) -> Container<Message, StyleType> {
     let font = style.get_extension().font;
 
     let col_adapter = get_col_adapter(sniffer, font);
+    let col_import_pcap = get_col_import_pcap(
+        language,
+        font,
+        &sniffer.capture_source.get_name(),
+        &sniffer.capture_source,
+    );
+    let col_capture_source = Column::new().push(col_adapter).push(col_import_pcap);
 
     let ip_active = &sniffer.filters.ip_versions;
     let col_ip_buttons = col_ip_buttons(ip_active, font, language);
@@ -110,7 +117,7 @@ pub fn initial_page(sniffer: &Sniffer) -> Container<Message, StyleType> {
 
     let body = Column::new().push(Space::with_height(5)).push(
         Row::new()
-            .push(col_adapter)
+            .push(col_capture_source)
             .push(Space::with_width(30))
             .push(filters_pane),
     );
@@ -365,6 +372,45 @@ fn get_col_adapter(sniffer: &Sniffer, font: Font) -> Column<Message, StyleType> 
             ),
             Direction::Vertical(ScrollbarType::properties()),
         ))
+}
+
+fn get_col_import_pcap<'a>(
+    language: Language,
+    font: Font,
+    path: &str,
+    cs: &CaptureSource,
+) -> Button<'a, Message, StyleType> {
+    let is_import_pcap_set = matches!(cs, CaptureSource::File(_));
+
+    let button_row = Row::new()
+        .align_y(Alignment::Center)
+        .push(Text::new(get_path_termination_string(path, 17)).font(font))
+        .push(button_open_file(
+            path.to_owned(),
+            FileInfo::PcapImport,
+            language,
+            font,
+            true,
+            Message::SetPcapImport,
+        ));
+
+    let content = Column::new()
+        .width(Length::Fill)
+        .align_x(Alignment::Center)
+        .spacing(5)
+        .push(Text::new("custom_style_translation(language)").font(font))
+        .push(button_row);
+
+    Button::new(content)
+        .height(75)
+        .width(380)
+        .padding(Padding::ZERO.top(10).bottom(5))
+        .class(if is_import_pcap_set {
+            ButtonType::BorderedRoundSelected
+        } else {
+            ButtonType::BorderedRound
+        })
+        .on_press(Message::SetPcapImport(path.to_string()))
 }
 
 fn get_export_pcap_group(

--- a/src/gui/pages/initial_page.rs
+++ b/src/gui/pages/initial_page.rs
@@ -26,6 +26,7 @@ use crate::gui::styles::text_input::TextInputType;
 use crate::gui::styles::types::gradient_type::GradientType;
 use crate::gui::types::export_pcap::ExportPcap;
 use crate::gui::types::message::Message;
+use crate::networking::types::capture_context::CaptureSource;
 use crate::networking::types::filters::Filters;
 use crate::networking::types::ip_collection::AddressCollection;
 use crate::networking::types::port_collection::PortCollection;
@@ -347,11 +348,17 @@ fn get_col_adapter(sniffer: &Sniffer, font: Font) -> Column<Message, StyleType> 
                         Button::new(Text::new(description).font(font))
                             .padding([20, 30])
                             .width(Length::Fill)
-                            .class(if name == sniffer.device.name {
-                                ButtonType::BorderedRoundSelected
-                            } else {
-                                ButtonType::BorderedRound
-                            })
+                            .class(
+                                if let CaptureSource::Device(device) = &sniffer.capture_source {
+                                    if name == device.name {
+                                        ButtonType::BorderedRoundSelected
+                                    } else {
+                                        ButtonType::BorderedRound
+                                    }
+                                } else {
+                                    ButtonType::BorderedRound
+                                },
+                            )
                             .on_press(Message::AdapterSelection(name)),
                     )
                 },

--- a/src/gui/pages/overview_page.rs
+++ b/src/gui/pages/overview_page.rs
@@ -16,10 +16,10 @@ use crate::gui::styles::style_constants::FONT_SIZE_TITLE;
 use crate::gui::styles::text::TextType;
 use crate::gui::styles::types::palette_extension::PaletteExtension;
 use crate::gui::types::message::Message;
+use crate::networking::types::capture_context::CaptureSource;
 use crate::networking::types::data_info::DataInfo;
 use crate::networking::types::filters::Filters;
 use crate::networking::types::host::Host;
-use crate::networking::types::my_device::MyDevice;
 use crate::report::get_report_entries::{get_host_entries, get_service_entries};
 use crate::report::types::search_parameters::SearchParameters;
 use crate::report::types::sort_type::SortType;
@@ -73,7 +73,7 @@ pub fn overview_page(sniffer: &Sniffer) -> Container<Message, StyleType> {
         match (observed, filtered) {
             (0, 0) => {
                 //no packets observed at all
-                body = body_no_packets(&sniffer.device, font, language, &sniffer.waiting);
+                body = body_no_packets(&sniffer.capture_source, font, language, &sniffer.waiting);
             }
             (observed, 0) => {
                 //no packets have been filtered but some have been observed
@@ -133,36 +133,32 @@ pub fn overview_page(sniffer: &Sniffer) -> Container<Message, StyleType> {
 }
 
 fn body_no_packets<'a>(
-    device: &MyDevice,
+    cs: &CaptureSource,
     font: Font,
     language: Language,
     waiting: &str,
 ) -> Column<'a, Message, StyleType> {
-    let link_type = device.link_type;
-    let mut adapter_info = device.name.clone();
-    let _ = write!(
-        adapter_info,
-        "\n{}",
-        link_type.full_print_on_one_line(language)
-    );
+    let link_type = cs.get_link_type();
+    let mut cs_info = cs.get_name();
+    let _ = write!(cs_info, "\n{}", link_type.full_print_on_one_line(language));
     let (icon_text, nothing_to_see_text) = if !link_type.is_supported() {
         (
             Icon::Warning.to_text().size(60),
-            unsupported_link_type_translation(language, &adapter_info)
+            unsupported_link_type_translation(language, &cs_info)
                 .align_x(Alignment::Center)
                 .font(font),
         )
-    } else if device.addresses.lock().unwrap().is_empty() {
+    } else if cs.get_addresses().lock().unwrap().is_empty() {
         (
             Icon::Warning.to_text().size(60),
-            no_addresses_translation(language, &adapter_info)
+            no_addresses_translation(language, &cs_info)
                 .align_x(Alignment::Center)
                 .font(font),
         )
     } else {
         (
             Icon::get_hourglass(waiting.len()).size(60),
-            waiting_translation(language, &adapter_info)
+            waiting_translation(language, &cs_info)
                 .align_x(Alignment::Center)
                 .font(font),
         )
@@ -443,7 +439,7 @@ fn lazy_col_info<'a>(sniffer: &Sniffer) -> Container<'a, Message, StyleType> {
     } = sniffer.configs.lock().unwrap().settings;
     let PaletteExtension { font, .. } = style.get_extension();
 
-    let col_device = col_device(language, font, &sniffer.device);
+    let col_device = col_device(language, font, &sniffer.capture_source);
 
     let col_data_representation =
         col_data_representation(language, font, sniffer.traffic_chart.chart_type);
@@ -502,20 +498,20 @@ fn container_chart(sniffer: &Sniffer, font: Font) -> Container<Message, StyleTyp
 fn col_device<'a>(
     language: Language,
     font: Font,
-    device: &MyDevice,
+    cs: &CaptureSource,
 ) -> Column<'a, Message, StyleType> {
-    let link_type = device.link_type;
+    let link_type = cs.get_link_type();
     #[cfg(not(target_os = "windows"))]
-    let adapter_info = &device.name;
+    let cs_info = &cs.get_name();
     #[cfg(target_os = "windows")]
-    let adapter_info = device.desc.as_ref().unwrap_or(&device.name);
+    let cs_info = cs.desc.as_ref().unwrap_or(&cs.name);
 
     Column::new()
         .height(Length::Fill)
         .spacing(10)
         .push(TextType::highlighted_subtitle_with_desc(
             network_adapter_translation(language),
-            adapter_info,
+            cs_info,
             font,
         ))
         .push(link_type.link_type_col(language, font))

--- a/src/gui/sniffer.rs
+++ b/src/gui/sniffer.rs
@@ -43,7 +43,7 @@ use crate::gui::types::timing_events::TimingEvents;
 use crate::mmdb::asn::ASN_MMDB;
 use crate::mmdb::country::COUNTRY_MMDB;
 use crate::mmdb::types::mmdb_reader::{MmdbReader, MmdbReaders};
-use crate::networking::types::capture_context::{CaptureContext, CaptureSource};
+use crate::networking::types::capture_context::{CaptureContext, CaptureSource, MyPcapImport};
 use crate::networking::types::filters::Filters;
 use crate::networking::types::host::Host;
 use crate::networking::types::host_data_states::HostDataStates;
@@ -536,6 +536,9 @@ impl Sniffer {
                 }
             }
             Message::WindowId(id) => self.id = id,
+            Message::SetPcapImport(path) => {
+                self.capture_source = CaptureSource::File(MyPcapImport::new(path));
+            }
             Message::TickInit => {}
         }
         Task::none()

--- a/src/gui/types/message.rs
+++ b/src/gui/types/message.rs
@@ -126,4 +126,6 @@ pub enum Message {
     ScaleFactorShortcut(bool),
     /// Set the window ID
     WindowId(Option<window::Id>),
+    /// Set the pcap import path
+    SetPcapImport(String),
 }

--- a/src/networking/types/capture_context.rs
+++ b/src/networking/types/capture_context.rs
@@ -107,7 +107,7 @@ impl CaptureType {
 
     pub fn stats(&mut self) -> Result<Stat, Error> {
         match self {
-            Self::Online(o) => o.stats(),
+            Self::Online(on) => on.stats(),
             Self::Offline(off) => off.stats(),
         }
     }
@@ -170,7 +170,7 @@ impl CaptureSource {
     pub fn get_name(&self) -> String {
         match self {
             Self::Device(device) => device.name.clone(),
-            Self::File(file) => get_path_termination_string(&file.path, 15),
+            Self::File(file) => get_path_termination_string(&file.path, 17),
         }
     }
 

--- a/src/networking/types/capture_context.rs
+++ b/src/networking/types/capture_context.rs
@@ -1,38 +1,30 @@
-use pcap::{Active, Capture, Savefile};
+use pcap::{Active, Address, Capture, Error, Packet, Savefile, Stat};
+use std::sync::{Arc, Mutex};
 
 use crate::networking::types::my_device::MyDevice;
 use crate::networking::types::my_link_type::MyLinkType;
+use crate::utils::formatted_strings::get_path_termination_string;
 
 pub enum CaptureContext {
     Online(Online),
     OnlineWithSavefile(OnlineWithSavefile),
+    Offline(Offline),
     Error(String),
 }
 
 impl CaptureContext {
-    pub fn new(device: &MyDevice, pcap_path: Option<&String>) -> Self {
-        let inactive = match Capture::from_device(device.to_pcap_device()) {
+    pub fn new(source: &CaptureSource, pcap_out_path: Option<&String>) -> Self {
+        let cap_type = match CaptureType::from_source(source, pcap_out_path) {
             Ok(c) => c,
             Err(e) => return Self::Error(e.to_string()),
         };
-
-        let cap_res = inactive
-            .promisc(true)
-            .snaplen(if pcap_path.is_some() {
-                i32::from(u16::MAX)
-            } else {
-                256 //limit stored packets slice dimension (to keep more in the buffer)
-            })
-            .immediate_mode(true) //parse packets ASAP!
-            .open();
-
-        let cap = match cap_res {
-            Ok(c) => c,
-            Err(e) => return Self::Error(e.to_string()),
+        let cap = match cap_type {
+            CaptureType::Online(cap) => cap,
+            CaptureType::Offline(cap) => return Self::new_offline(cap),
         };
 
-        if let Some(path) = pcap_path {
-            let savefile_res = cap.savefile(path);
+        if let Some(out_path) = pcap_out_path {
+            let savefile_res = cap.savefile(out_path);
             match savefile_res {
                 Ok(s) => Self::new_online_with_savefile(cap, s),
                 Err(e) => Self::Error(e.to_string()),
@@ -53,6 +45,10 @@ impl CaptureContext {
         })
     }
 
+    fn new_offline(cap: Capture<pcap::Offline>) -> Self {
+        Self::Offline(Offline { cap })
+    }
+
     pub fn error(&self) -> Option<&str> {
         match self {
             Self::Error(e) => Some(e),
@@ -60,20 +56,24 @@ impl CaptureContext {
         }
     }
 
-    pub fn consume(self) -> (Capture<Active>, Option<Savefile>) {
+    pub fn consume(self) -> (CaptureType, Option<Savefile>) {
         match self {
-            Self::Online(o) => (o.cap, None),
-            Self::OnlineWithSavefile(ows) => (ows.online.cap, Some(ows.savefile)),
+            Self::Online(on) => (CaptureType::Online(on.cap), None),
+            Self::OnlineWithSavefile(onws) => {
+                (CaptureType::Online(onws.online.cap), Some(onws.savefile))
+            }
+            Self::Offline(off) => (CaptureType::Offline(off.cap), None),
             Self::Error(_) => panic!(),
         }
     }
 
     pub fn my_link_type(&self) -> MyLinkType {
         match self {
-            Self::Online(o) => MyLinkType::from_pcap_link_type(o.cap.get_datalink()),
-            Self::OnlineWithSavefile(ows) => {
-                MyLinkType::from_pcap_link_type(ows.online.cap.get_datalink())
+            Self::Online(on) => MyLinkType::from_pcap_link_type(on.cap.get_datalink()),
+            Self::OnlineWithSavefile(onws) => {
+                MyLinkType::from_pcap_link_type(onws.online.cap.get_datalink())
             }
+            Self::Offline(off) => MyLinkType::from_pcap_link_type(off.cap.get_datalink()),
             Self::Error(_) => MyLinkType::default(),
         }
     }
@@ -86,4 +86,114 @@ pub struct Online {
 pub struct OnlineWithSavefile {
     online: Online,
     savefile: Savefile,
+}
+
+pub struct Offline {
+    cap: Capture<pcap::Offline>,
+}
+
+pub enum CaptureType {
+    Online(Capture<Active>),
+    Offline(Capture<pcap::Offline>),
+}
+
+impl CaptureType {
+    pub fn next_packet(&mut self) -> Result<Packet, Error> {
+        match self {
+            Self::Online(on) => on.next_packet(),
+            Self::Offline(off) => off.next_packet(),
+        }
+    }
+
+    pub fn stats(&mut self) -> Result<Stat, Error> {
+        match self {
+            Self::Online(o) => o.stats(),
+            Self::Offline(off) => off.stats(),
+        }
+    }
+
+    fn from_source(source: &CaptureSource, pcap_out_path: Option<&String>) -> Result<Self, Error> {
+        match source {
+            CaptureSource::Device(device) => {
+                let inactive = Capture::from_device(device.to_pcap_device())?;
+                let cap = inactive
+                    .promisc(true)
+                    .snaplen(if pcap_out_path.is_some() {
+                        i32::from(u16::MAX)
+                    } else {
+                        256 //limit stored packets slice dimension (to keep more in the buffer)
+                    })
+                    .immediate_mode(true) //parse packets ASAP!
+                    .open()?;
+                Ok(Self::Online(cap))
+            }
+            CaptureSource::File(file) => Ok(Self::Offline(Capture::from_file(&file.path)?)),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub enum CaptureSource {
+    Device(MyDevice),
+    File(MyPcapImport),
+}
+
+impl CaptureSource {
+    pub fn get_addresses(&self) -> Arc<Mutex<Vec<Address>>> {
+        match self {
+            Self::Device(device) => device.addresses.clone(),
+            Self::File(_) => Arc::new(Mutex::new(vec![])),
+        }
+    }
+
+    pub fn set_addresses(&self, addresses: Vec<Address>) {
+        match self {
+            Self::Device(device) => *device.addresses.lock().unwrap() = addresses,
+            _ => {}
+        }
+    }
+
+    pub fn get_link_type(&self) -> MyLinkType {
+        match self {
+            Self::Device(device) => device.link_type,
+            Self::File(file) => file.link_type,
+        }
+    }
+
+    pub fn set_link_type(&mut self, link_type: MyLinkType) {
+        match self {
+            Self::Device(device) => device.link_type = link_type,
+            Self::File(file) => file.link_type = link_type,
+        }
+    }
+
+    pub fn get_name(&self) -> String {
+        match self {
+            Self::Device(device) => device.name.clone(),
+            Self::File(file) => get_path_termination_string(&file.path, 15),
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    pub fn get_desc(&self) -> Option<String> {
+        match self {
+            Self::Device(device) => device.desc.clone(),
+            Self::File(_) => None,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct MyPcapImport {
+    pub path: String,
+    pub link_type: MyLinkType,
+}
+
+impl MyPcapImport {
+    pub fn new(path: String) -> Self {
+        Self {
+            path,
+            link_type: MyLinkType::default(),
+        }
+    }
 }

--- a/src/secondary_threads/parse_packets.rs
+++ b/src/secondary_threads/parse_packets.rs
@@ -14,14 +14,13 @@ use crate::networking::manage_packets::{
     analyze_headers, get_address_to_lookup, modify_or_insert_in_map, reverse_dns_lookup,
 };
 use crate::networking::types::arp_type::ArpType;
-use crate::networking::types::capture_context::CaptureContext;
+use crate::networking::types::capture_context::{CaptureContext, CaptureSource};
 use crate::networking::types::data_info::DataInfo;
 use crate::networking::types::filters::Filters;
 use crate::networking::types::host::Host;
 use crate::networking::types::host_data_states::HostData;
 use crate::networking::types::icmp_type::IcmpType;
 use crate::networking::types::info_address_port_pair::InfoAddressPortPair;
-use crate::networking::types::my_device::MyDevice;
 use crate::networking::types::my_link_type::MyLinkType;
 use crate::networking::types::packet_filters_fields::PacketFiltersFields;
 use crate::utils::error_logger::{ErrorLogger, Location};
@@ -31,7 +30,7 @@ use crate::{InfoTraffic, location};
 /// to the user specified filters, and inserts them into the shared map variable.
 pub fn parse_packets(
     current_capture_id: &Mutex<usize>,
-    device: &MyDevice,
+    cs: &CaptureSource,
     filters: &Filters,
     info_traffic_mutex: &Arc<Mutex<InfoTraffic>>,
     mmdb_readers: &MmdbReaders,
@@ -86,7 +85,7 @@ pub fn parse_packets(
                         new_info = modify_or_insert_in_map(
                             info_traffic_mutex,
                             &key,
-                            device,
+                            cs,
                             mac_addresses,
                             icmp_type,
                             arp_type,
@@ -136,7 +135,7 @@ pub fn parse_packets(
                                 // launch new thread to resolve host name
                                 let key2 = key;
                                 let info_traffic2 = info_traffic_mutex.clone();
-                                let device2 = device.clone();
+                                let device2 = cs.clone();
                                 let mmdb_readers_2 = mmdb_readers.clone();
                                 let host_data2 = host_data.clone();
                                 let _ = thread::Builder::new()

--- a/src/utils/types/file_info.rs
+++ b/src/utils/types/file_info.rs
@@ -8,6 +8,7 @@ pub enum FileInfo {
     Style,
     Database,
     Directory,
+    PcapImport,
 }
 
 impl FileInfo {
@@ -16,6 +17,7 @@ impl FileInfo {
             FileInfo::Style => "toml",
             FileInfo::Database => "mmdb",
             FileInfo::Directory => "",
+            FileInfo::PcapImport => "pcap",
         }
     }
 
@@ -24,6 +26,7 @@ impl FileInfo {
             FileInfo::Style => style_from_file_translation(language),
             FileInfo::Database => database_from_file_translation(language),
             FileInfo::Directory => select_directory_translation(language),
+            FileInfo::PcapImport => "Import pcap file",
         }
     }
 }


### PR DESCRIPTION
Finally introduce the possibility to **read data from a PCAP file** rather than a network adapter.

This PR makes Sniffnet fully compatible with the output produced by other network analysers: this means that now you can import data from other tools and visualise it in a Sniffnet interface.

Fixes #283.

> [!NOTE]
> _PCAP file import is already supported by Sniffnet since v1.3.0  (see #473)._

***

TODO list before merging: 

- [ ] Add generic capture source to abstract either a network device or a PCAP file
- [ ] Add PCAP file selection in the UI
- When importing data from a PCAP file:
  - [ ] Replace the live chart with a representation that's more suitable for offline data 
  - [ ] Find an alternative way to establish traffic directionality given that interface addresses are not available
  - [ ] Disable notifications
  - [ ] Read timestamps instead of assigning them manually
  - [ ] Display a loading screen until all data from the PCAP is parsed
  - [ ] Sort data by descending amount value by default (instead of latest time)
  - [ ] Info column in overview page should include data about the file instead of the adapter name