### PR TITLE
More notification details

### DIFF
--- a/src/chart/manage_chart_data.rs
+++ b/src/chart/manage_chart_data.rs
@@ -16,16 +16,20 @@ impl TrafficChart {
         self.ticks += 1;
 
         #[allow(clippy::cast_precision_loss)]
-        let out_bytes_entry =
-            -1.0 * (info_traffic.tot_out_bytes - info_traffic.tot_out_bytes_prev) as f32;
+        let out_bytes_entry = -1.0
+            * (info_traffic.tot_data_info.outgoing_bytes()
+                - info_traffic.tot_data_info_prev.outgoing_bytes()) as f32;
         #[allow(clippy::cast_precision_loss)]
-        let in_bytes_entry = (info_traffic.tot_in_bytes - info_traffic.tot_in_bytes_prev) as f32;
+        let in_bytes_entry = (info_traffic.tot_data_info.incoming_bytes()
+            - info_traffic.tot_data_info_prev.incoming_bytes()) as f32;
         #[allow(clippy::cast_precision_loss)]
-        let out_packets_entry =
-            -1.0 * (info_traffic.tot_out_packets - info_traffic.tot_out_packets_prev) as f32;
+        let out_packets_entry = -1.0
+            * (info_traffic.tot_data_info.outgoing_packets()
+                - info_traffic.tot_data_info_prev.outgoing_packets()) as f32;
         #[allow(clippy::cast_precision_loss)]
-        let in_packets_entry =
-            (info_traffic.tot_in_packets - info_traffic.tot_in_packets_prev) as f32;
+        let in_packets_entry = (info_traffic.tot_data_info.incoming_packets()
+            - info_traffic.tot_data_info_prev.incoming_packets())
+            as f32;
 
         let out_bytes_point = (tot_seconds, out_bytes_entry);
         let in_bytes_point = (tot_seconds, in_bytes_entry);
@@ -163,6 +167,8 @@ mod tests {
     use splines::{Interpolation, Key, Spline};
 
     use crate::chart::manage_chart_data::{ChartSeries, get_max, get_min};
+    use crate::networking::types::data_info::DataInfo;
+    use crate::networking::types::traffic_direction::TrafficDirection;
     use crate::utils::types::timestamp::Timestamp;
     use crate::{ChartType, InfoTraffic, Language, StyleType, TrafficChart};
 
@@ -250,6 +256,14 @@ mod tests {
         };
         let tot_sent = 1000 * 28 + 500;
         let tot_received = 21000 * 28 + 1000;
+        let tot_data_info_prev =
+            DataInfo::new_for_tests(tot_received, tot_sent, tot_received, tot_sent);
+        let tot_data_info = DataInfo::new_for_tests(
+            tot_received + 4444,
+            tot_sent + 3333,
+            tot_received + 2222,
+            tot_sent + 1111,
+        );
         let mut traffic_chart = TrafficChart {
             ticks: 29,
             out_bytes: sent.clone(),
@@ -271,15 +285,9 @@ mod tests {
         let mut info_traffic = InfoTraffic {
             all_bytes: 0,
             all_packets: 0,
-            tot_out_bytes: tot_sent + 1111,
-            tot_in_bytes: tot_received + 2222,
-            tot_out_packets: tot_sent + 3333,
-            tot_in_packets: tot_received + 4444,
+            tot_data_info,
             dropped_packets: 0,
-            tot_out_bytes_prev: tot_sent,
-            tot_in_bytes_prev: tot_received,
-            tot_out_packets_prev: tot_sent,
-            tot_in_packets_prev: tot_received,
+            tot_data_info_prev,
             ..Default::default()
         };
 
@@ -292,10 +300,7 @@ mod tests {
         assert_eq!(get_max(&traffic_chart.in_bytes), 21000.0);
 
         // prev values aren't updated here anymore: manually set them
-        info_traffic.tot_out_bytes_prev = info_traffic.tot_out_bytes;
-        info_traffic.tot_in_bytes_prev = info_traffic.tot_in_bytes;
-        info_traffic.tot_out_packets_prev = info_traffic.tot_out_packets;
-        info_traffic.tot_in_packets_prev = info_traffic.tot_in_packets;
+        info_traffic.tot_data_info_prev = info_traffic.tot_data_info;
 
         let mut sent_bytes = sent.clone();
         sent_bytes
@@ -337,17 +342,20 @@ mod tests {
             received_bytes.spline.keys()
         );
 
-        info_traffic.tot_out_bytes += 99;
-        info_traffic.tot_in_packets += 990;
-        info_traffic.tot_in_bytes += 2;
+        info_traffic
+            .tot_data_info
+            .add_packets(990, 2, TrafficDirection::Incoming);
+        info_traffic
+            .tot_data_info
+            .add_packet(99, TrafficDirection::Outgoing);
         traffic_chart.update_charts_data(&info_traffic, false);
-        info_traffic.tot_out_bytes_prev = info_traffic.tot_out_bytes;
-        info_traffic.tot_in_bytes_prev = info_traffic.tot_in_bytes;
-        info_traffic.tot_out_packets_prev = info_traffic.tot_out_packets;
-        info_traffic.tot_in_packets_prev = info_traffic.tot_in_packets;
-        info_traffic.tot_out_bytes += 77;
-        info_traffic.tot_in_packets += 1;
-        info_traffic.tot_out_packets += 220;
+        info_traffic.tot_data_info_prev = info_traffic.tot_data_info;
+        info_traffic
+            .tot_data_info
+            .add_packet(0, TrafficDirection::Incoming);
+        info_traffic
+            .tot_data_info
+            .add_packets(220, 77, TrafficDirection::Outgoing);
         traffic_chart.update_charts_data(&info_traffic, false);
 
         sent_bytes.spline.remove(0);
@@ -370,7 +378,7 @@ mod tests {
         sent_packets.spline.remove(0);
         sent_packets
             .spline
-            .add(Key::new(30.0, 0.0, Interpolation::Cosine));
+            .add(Key::new(30.0, -1.0, Interpolation::Cosine));
         sent_packets
             .spline
             .add(Key::new(31.0, -220.0, Interpolation::Cosine));

--- a/src/chart/manage_chart_data.rs
+++ b/src/chart/manage_chart_data.rs
@@ -4,11 +4,11 @@ use crate::TrafficChart;
 use crate::networking::types::info_traffic::InfoTraffic;
 
 impl TrafficChart {
-    pub fn update_charts_data(&mut self, info_traffic: &InfoTraffic, no_more_packets: bool) {
+    pub fn update_charts_data(&mut self, info_traffic_msg: &InfoTraffic, no_more_packets: bool) {
         self.no_more_packets = no_more_packets;
 
         if self.ticks == 0 {
-            self.first_packet_timestamp = info_traffic.last_packet_timestamp;
+            self.first_packet_timestamp = info_traffic_msg.last_packet_timestamp;
         }
 
         #[allow(clippy::cast_precision_loss)]
@@ -16,20 +16,13 @@ impl TrafficChart {
         self.ticks += 1;
 
         #[allow(clippy::cast_precision_loss)]
-        let out_bytes_entry = -1.0
-            * (info_traffic.tot_data_info.outgoing_bytes()
-                - info_traffic.tot_data_info_prev.outgoing_bytes()) as f32;
+        let out_bytes_entry = -1.0 * info_traffic_msg.tot_data_info.outgoing_bytes() as f32;
         #[allow(clippy::cast_precision_loss)]
-        let in_bytes_entry = (info_traffic.tot_data_info.incoming_bytes()
-            - info_traffic.tot_data_info_prev.incoming_bytes()) as f32;
+        let in_bytes_entry = info_traffic_msg.tot_data_info.incoming_bytes() as f32;
         #[allow(clippy::cast_precision_loss)]
-        let out_packets_entry = -1.0
-            * (info_traffic.tot_data_info.outgoing_packets()
-                - info_traffic.tot_data_info_prev.outgoing_packets()) as f32;
+        let out_packets_entry = -1.0 * info_traffic_msg.tot_data_info.outgoing_packets() as f32;
         #[allow(clippy::cast_precision_loss)]
-        let in_packets_entry = (info_traffic.tot_data_info.incoming_packets()
-            - info_traffic.tot_data_info_prev.incoming_packets())
-            as f32;
+        let in_packets_entry = info_traffic_msg.tot_data_info.incoming_packets() as f32;
 
         let out_bytes_point = (tot_seconds, out_bytes_entry);
         let in_bytes_point = (tot_seconds, in_bytes_entry);
@@ -168,7 +161,6 @@ mod tests {
 
     use crate::chart::manage_chart_data::{ChartSeries, get_max, get_min};
     use crate::networking::types::data_info::DataInfo;
-    use crate::networking::types::traffic_direction::TrafficDirection;
     use crate::utils::types::timestamp::Timestamp;
     use crate::{ChartType, InfoTraffic, Language, StyleType, TrafficChart};
 
@@ -254,16 +246,7 @@ mod tests {
             spline: received_spl,
             all_time: vec![],
         };
-        let tot_sent = 1000 * 28 + 500;
-        let tot_received = 21000 * 28 + 1000;
-        let tot_data_info_prev =
-            DataInfo::new_for_tests(tot_received, tot_sent, tot_received, tot_sent);
-        let tot_data_info = DataInfo::new_for_tests(
-            tot_received + 4444,
-            tot_sent + 3333,
-            tot_received + 2222,
-            tot_sent + 1111,
-        );
+        let tot_data_info = DataInfo::new_for_tests(4444, 3333, 2222, 1111);
         let mut traffic_chart = TrafficChart {
             ticks: 29,
             out_bytes: sent.clone(),
@@ -287,7 +270,6 @@ mod tests {
             all_packets: 0,
             tot_data_info,
             dropped_packets: 0,
-            tot_data_info_prev,
             ..Default::default()
         };
 
@@ -298,9 +280,6 @@ mod tests {
 
         assert_eq!(get_min(&traffic_chart.out_packets), -3333.0);
         assert_eq!(get_max(&traffic_chart.in_bytes), 21000.0);
-
-        // prev values aren't updated here anymore: manually set them
-        info_traffic.tot_data_info_prev = info_traffic.tot_data_info;
 
         let mut sent_bytes = sent.clone();
         sent_bytes
@@ -342,20 +321,9 @@ mod tests {
             received_bytes.spline.keys()
         );
 
-        info_traffic
-            .tot_data_info
-            .add_packets(990, 2, TrafficDirection::Incoming);
-        info_traffic
-            .tot_data_info
-            .add_packet(99, TrafficDirection::Outgoing);
+        info_traffic.tot_data_info = DataInfo::new_for_tests(990, 1, 2, 99);
         traffic_chart.update_charts_data(&info_traffic, false);
-        info_traffic.tot_data_info_prev = info_traffic.tot_data_info;
-        info_traffic
-            .tot_data_info
-            .add_packet(0, TrafficDirection::Incoming);
-        info_traffic
-            .tot_data_info
-            .add_packets(220, 77, TrafficDirection::Outgoing);
+        info_traffic.tot_data_info = DataInfo::new_for_tests(1, 220, 0, 77);
         traffic_chart.update_charts_data(&info_traffic, false);
 
         sent_bytes.spline.remove(0);

--- a/src/gui/pages/inspect_page.rs
+++ b/src/gui/pages/inspect_page.rs
@@ -556,7 +556,7 @@ fn get_agglomerates_row<'a>(
     let tot_bytes = tot.tot_bytes();
 
     let (in_length, out_length) = get_bars_length(chart_type, &tot, &tot);
-    let bars = get_bars(in_length, out_length);
+    let bars = get_bars(in_length, out_length).width(ReportCol::FILTER_COLUMNS_WIDTH);
 
     let bytes_col = Column::new()
         .align_x(Alignment::Center)

--- a/src/gui/pages/notifications_page.rs
+++ b/src/gui/pages/notifications_page.rs
@@ -162,15 +162,10 @@ fn packets_notification_log<'a>(
         .height(Length::Fill)
         .spacing(30)
         .push(
-            Tooltip::new(
-                Icon::PacketsThreshold
-                    .to_text()
-                    .size(80)
-                    .line_height(LineHeight::Relative(1.0)),
-                Text::new(packets_exceeded_translation(language)).font(font),
-                Position::FollowCursor,
-            )
-            .class(ContainerType::Tooltip),
+            Icon::PacketsThreshold
+                .to_text()
+                .size(80)
+                .line_height(LineHeight::Relative(1.0)),
         )
         .push(
             Column::new()
@@ -243,15 +238,10 @@ fn bytes_notification_log<'a>(
         .align_y(Alignment::Center)
         .height(Length::Fill)
         .push(
-            Tooltip::new(
-                Icon::BytesThreshold
-                    .to_text()
-                    .size(80)
-                    .line_height(LineHeight::Relative(1.0)),
-                Text::new(bytes_exceeded_translation(language)).font(font),
-                Position::FollowCursor,
-            )
-            .class(ContainerType::Tooltip),
+            Icon::BytesThreshold
+                .to_text()
+                .size(80)
+                .line_height(LineHeight::Relative(1.0)),
         )
         .push(
             Column::new()
@@ -327,16 +317,11 @@ fn favorite_notification_log<'a>(
         .align_y(Alignment::Center)
         .height(Length::Fill)
         .push(
-            Tooltip::new(
-                Icon::Star
-                    .to_text()
-                    .size(80)
-                    .class(TextType::Starred)
-                    .line_height(LineHeight::Relative(1.0)),
-                Text::new(favorite_transmitted_translation(language)).font(font),
-                Position::FollowCursor,
-            )
-            .class(ContainerType::Tooltip),
+            Icon::Star
+                .to_text()
+                .size(80)
+                .class(TextType::Starred)
+                .line_height(LineHeight::Relative(1.0)),
         )
         .push(
             Column::new()

--- a/src/gui/pages/notifications_page.rs
+++ b/src/gui/pages/notifications_page.rs
@@ -69,15 +69,15 @@ pub fn notifications_page(sniffer: &Sniffer) -> Container<Message, StyleType> {
     } else {
         let logged_notifications = logged_notifications(sniffer);
         let body_row = Row::new()
+            .spacing(10)
             .padding(Padding::new(10.0).bottom(0))
-            .width(Length::Fill)
             .push(
                 Container::new(if sniffer.logged_notifications.len() < 30 {
                     Text::new("")
                 } else {
                     Text::new(only_last_30_translation(language)).font(font)
                 })
-                .width(Length::Fill)
+                .width(150)
                 .height(Length::Fill)
                 .align_x(Alignment::Center)
                 .align_y(Alignment::Center),
@@ -88,7 +88,7 @@ pub fn notifications_page(sniffer: &Sniffer) -> Container<Message, StyleType> {
             ))
             .push(
                 Container::new(get_button_clear_all(font, language))
-                    .width(Length::Fill)
+                    .width(150)
                     .height(Length::Fill)
                     .align_x(Alignment::Center)
                     .align_y(Alignment::Center),
@@ -205,7 +205,7 @@ fn packets_notification_log<'a>(
         );
     Container::new(content)
         .height(120)
-        .width(800)
+        .width(Length::Fill)
         .padding(10)
         .class(ContainerType::BorderedRound)
 }
@@ -283,7 +283,7 @@ fn bytes_notification_log<'a>(
         );
     Container::new(content)
         .height(120)
-        .width(800)
+        .width(Length::Fill)
         .padding(10)
         .class(ContainerType::BorderedRound)
 }
@@ -330,11 +330,11 @@ fn favorite_notification_log<'a>(
                         .font(font),
                 ),
         )
-        .push(Column::new().spacing(7).width(Length::Fill).push(host_bar));
+        .push(Column::new().spacing(7).push(host_bar));
 
     Container::new(content)
         .height(120)
-        .width(800)
+        .width(Length::Fill)
         .padding(10)
         .class(ContainerType::BorderedRound)
 }
@@ -368,7 +368,7 @@ fn logged_notifications<'a>(sniffer: &Sniffer) -> Column<'a, Message, StyleType>
     let chart_type = sniffer.traffic_chart.chart_type;
     let font = style.get_extension().font;
     let mut ret_val = Column::new()
-        .width(830)
+        .padding(Padding::ZERO.right(15))
         .spacing(10)
         .align_x(Alignment::Center);
 

--- a/src/gui/pages/notifications_page.rs
+++ b/src/gui/pages/notifications_page.rs
@@ -4,7 +4,7 @@ use iced::widget::text::LineHeight;
 use iced::widget::tooltip::Position;
 use iced::widget::{Column, Container, Row, Scrollable, Text, Tooltip};
 use iced::widget::{Space, button, vertical_space};
-use iced::{Alignment, Font, Length};
+use iced::{Alignment, Font, Length, Padding};
 use std::fmt::Write;
 
 use crate::chart::types::chart_type::ChartType;
@@ -54,7 +54,7 @@ pub fn notifications_page(sniffer: &Sniffer) -> Container<Message, StyleType> {
         sniffer.unread_notifications,
     );
 
-    tab_and_body = tab_and_body.push(tabs).push(Space::with_height(15));
+    tab_and_body = tab_and_body.push(tabs);
 
     if notifications.packets_notification.threshold.is_none()
         && notifications.bytes_notification.threshold.is_none()
@@ -69,6 +69,7 @@ pub fn notifications_page(sniffer: &Sniffer) -> Container<Message, StyleType> {
     } else {
         let logged_notifications = logged_notifications(sniffer);
         let body_row = Row::new()
+            .padding(Padding::new(10.0).bottom(0))
             .width(Length::Fill)
             .push(
                 Container::new(if sniffer.logged_notifications.len() < 30 {
@@ -76,7 +77,6 @@ pub fn notifications_page(sniffer: &Sniffer) -> Container<Message, StyleType> {
                 } else {
                     Text::new(only_last_30_translation(language)).font(font)
                 })
-                .padding(10)
                 .width(Length::Fill)
                 .height(Length::Fill)
                 .align_x(Alignment::Center)
@@ -369,7 +369,6 @@ fn logged_notifications<'a>(sniffer: &Sniffer) -> Column<'a, Message, StyleType>
     let font = style.get_extension().font;
     let mut ret_val = Column::new()
         .width(830)
-        .padding(5)
         .spacing(10)
         .align_x(Alignment::Center);
 

--- a/src/gui/pages/overview_page.rs
+++ b/src/gui/pages/overview_page.rs
@@ -69,7 +69,7 @@ pub fn overview_page(sniffer: &Sniffer) -> Container<Message, StyleType> {
     } else {
         // NO pcap error detected
         let observed = sniffer.info_traffic.all_packets;
-        let filtered = sniffer.info_traffic.tot_out_packets + sniffer.info_traffic.tot_in_packets;
+        let filtered = sniffer.info_traffic.tot_data_info.tot_packets();
 
         match (observed, filtered) {
             (0, 0) => {

--- a/src/gui/pages/settings_notifications_page.rs
+++ b/src/gui/pages/settings_notifications_page.rs
@@ -324,7 +324,7 @@ fn input_group_bytes<'a>(
         .push(
             TextInput::new(
                 "0",
-                if curr_threshold_str == "0" {
+                if curr_threshold_str.starts_with('0') {
                     ""
                 } else {
                     &curr_threshold_str

--- a/src/gui/pages/thumbnail_page.rs
+++ b/src/gui/pages/thumbnail_page.rs
@@ -27,7 +27,7 @@ pub fn thumbnail_page(sniffer: &Sniffer) -> Container<Message, StyleType> {
     let ConfigSettings { style, .. } = sniffer.configs.settings;
     let font = style.get_extension().font;
 
-    let filtered = sniffer.info_traffic.tot_out_packets + sniffer.info_traffic.tot_in_packets;
+    let filtered = sniffer.info_traffic.tot_data_info.tot_packets();
 
     if filtered == 0 {
         return Container::new(

--- a/src/gui/sniffer.rs
+++ b/src/gui/sniffer.rs
@@ -1109,6 +1109,15 @@ impl Sniffer {
             rdns,
         } = host_msg;
 
+        let data_info_host = DataInfoHost {
+            data_info: other_data,
+            is_favorite: false,
+            is_loopback,
+            is_local,
+            is_bogon,
+            traffic_type,
+        };
+
         self.info_traffic
             .hosts
             .entry(host.clone())
@@ -1119,14 +1128,7 @@ impl Sniffer {
                 data_info_host.is_bogon = is_bogon;
                 data_info_host.traffic_type = traffic_type;
             })
-            .or_insert_with(|| DataInfoHost {
-                data_info: other_data,
-                is_favorite: false,
-                is_loopback,
-                is_local,
-                is_bogon,
-                traffic_type,
-            });
+            .or_insert(data_info_host);
 
         self.addresses_resolved
             .insert(address_to_lookup, (rdns, host.clone()));
@@ -1136,7 +1138,9 @@ impl Sniffer {
 
         // check if the newly resolved host was featured in the favorites (possible in case of already existing host)
         if self.favorite_hosts.contains(&host) {
-            self.info_traffic.favorites_last_interval.insert(host);
+            self.info_traffic
+                .favorites_last_interval
+                .insert((host, data_info_host));
         }
     }
 

--- a/src/gui/sniffer.rs
+++ b/src/gui/sniffer.rs
@@ -1158,11 +1158,12 @@ mod tests {
     use crate::gui::styles::types::gradient_type::GradientType;
     use crate::gui::types::message::Message;
     use crate::gui::types::timing_events::TimingEvents;
+    use crate::networking::types::data_info::DataInfo;
     use crate::networking::types::host::Host;
     use crate::networking::types::info_traffic::InfoTrafficMessage;
     use crate::networking::types::traffic_direction::TrafficDirection;
     use crate::notifications::types::logged_notification::{
-        LoggedNotification, PacketsThresholdExceeded,
+        DataThresholdExceeded, LoggedNotification,
     };
     use crate::notifications::types::notifications::{
         BytesNotification, FavoriteNotification, Notification, Notifications, PacketsNotification,
@@ -1922,10 +1923,9 @@ mod tests {
         let mut sniffer = Sniffer::new(Configs::default());
         sniffer.logged_notifications =
             VecDeque::from([LoggedNotification::PacketsThresholdExceeded(
-                PacketsThresholdExceeded {
+                DataThresholdExceeded {
                     threshold: 0,
-                    incoming: 0,
-                    outgoing: 0,
+                    data_info: DataInfo::default(),
                     timestamp: "".to_string(),
                 },
             )]);

--- a/src/gui/sniffer.rs
+++ b/src/gui/sniffer.rs
@@ -46,7 +46,6 @@ use crate::mmdb::types::mmdb_reader::{MmdbReader, MmdbReaders};
 use crate::networking::parse_packets::BackendTrafficMessage;
 use crate::networking::parse_packets::parse_packets;
 use crate::networking::types::capture_context::{CaptureContext, CaptureSource, MyPcapImport};
-use crate::networking::types::data_info_host::DataInfoHost;
 use crate::networking::types::filters::Filters;
 use crate::networking::types::host::{Host, HostMessage};
 use crate::networking::types::host_data_states::HostDataStates;
@@ -1100,33 +1099,16 @@ impl Sniffer {
     fn handle_new_host(&mut self, host_msg: HostMessage) {
         let HostMessage {
             host,
-            other_data,
-            is_loopback,
-            is_local,
-            is_bogon,
-            traffic_type,
+            data_info_host,
             address_to_lookup,
             rdns,
         } = host_msg;
 
-        let data_info_host = DataInfoHost {
-            data_info: other_data,
-            is_favorite: false,
-            is_loopback,
-            is_local,
-            is_bogon,
-            traffic_type,
-        };
-
         self.info_traffic
             .hosts
             .entry(host.clone())
-            .and_modify(|data_info_host| {
-                data_info_host.data_info.refresh(other_data);
-                data_info_host.is_loopback = is_loopback;
-                data_info_host.is_local = is_local;
-                data_info_host.is_bogon = is_bogon;
-                data_info_host.traffic_type = traffic_type;
+            .and_modify(|d| {
+                d.refresh(&data_info_host);
             })
             .or_insert(data_info_host);
 

--- a/src/gui/types/message.rs
+++ b/src/gui/types/message.rs
@@ -6,7 +6,7 @@ use crate::gui::pages::types::running_page::RunningPage;
 use crate::gui::pages::types::settings_page::SettingsPage;
 use crate::gui::styles::types::gradient_type::GradientType;
 use crate::networking::types::host::{Host, HostMessage};
-use crate::networking::types::info_traffic::InfoTrafficMessage;
+use crate::networking::types::info_traffic::InfoTraffic;
 use crate::notifications::types::notifications::Notification;
 use crate::report::types::search_parameters::SearchParameters;
 use crate::report::types::sort_type::SortType;
@@ -20,7 +20,7 @@ pub enum Message {
     /// Run tasks to initialize the app
     StartApp(Option<window::Id>),
     /// Sent by the backend parsing packets; includes the capture id, new data, new hosts batched data, and whether an offline capture has finished
-    TickRun(usize, InfoTrafficMessage, Vec<HostMessage>, bool),
+    TickRun(usize, InfoTraffic, Vec<HostMessage>, bool),
     /// Select network device
     DeviceSelection(String),
     /// Select IP filter

--- a/src/networking/manage_packets.rs
+++ b/src/networking/manage_packets.rs
@@ -10,7 +10,7 @@ use crate::networking::types::bogon::is_bogon;
 use crate::networking::types::capture_context::CaptureSource;
 use crate::networking::types::icmp_type::{IcmpType, IcmpTypeV4, IcmpTypeV6};
 use crate::networking::types::info_address_port_pair::InfoAddressPortPair;
-use crate::networking::types::info_traffic::InfoTrafficMessage;
+use crate::networking::types::info_traffic::InfoTraffic;
 use crate::networking::types::packet_filters_fields::PacketFiltersFields;
 use crate::networking::types::service::Service;
 use crate::networking::types::service_query::ServiceQuery;
@@ -249,7 +249,7 @@ pub fn get_service(
 
 /// Function to insert the source and destination of a packet into the map containing the analyzed traffic
 pub fn modify_or_insert_in_map(
-    info_traffic_msg: &mut InfoTrafficMessage,
+    info_traffic_msg: &mut InfoTraffic,
     key: &AddressPortPair,
     cs: &CaptureSource,
     mac_addresses: (Option<String>, Option<String>),

--- a/src/networking/parse_packets.rs
+++ b/src/networking/parse_packets.rs
@@ -388,13 +388,18 @@ fn reverse_dns_lookup(
         .insert(address_to_lookup, new_host.clone());
     drop(resolutions_lock);
 
-    let msg_data = HostMessage {
-        host: new_host,
-        other_data,
-        is_loopback,
+    let data_info_host = DataInfoHost {
+        data_info: other_data,
+        is_favorite: false,
         is_local,
         is_bogon,
+        is_loopback,
         traffic_type,
+    };
+
+    let msg_data = HostMessage {
+        host: new_host,
+        data_info_host,
         address_to_lookup,
         rdns,
     };

--- a/src/networking/parse_packets.rs
+++ b/src/networking/parse_packets.rs
@@ -154,7 +154,9 @@ pub fn parse_packets(
                             exchanged_bytes,
                         );
 
-                        info_traffic_msg.add_packet(exchanged_bytes, traffic_direction);
+                        info_traffic_msg
+                            .tot_data_info
+                            .add_packet(exchanged_bytes, traffic_direction);
 
                         // check the rDNS status of this address and act accordingly
                         let address_to_lookup = get_address_to_lookup(&key, traffic_direction);

--- a/src/networking/parse_packets.rs
+++ b/src/networking/parse_packets.rs
@@ -152,7 +152,6 @@ pub fn parse_packets(
                             icmp_type,
                             arp_type,
                             exchanged_bytes,
-                            &resolutions_state,
                         );
 
                         info_traffic_msg.add_packet(exchanged_bytes, traffic_direction);

--- a/src/networking/parse_packets.rs
+++ b/src/networking/parse_packets.rs
@@ -17,7 +17,7 @@ use crate::networking::types::data_info_host::DataInfoHost;
 use crate::networking::types::filters::Filters;
 use crate::networking::types::host::{Host, HostMessage};
 use crate::networking::types::icmp_type::IcmpType;
-use crate::networking::types::info_traffic::InfoTrafficMessage;
+use crate::networking::types::info_traffic::InfoTraffic;
 use crate::networking::types::my_link_type::MyLinkType;
 use crate::networking::types::packet_filters_fields::PacketFiltersFields;
 use crate::networking::types::traffic_direction::TrafficDirection;
@@ -48,7 +48,7 @@ pub fn parse_packets(
     let my_link_type = capture_context.my_link_type();
     let (mut cap, mut savefile) = capture_context.consume();
 
-    let mut info_traffic_msg = InfoTrafficMessage::default();
+    let mut info_traffic_msg = InfoTraffic::default();
     let resolutions_state = Arc::new(Mutex::new(AddressesResolutionState::default()));
     // list of newly resolved hosts to be sent (batched to avoid UI updates too often)
     let new_hosts_to_send = Arc::new(Mutex::new(Vec::new()));
@@ -420,14 +420,14 @@ pub struct AddressesResolutionState {
 
 #[allow(clippy::large_enum_variant)]
 pub enum BackendTrafficMessage {
-    TickRun(usize, InfoTrafficMessage, Vec<HostMessage>, bool),
+    TickRun(usize, InfoTraffic, Vec<HostMessage>, bool),
     PendingHosts(usize, Vec<HostMessage>),
     OfflineGap(usize, u32),
 }
 
 fn maybe_send_tick_run_live(
     cap_id: usize,
-    info_traffic_msg: &mut InfoTrafficMessage,
+    info_traffic_msg: &mut InfoTraffic,
     new_hosts_to_send: &Arc<Mutex<Vec<HostMessage>>>,
     cs: &mut CaptureSource,
     first_packet_ticks: &mut Option<Instant>,
@@ -453,7 +453,7 @@ fn maybe_send_tick_run_live(
 
 fn maybe_send_tick_run_offline(
     cap_id: usize,
-    info_traffic_msg: &mut InfoTrafficMessage,
+    info_traffic_msg: &mut InfoTraffic,
     new_hosts_to_send: &Arc<Mutex<Vec<HostMessage>>>,
     next_packet_timestamp: Timestamp,
     tx: &Sender<BackendTrafficMessage>,

--- a/src/networking/types/data_info.rs
+++ b/src/networking/types/data_info.rs
@@ -96,13 +96,6 @@ impl DataInfo {
         self.final_instant = rhs.final_instant;
     }
 
-    pub fn subtract(&mut self, rhs: Self) {
-        self.incoming_packets -= rhs.incoming_packets;
-        self.outgoing_packets -= rhs.outgoing_packets;
-        self.incoming_bytes -= rhs.incoming_bytes;
-        self.outgoing_bytes -= rhs.outgoing_bytes;
-    }
-
     pub fn compare(&self, other: &Self, sort_type: SortType, chart_type: ChartType) -> Ordering {
         match chart_type {
             ChartType::Packets => match sort_type {

--- a/src/networking/types/data_info.rs
+++ b/src/networking/types/data_info.rs
@@ -96,6 +96,13 @@ impl DataInfo {
         self.final_instant = rhs.final_instant;
     }
 
+    pub fn subtract(&mut self, rhs: Self) {
+        self.incoming_packets -= rhs.incoming_packets;
+        self.outgoing_packets -= rhs.outgoing_packets;
+        self.incoming_bytes -= rhs.incoming_bytes;
+        self.outgoing_bytes -= rhs.outgoing_bytes;
+    }
+
     pub fn compare(&self, other: &Self, sort_type: SortType, chart_type: ChartType) -> Ordering {
         match chart_type {
             ChartType::Packets => match sort_type {

--- a/src/networking/types/data_info.rs
+++ b/src/networking/types/data_info.rs
@@ -8,7 +8,7 @@ use std::time::Instant;
 
 /// Amount of exchanged data (packets and bytes) incoming and outgoing, with the timestamp of the latest occurrence
 // data fields are private to make them only editable via the provided methods: needed to correctly refresh timestamps
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub struct DataInfo {
     /// Incoming packets
     incoming_packets: u128,

--- a/src/networking/types/data_info_host.rs
+++ b/src/networking/types/data_info_host.rs
@@ -4,7 +4,7 @@ use crate::networking::types::data_info::DataInfo;
 use crate::networking::types::traffic_type::TrafficType;
 
 /// Host-related information.
-#[derive(Clone, Copy, Default, Debug)]
+#[derive(Clone, Copy, Default, Debug, Eq, PartialEq, Hash)]
 pub struct DataInfoHost {
     /// Incoming and outgoing packets and bytes
     pub data_info: DataInfo,

--- a/src/networking/types/host.rs
+++ b/src/networking/types/host.rs
@@ -1,7 +1,6 @@
 use crate::countries::types::country::Country;
 use crate::networking::types::asn::Asn;
-use crate::networking::types::data_info::DataInfo;
-use crate::networking::types::traffic_type::TrafficType;
+use crate::networking::types::data_info_host::DataInfoHost;
 use std::net::IpAddr;
 
 /// Struct to represent a network host
@@ -30,11 +29,7 @@ pub struct ThumbnailHost {
 #[derive(Clone, Debug)]
 pub struct HostMessage {
     pub host: Host,
-    pub other_data: DataInfo,
-    pub is_loopback: bool,
-    pub is_local: bool,
-    pub is_bogon: Option<&'static str>,
-    pub traffic_type: TrafficType,
+    pub data_info_host: DataInfoHost,
     pub address_to_lookup: IpAddr,
     pub rdns: String,
 }

--- a/src/networking/types/info_traffic.rs
+++ b/src/networking/types/info_traffic.rs
@@ -43,7 +43,7 @@ pub struct InfoTraffic {
     /// Map of the hosts with their data info
     pub hosts: HashMap<Host, DataInfoHost>,
     /// Collection of favorite hosts that exchanged data in the last interval
-    pub favorites_last_interval: HashSet<Host>,
+    pub favorites_last_interval: HashSet<(Host, DataInfoHost)>,
 }
 
 impl InfoTraffic {
@@ -82,18 +82,19 @@ impl InfoTraffic {
                 .or_insert(value);
         }
 
+        self.favorites_last_interval = msg
+            .hosts
+            .iter()
+            .filter(|(h, _)| favorites.contains(h))
+            .map(|(h, data)| (h.clone(), *data))
+            .collect();
+
         for (key, value) in msg.hosts {
             self.hosts
                 .entry(key)
                 .and_modify(|x| x.refresh(&value))
                 .or_insert(value);
         }
-
-        self.favorites_last_interval = msg
-            .potential_favorites
-            .into_iter()
-            .filter(|h| favorites.contains(h))
-            .collect();
     }
 
     pub fn get_thumbnail_data(&self, chart_type: ChartType) -> (u128, u128, u128, u128) {
@@ -141,8 +142,6 @@ pub struct InfoTrafficMessage {
     pub services: HashMap<Service, DataInfo>,
     /// Map of the hosts with their data info
     pub hosts: HashMap<Host, DataInfoHost>,
-    /// Collection of potentially favorite hosts that exchanged data in the last interval
-    pub potential_favorites: HashSet<Host>,
 }
 
 impl InfoTrafficMessage {

--- a/src/networking/types/info_traffic.rs
+++ b/src/networking/types/info_traffic.rs
@@ -5,21 +5,14 @@ use crate::networking::types::data_info::DataInfo;
 use crate::networking::types::data_info_host::DataInfoHost;
 use crate::networking::types::host::Host;
 use crate::networking::types::info_address_port_pair::InfoAddressPortPair;
-use crate::networking::types::traffic_direction::TrafficDirection;
 use crate::utils::types::timestamp::Timestamp;
 use std::collections::{HashMap, HashSet};
 
 /// Struct containing overall traffic statistics and data.
 #[derive(Debug, Default)]
 pub struct InfoTraffic {
-    /// Total amount of filtered bytes received.
-    pub tot_in_bytes: u128,
-    /// Total amount of filtered bytes sent.
-    pub tot_out_bytes: u128,
-    /// Total amount of filtered packets received.
-    pub tot_in_packets: u128,
-    /// Total amount of filtered packets sent.
-    pub tot_out_packets: u128,
+    /// Total amount of exchanged data
+    pub tot_data_info: DataInfo,
     /// Total packets including those not filtered
     pub all_packets: u128,
     /// Total bytes including those not filtered
@@ -28,35 +21,24 @@ pub struct InfoTraffic {
     pub dropped_packets: u32,
     /// Timestamp of the latest parsed packet
     pub last_packet_timestamp: Timestamp,
-    /// Total sent bytes filtered before the current time interval
-    pub tot_out_bytes_prev: u128,
-    /// Total received bytes filtered before the current time interval
-    pub tot_in_bytes_prev: u128,
-    /// Total sent packets filtered before the current time interval
-    pub tot_out_packets_prev: u128,
-    /// Total received packets filtered before the current time interval
-    pub tot_in_packets_prev: u128,
     /// Map of the filtered traffic
     pub map: HashMap<AddressPortPair, InfoAddressPortPair>,
     /// Map of the upper layer services with their data info
     pub services: HashMap<Service, DataInfo>,
     /// Map of the hosts with their data info
     pub hosts: HashMap<Host, DataInfoHost>,
+    /// Total amount of exchanged data before the current time interval
+    pub tot_data_info_prev: DataInfo,
     /// Collection of favorite hosts that exchanged data in the last interval
     pub favorites_last_interval: HashSet<(Host, DataInfoHost)>,
 }
 
 impl InfoTraffic {
     pub fn refresh(&mut self, msg: InfoTrafficMessage, favorites: &HashSet<Host>) {
-        self.tot_out_bytes_prev = self.tot_out_bytes;
-        self.tot_in_bytes_prev = self.tot_in_bytes;
-        self.tot_out_packets_prev = self.tot_out_packets;
-        self.tot_in_packets_prev = self.tot_in_packets;
+        self.tot_data_info_prev = self.tot_data_info;
 
-        self.tot_in_bytes += msg.tot_in_bytes;
-        self.tot_out_bytes += msg.tot_out_bytes;
-        self.tot_in_packets += msg.tot_in_packets;
-        self.tot_out_packets += msg.tot_out_packets;
+        self.tot_data_info.refresh(msg.tot_data_info);
+
         self.all_packets += msg.all_packets;
         self.all_bytes += msg.all_bytes;
         self.dropped_packets = msg.dropped_packets;
@@ -100,17 +82,21 @@ impl InfoTraffic {
     pub fn get_thumbnail_data(&self, chart_type: ChartType) -> (u128, u128, u128, u128) {
         if chart_type.eq(&ChartType::Bytes) {
             (
-                self.tot_in_bytes,
-                self.tot_out_bytes,
-                self.all_bytes - self.tot_out_bytes - self.tot_in_bytes,
+                self.tot_data_info.incoming_bytes(),
+                self.tot_data_info.outgoing_bytes(),
+                self.all_bytes
+                    - self.tot_data_info.outgoing_bytes()
+                    - self.tot_data_info.incoming_bytes(),
                 // assume that the dropped packets have the same size as the average packet
                 u128::from(self.dropped_packets) * self.all_bytes / self.all_packets,
             )
         } else {
             (
-                self.tot_in_packets,
-                self.tot_out_packets,
-                self.all_packets - self.tot_out_packets - self.tot_in_packets,
+                self.tot_data_info.incoming_packets(),
+                self.tot_data_info.outgoing_packets(),
+                self.all_packets
+                    - self.tot_data_info.outgoing_packets()
+                    - self.tot_data_info.incoming_packets(),
                 u128::from(self.dropped_packets),
             )
         }
@@ -120,14 +106,8 @@ impl InfoTraffic {
 /// Struct containing traffic statistics and data related to the last time interval.
 #[derive(Debug, Clone, Default)]
 pub struct InfoTrafficMessage {
-    /// Total amount of filtered bytes received.
-    pub tot_in_bytes: u128,
-    /// Total amount of filtered bytes sent.
-    pub tot_out_bytes: u128,
-    /// Total amount of filtered packets received.
-    pub tot_in_packets: u128,
-    /// Total amount of filtered packets sent.
-    pub tot_out_packets: u128,
+    /// Total amount of exchanged data
+    pub tot_data_info: DataInfo,
     /// Total packets including those not filtered
     pub all_packets: u128,
     /// Total bytes including those not filtered
@@ -145,18 +125,6 @@ pub struct InfoTrafficMessage {
 }
 
 impl InfoTrafficMessage {
-    pub fn add_packet(&mut self, bytes: u128, traffic_direction: TrafficDirection) {
-        if traffic_direction == TrafficDirection::Outgoing {
-            //increment number of sent packets and bytes
-            self.tot_out_packets += 1;
-            self.tot_out_bytes += bytes;
-        } else {
-            //increment number of received packets and bytes
-            self.tot_in_packets += 1;
-            self.tot_in_bytes += bytes;
-        }
-    }
-
     pub fn take_but_leave_something(&mut self) -> Self {
         let info_traffic = Self {
             last_packet_timestamp: self.last_packet_timestamp,

--- a/src/networking/types/traffic_type.rs
+++ b/src/networking/types/traffic_type.rs
@@ -1,5 +1,5 @@
 /// Enum representing the possible traffic type (unicast, multicast or broadcast).
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 pub enum TrafficType {
     /// Unicast traffic
     Unicast,

--- a/src/notifications/notify_and_log.rs
+++ b/src/notifications/notify_and_log.rs
@@ -22,8 +22,10 @@ pub fn notify_and_log(
     let timestamp = info_traffic.last_packet_timestamp;
     // packets threshold
     if let Some(threshold) = notifications.packets_notification.threshold {
-        let sent_packets_entry = info_traffic.tot_out_packets - info_traffic.tot_out_packets_prev;
-        let received_packets_entry = info_traffic.tot_in_packets - info_traffic.tot_in_packets_prev;
+        let sent_packets_entry = info_traffic.tot_data_info.outgoing_packets()
+            - info_traffic.tot_data_info_prev.outgoing_packets();
+        let received_packets_entry = info_traffic.tot_data_info.incoming_packets()
+            - info_traffic.tot_data_info_prev.incoming_packets();
         if received_packets_entry + sent_packets_entry > u128::from(threshold) {
             // log this notification
             emitted_notifications += 1;
@@ -45,8 +47,10 @@ pub fn notify_and_log(
     }
     // bytes threshold
     if let Some(threshold) = notifications.bytes_notification.threshold {
-        let sent_bytes_entry = info_traffic.tot_out_bytes - info_traffic.tot_out_bytes_prev;
-        let received_bytes_entry = info_traffic.tot_in_bytes - info_traffic.tot_in_bytes_prev;
+        let sent_bytes_entry = info_traffic.tot_data_info.outgoing_bytes()
+            - info_traffic.tot_data_info_prev.outgoing_bytes();
+        let received_bytes_entry = info_traffic.tot_data_info.incoming_bytes()
+            - info_traffic.tot_data_info_prev.incoming_bytes();
         if received_bytes_entry + sent_bytes_entry > u128::from(threshold) {
             //log this notification
             emitted_notifications += 1;

--- a/src/notifications/notify_and_log.rs
+++ b/src/notifications/notify_and_log.rs
@@ -1,6 +1,5 @@
 use crate::InfoTraffic;
 use crate::networking::types::capture_context::CaptureSource;
-use crate::networking::types::data_info_host::DataInfoHost;
 use crate::notifications::types::logged_notification::{
     BytesThresholdExceeded, FavoriteTransmitted, LoggedNotification, PacketsThresholdExceeded,
 };
@@ -71,17 +70,13 @@ pub fn notify_and_log(
     if notifications.favorite_notification.notify_on_favorite
         && !info_traffic.favorites_last_interval.is_empty()
     {
-        for host in info_traffic.favorites_last_interval.clone() {
+        for (host, data_info_host) in info_traffic.favorites_last_interval.clone() {
             //log this notification
             emitted_notifications += 1;
             if logged_notifications.len() >= 30 {
                 logged_notifications.pop_back();
             }
 
-            let data_info_host = *info_traffic
-                .hosts
-                .get(&host)
-                .unwrap_or(&DataInfoHost::default());
             logged_notifications.push_front(LoggedNotification::FavoriteTransmitted(
                 FavoriteTransmitted {
                     host,

--- a/src/notifications/notify_and_log.rs
+++ b/src/notifications/notify_and_log.rs
@@ -1,7 +1,7 @@
 use crate::InfoTraffic;
 use crate::networking::types::capture_context::CaptureSource;
 use crate::notifications::types::logged_notification::{
-    BytesThresholdExceeded, FavoriteTransmitted, LoggedNotification, PacketsThresholdExceeded,
+    DataThresholdExceeded, FavoriteTransmitted, LoggedNotification,
 };
 use crate::notifications::types::notifications::Notifications;
 use crate::notifications::types::sound::{Sound, play};
@@ -20,23 +20,20 @@ pub fn notify_and_log(
     let mut sound_to_play = Sound::None;
     let mut emitted_notifications = 0;
     let timestamp = info_traffic.last_packet_timestamp;
+    let mut data_info_delta = info_traffic.tot_data_info;
+    data_info_delta.subtract(info_traffic.tot_data_info_prev);
     // packets threshold
     if let Some(threshold) = notifications.packets_notification.threshold {
-        let sent_packets_entry = info_traffic.tot_data_info.outgoing_packets()
-            - info_traffic.tot_data_info_prev.outgoing_packets();
-        let received_packets_entry = info_traffic.tot_data_info.incoming_packets()
-            - info_traffic.tot_data_info_prev.incoming_packets();
-        if received_packets_entry + sent_packets_entry > u128::from(threshold) {
+        if data_info_delta.tot_packets() > u128::from(threshold) {
             // log this notification
             emitted_notifications += 1;
             if logged_notifications.len() >= 30 {
                 logged_notifications.pop_back();
             }
             logged_notifications.push_front(LoggedNotification::PacketsThresholdExceeded(
-                PacketsThresholdExceeded {
+                DataThresholdExceeded {
                     threshold: notifications.packets_notification.previous_threshold,
-                    incoming: received_packets_entry.try_into().unwrap_or_default(),
-                    outgoing: sent_packets_entry.try_into().unwrap_or_default(),
+                    data_info: data_info_delta,
                     timestamp: get_formatted_timestamp(timestamp),
                 },
             ));
@@ -47,21 +44,16 @@ pub fn notify_and_log(
     }
     // bytes threshold
     if let Some(threshold) = notifications.bytes_notification.threshold {
-        let sent_bytes_entry = info_traffic.tot_data_info.outgoing_bytes()
-            - info_traffic.tot_data_info_prev.outgoing_bytes();
-        let received_bytes_entry = info_traffic.tot_data_info.incoming_bytes()
-            - info_traffic.tot_data_info_prev.incoming_bytes();
-        if received_bytes_entry + sent_bytes_entry > u128::from(threshold) {
+        if data_info_delta.tot_bytes() > u128::from(threshold) {
             //log this notification
             emitted_notifications += 1;
             if logged_notifications.len() >= 30 {
                 logged_notifications.pop_back();
             }
             logged_notifications.push_front(LoggedNotification::BytesThresholdExceeded(
-                BytesThresholdExceeded {
+                DataThresholdExceeded {
                     threshold: notifications.bytes_notification.previous_threshold,
-                    incoming: received_bytes_entry.try_into().unwrap_or_default(),
-                    outgoing: sent_bytes_entry.try_into().unwrap_or_default(),
+                    data_info: data_info_delta,
                     timestamp: get_formatted_timestamp(timestamp),
                 },
             ));

--- a/src/notifications/notify_and_log.rs
+++ b/src/notifications/notify_and_log.rs
@@ -1,13 +1,15 @@
 use crate::InfoTraffic;
 use crate::chart::types::chart_type::ChartType;
 use crate::networking::types::capture_context::CaptureSource;
+use crate::networking::types::data_info_host::DataInfoHost;
+use crate::networking::types::host::Host;
 use crate::notifications::types::logged_notification::{
     DataThresholdExceeded, FavoriteTransmitted, LoggedNotification,
 };
 use crate::notifications::types::notifications::Notifications;
 use crate::notifications::types::sound::{Sound, play};
 use crate::utils::formatted_strings::get_formatted_timestamp;
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 
 /// Checks if one or more notifications have to be emitted and logs them.
 ///
@@ -15,17 +17,17 @@ use std::collections::VecDeque;
 pub fn notify_and_log(
     logged_notifications: &mut VecDeque<LoggedNotification>,
     notifications: Notifications,
-    info_traffic: &InfoTraffic,
+    info_traffic_msg: &InfoTraffic,
+    favorites: &HashSet<Host>,
     cs: &CaptureSource,
 ) -> usize {
     let mut sound_to_play = Sound::None;
     let mut emitted_notifications = 0;
-    let timestamp = info_traffic.last_packet_timestamp;
-    let mut data_info_delta = info_traffic.tot_data_info;
-    data_info_delta.subtract(info_traffic.tot_data_info_prev);
+    let timestamp = info_traffic_msg.last_packet_timestamp;
+    let data_info = info_traffic_msg.tot_data_info;
     // packets threshold
     if let Some(threshold) = notifications.packets_notification.threshold {
-        if data_info_delta.tot_packets() > u128::from(threshold) {
+        if data_info.tot_packets() > u128::from(threshold) {
             // log this notification
             emitted_notifications += 1;
             if logged_notifications.len() >= 30 {
@@ -35,7 +37,7 @@ pub fn notify_and_log(
                 DataThresholdExceeded {
                     chart_type: ChartType::Packets,
                     threshold: notifications.packets_notification.previous_threshold,
-                    data_info: data_info_delta,
+                    data_info,
                     timestamp: get_formatted_timestamp(timestamp),
                 },
             ));
@@ -46,7 +48,7 @@ pub fn notify_and_log(
     }
     // bytes threshold
     if let Some(threshold) = notifications.bytes_notification.threshold {
-        if data_info_delta.tot_bytes() > u128::from(threshold) {
+        if data_info.tot_bytes() > u128::from(threshold) {
             //log this notification
             emitted_notifications += 1;
             if logged_notifications.len() >= 30 {
@@ -56,7 +58,7 @@ pub fn notify_and_log(
                 DataThresholdExceeded {
                     chart_type: ChartType::Bytes,
                     threshold: notifications.bytes_notification.previous_threshold,
-                    data_info: data_info_delta,
+                    data_info,
                     timestamp: get_formatted_timestamp(timestamp),
                 },
             ));
@@ -66,26 +68,32 @@ pub fn notify_and_log(
         }
     }
     // from favorites
-    if notifications.favorite_notification.notify_on_favorite
-        && !info_traffic.favorites_last_interval.is_empty()
-    {
-        for (host, data_info_host) in info_traffic.favorites_last_interval.clone() {
-            //log this notification
-            emitted_notifications += 1;
-            if logged_notifications.len() >= 30 {
-                logged_notifications.pop_back();
-            }
+    if notifications.favorite_notification.notify_on_favorite {
+        let favorites_last_interval: HashSet<(Host, DataInfoHost)> = info_traffic_msg
+            .hosts
+            .iter()
+            .filter(|(h, _)| favorites.contains(h))
+            .map(|(h, data)| (h.clone(), *data))
+            .collect();
+        if !favorites_last_interval.is_empty() {
+            for (host, data_info_host) in favorites_last_interval {
+                //log this notification
+                emitted_notifications += 1;
+                if logged_notifications.len() >= 30 {
+                    logged_notifications.pop_back();
+                }
 
-            logged_notifications.push_front(LoggedNotification::FavoriteTransmitted(
-                FavoriteTransmitted {
-                    host,
-                    data_info_host,
-                    timestamp: get_formatted_timestamp(timestamp),
-                },
-            ));
-        }
-        if sound_to_play.eq(&Sound::None) {
-            sound_to_play = notifications.favorite_notification.sound;
+                logged_notifications.push_front(LoggedNotification::FavoriteTransmitted(
+                    FavoriteTransmitted {
+                        host,
+                        data_info_host,
+                        timestamp: get_formatted_timestamp(timestamp),
+                    },
+                ));
+            }
+            if sound_to_play.eq(&Sound::None) {
+                sound_to_play = notifications.favorite_notification.sound;
+            }
         }
     }
 

--- a/src/notifications/notify_and_log.rs
+++ b/src/notifications/notify_and_log.rs
@@ -1,4 +1,5 @@
 use crate::InfoTraffic;
+use crate::chart::types::chart_type::ChartType;
 use crate::networking::types::capture_context::CaptureSource;
 use crate::notifications::types::logged_notification::{
     DataThresholdExceeded, FavoriteTransmitted, LoggedNotification,
@@ -30,8 +31,9 @@ pub fn notify_and_log(
             if logged_notifications.len() >= 30 {
                 logged_notifications.pop_back();
             }
-            logged_notifications.push_front(LoggedNotification::PacketsThresholdExceeded(
+            logged_notifications.push_front(LoggedNotification::DataThresholdExceeded(
                 DataThresholdExceeded {
+                    chart_type: ChartType::Packets,
                     threshold: notifications.packets_notification.previous_threshold,
                     data_info: data_info_delta,
                     timestamp: get_formatted_timestamp(timestamp),
@@ -50,8 +52,9 @@ pub fn notify_and_log(
             if logged_notifications.len() >= 30 {
                 logged_notifications.pop_back();
             }
-            logged_notifications.push_front(LoggedNotification::BytesThresholdExceeded(
+            logged_notifications.push_front(LoggedNotification::DataThresholdExceeded(
                 DataThresholdExceeded {
+                    chart_type: ChartType::Bytes,
                     threshold: notifications.bytes_notification.previous_threshold,
                     data_info: data_info_delta,
                     timestamp: get_formatted_timestamp(timestamp),

--- a/src/notifications/types/logged_notification.rs
+++ b/src/notifications/types/logged_notification.rs
@@ -12,6 +12,16 @@ pub enum LoggedNotification {
     FavoriteTransmitted(FavoriteTransmitted),
 }
 
+impl LoggedNotification {
+    pub fn data_info(&self) -> DataInfo {
+        match self {
+            LoggedNotification::BytesThresholdExceeded(d)
+            | LoggedNotification::PacketsThresholdExceeded(d) => d.data_info,
+            LoggedNotification::FavoriteTransmitted(f) => f.data_info_host.data_info,
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct DataThresholdExceeded {
     pub(crate) threshold: u64,

--- a/src/notifications/types/logged_notification.rs
+++ b/src/notifications/types/logged_notification.rs
@@ -1,13 +1,12 @@
+use crate::chart::types::chart_type::ChartType;
 use crate::networking::types::data_info::DataInfo;
 use crate::networking::types::data_info_host::DataInfoHost;
 use crate::networking::types::host::Host;
 
 /// Enum representing the possible notification events.
 pub enum LoggedNotification {
-    /// Packets threshold exceeded
-    PacketsThresholdExceeded(DataThresholdExceeded),
-    /// Byte threshold exceeded
-    BytesThresholdExceeded(DataThresholdExceeded),
+    /// Data threshold exceeded
+    DataThresholdExceeded(DataThresholdExceeded),
     /// Favorite connection exchanged data
     FavoriteTransmitted(FavoriteTransmitted),
 }
@@ -15,8 +14,7 @@ pub enum LoggedNotification {
 impl LoggedNotification {
     pub fn data_info(&self) -> DataInfo {
         match self {
-            LoggedNotification::BytesThresholdExceeded(d)
-            | LoggedNotification::PacketsThresholdExceeded(d) => d.data_info,
+            LoggedNotification::DataThresholdExceeded(d) => d.data_info,
             LoggedNotification::FavoriteTransmitted(f) => f.data_info_host.data_info,
         }
     }
@@ -24,6 +22,7 @@ impl LoggedNotification {
 
 #[derive(Clone)]
 pub struct DataThresholdExceeded {
+    pub(crate) chart_type: ChartType,
     pub(crate) threshold: u64,
     pub(crate) data_info: DataInfo,
     pub(crate) timestamp: String,

--- a/src/notifications/types/logged_notification.rs
+++ b/src/notifications/types/logged_notification.rs
@@ -1,29 +1,21 @@
+use crate::networking::types::data_info::DataInfo;
 use crate::networking::types::data_info_host::DataInfoHost;
 use crate::networking::types::host::Host;
 
 /// Enum representing the possible notification events.
 pub enum LoggedNotification {
     /// Packets threshold exceeded
-    PacketsThresholdExceeded(PacketsThresholdExceeded),
+    PacketsThresholdExceeded(DataThresholdExceeded),
     /// Byte threshold exceeded
-    BytesThresholdExceeded(BytesThresholdExceeded),
+    BytesThresholdExceeded(DataThresholdExceeded),
     /// Favorite connection exchanged data
     FavoriteTransmitted(FavoriteTransmitted),
 }
 
 #[derive(Clone)]
-pub struct PacketsThresholdExceeded {
-    pub(crate) threshold: u32,
-    pub(crate) incoming: u32,
-    pub(crate) outgoing: u32,
-    pub(crate) timestamp: String,
-}
-
-#[derive(Clone)]
-pub struct BytesThresholdExceeded {
+pub struct DataThresholdExceeded {
     pub(crate) threshold: u64,
-    pub(crate) incoming: u32,
-    pub(crate) outgoing: u32,
+    pub(crate) data_info: DataInfo,
     pub(crate) timestamp: String,
 }
 

--- a/src/notifications/types/notifications.rs
+++ b/src/notifications/types/notifications.rs
@@ -37,11 +37,11 @@ pub enum Notification {
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Debug, Copy)]
 pub struct PacketsNotification {
     /// Threshold of received + sent packets; if exceeded a notification is emitted
-    pub threshold: Option<u32>,
+    pub threshold: Option<u64>,
     /// The sound to emit
     pub sound: Sound,
     /// The last used Some value for the threshold field
-    pub previous_threshold: u32,
+    pub previous_threshold: u64,
 }
 
 impl Default for PacketsNotification {

--- a/src/report/types/report_col.rs
+++ b/src/report/types/report_col.rs
@@ -41,6 +41,8 @@ impl ReportCol {
         ReportCol::Packets,
     ];
 
+    pub(crate) const FILTER_COLUMNS_WIDTH: f32 = 4.0 * SMALL_COL_WIDTH + 2.0 * LARGE_COL_WIDTH;
+
     pub(crate) fn get_title(&self, language: Language) -> String {
         match self {
             ReportCol::SrcIp | ReportCol::DstIp => address_translation(language).to_string(),

--- a/src/translations/translations.rs
+++ b/src/translations/translations.rs
@@ -1971,32 +1971,32 @@ pub fn bytes_exceeded_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn bytes_exceeded_value_translation(language: Language, value: &str) -> String {
-    match language {
-        Language::EN => format!("{value} have been exchanged"),
-        Language::IT => format!("{value} sono stati scambiati"),
-        Language::FR => format!("{value} ont été échangé"),
-        Language::ES => format!("{value} han sido intercambiado/s"),
-        Language::PL => format!("Wymieniono {value}"),
-        Language::DE => format!("{value} wurden ausgetauscht"),
-        Language::UK => format!("{value} було обміняно"),
-        Language::ZH => format!("已交换字节 {value}"),
-        Language::ZH_TW => format!("已交換 {value} 位元組"),
-        Language::RO => format!("au fost transferați {value}"),
-        Language::KO => format!("바이트 {value} 가 교환되었습니다"),
-        Language::TR => format!("{value} aktarıldı"),
-        Language::RU => format!("{value} обмена информацией"),
-        Language::PT => format!("Foram trocados {value}"),
-        Language::EL => format!("{value} έχουν ανταλλαγεί"),
-        // Language::FA => format!("{value} بایت مبادله شده است"),
-        Language::SV => format!("{value} har utbytts"),
-        Language::FI => format!("{value} on vaihdettu"),
-        Language::JA => format!("{value} の送受信が発生しました"),
-        Language::UZ => format!("{value} ma'lumot almashinuvi"),
-        Language::VI => format!("{value} đã được trao đổi"),
-        Language::ID => format!("{value} telah dipertukarkan"),
-    }
-}
+// pub fn bytes_exceeded_value_translation(language: Language, value: &str) -> String {
+//     match language {
+//         Language::EN => format!("{value} have been exchanged"),
+//         Language::IT => format!("{value} sono stati scambiati"),
+//         Language::FR => format!("{value} ont été échangé"),
+//         Language::ES => format!("{value} han sido intercambiado/s"),
+//         Language::PL => format!("Wymieniono {value}"),
+//         Language::DE => format!("{value} wurden ausgetauscht"),
+//         Language::UK => format!("{value} було обміняно"),
+//         Language::ZH => format!("已交换字节 {value}"),
+//         Language::ZH_TW => format!("已交換 {value} 位元組"),
+//         Language::RO => format!("au fost transferați {value}"),
+//         Language::KO => format!("바이트 {value} 가 교환되었습니다"),
+//         Language::TR => format!("{value} aktarıldı"),
+//         Language::RU => format!("{value} обмена информацией"),
+//         Language::PT => format!("Foram trocados {value}"),
+//         Language::EL => format!("{value} έχουν ανταλλαγεί"),
+//         // Language::FA => format!("{value} بایت مبادله شده است"),
+//         Language::SV => format!("{value} har utbytts"),
+//         Language::FI => format!("{value} on vaihdettu"),
+//         Language::JA => format!("{value} の送受信が発生しました"),
+//         Language::UZ => format!("{value} ma'lumot almashinuvi"),
+//         Language::VI => format!("{value} đã được trao đổi"),
+//         Language::ID => format!("{value} telah dipertukarkan"),
+//     }
+// }
 
 pub fn packets_exceeded_translation(language: Language) -> &'static str {
     match language {
@@ -2025,56 +2025,56 @@ pub fn packets_exceeded_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn packets_exceeded_value_translation(language: Language, value: u32) -> String {
-    match language {
-        Language::EN => match value {
-            1 => "1 packet has been exchanged".to_owned(),
-            npackets => format!("{npackets} packets have been exchanged"),
-        },
-        Language::IT => match value {
-            1 => "1 pacchetto è stato scambiato".to_owned(),
-            npackets => format!("{npackets} pacchetti sono stati scambiati"),
-        },
-        Language::FR => match value {
-            1 => "1 paquet a été échangé".to_owned(),
-            npackets => format!("{npackets} paquets ont été échangés"),
-        },
-        Language::ES => format!("{value} paquete/s han sido intercambiado/s"),
-        Language::PL => format!("Wymieniono {value} pakietów"),
-        Language::DE => match value {
-            1 => "1 Paket wurde ausgetauscht".to_owned(),
-            npackets => format!("{npackets} Pakete wurden ausgetauscht"),
-        },
-        Language::UK => format!("Обміняно {value} пакетів"),
-        Language::ZH => format!("已交换数据包 {value}"),
-        Language::ZH_TW => format!("已交換 {value} 個封包"),
-        Language::RO => format!("au fost transferate {value} pachete"),
-        Language::KO => format!("패킷 {value} 가 교환되었습니다"),
-        Language::TR => format!("{value} paket aktarıldı"),
-        Language::RU => format!("{value} пакет(ов) обмена информацией"),
-        Language::PT => match value {
-            1 => "Foi trocado 1 pacote".to_owned(),
-            npackets => format!("Foram trocados {npackets} pacotes"),
-        },
-        Language::EL => match value {
-            1 => "1 πακέτο έχει ανταλλαγεί".to_owned(),
-            npackets => format!("{npackets} πακέτα έχουν ανταλλαγεί"),
-        },
-        // Language::FA => format!("{value} بسته مبادله شده است"),
-        Language::SV => match value {
-            1 => "1 paket har utbytts".to_owned(),
-            npackets => format!("{npackets} paket har utbytts"),
-        },
-        Language::FI => match value {
-            1 => "1 paketti vaihdettu".to_owned(),
-            npackets => format!("{npackets} pakettia vaihdettu"),
-        },
-        Language::JA => format!("{value} パケットの送受信が発生しました"),
-        Language::UZ => format!("{value} paket uzatildi"),
-        Language::VI => format!("{value} gói tin đã được trao đổi"),
-        Language::ID => format!("{value} paket telah dipertukarkan"),
-    }
-}
+// pub fn packets_exceeded_value_translation(language: Language, value: u32) -> String {
+//     match language {
+//         Language::EN => match value {
+//             1 => "1 packet has been exchanged".to_owned(),
+//             npackets => format!("{npackets} packets have been exchanged"),
+//         },
+//         Language::IT => match value {
+//             1 => "1 pacchetto è stato scambiato".to_owned(),
+//             npackets => format!("{npackets} pacchetti sono stati scambiati"),
+//         },
+//         Language::FR => match value {
+//             1 => "1 paquet a été échangé".to_owned(),
+//             npackets => format!("{npackets} paquets ont été échangés"),
+//         },
+//         Language::ES => format!("{value} paquete/s han sido intercambiado/s"),
+//         Language::PL => format!("Wymieniono {value} pakietów"),
+//         Language::DE => match value {
+//             1 => "1 Paket wurde ausgetauscht".to_owned(),
+//             npackets => format!("{npackets} Pakete wurden ausgetauscht"),
+//         },
+//         Language::UK => format!("Обміняно {value} пакетів"),
+//         Language::ZH => format!("已交换数据包 {value}"),
+//         Language::ZH_TW => format!("已交換 {value} 個封包"),
+//         Language::RO => format!("au fost transferate {value} pachete"),
+//         Language::KO => format!("패킷 {value} 가 교환되었습니다"),
+//         Language::TR => format!("{value} paket aktarıldı"),
+//         Language::RU => format!("{value} пакет(ов) обмена информацией"),
+//         Language::PT => match value {
+//             1 => "Foi trocado 1 pacote".to_owned(),
+//             npackets => format!("Foram trocados {npackets} pacotes"),
+//         },
+//         Language::EL => match value {
+//             1 => "1 πακέτο έχει ανταλλαγεί".to_owned(),
+//             npackets => format!("{npackets} πακέτα έχουν ανταλλαγεί"),
+//         },
+//         // Language::FA => format!("{value} بسته مبادله شده است"),
+//         Language::SV => match value {
+//             1 => "1 paket har utbytts".to_owned(),
+//             npackets => format!("{npackets} paket har utbytts"),
+//         },
+//         Language::FI => match value {
+//             1 => "1 paketti vaihdettu".to_owned(),
+//             npackets => format!("{npackets} pakettia vaihdettu"),
+//         },
+//         Language::JA => format!("{value} パケットの送受信が発生しました"),
+//         Language::UZ => format!("{value} paket uzatildi"),
+//         Language::VI => format!("{value} gói tin đã được trao đổi"),
+//         Language::ID => format!("{value} paket telah dipertukarkan"),
+//     }
+// }
 
 pub fn favorite_transmitted_translation(language: Language) -> &'static str {
     match language {


### PR DESCRIPTION
Improve the overall appearance of notifications page, and include more details for each notification:
- the list of involved hosts and services (for bytes/packets threshold notifications)
- the amount of exchanged data (for favourite notifications)

Fixes #637.