### PR TITLE
Fix: Container Running with Dangerous Root Access Permissions in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,7 @@ RUN apt-get update && apt-get install -y \
 
 COPY --from=builder /usr/src/sniffnet/target/release/sniffnet /usr/local/bin/sniffnet
 
+# Create a non-root user
+RUN groupadd -r sniffnet && useradd -r -g sniffnet sniffnet
+USER sniffnet
 ENTRYPOINT ["sniffnet"]


### PR DESCRIPTION
**Context and Purpose:**

This PR automatically remediates a security vulnerability:
- **Description:** By not specifying a USER, a program in the container may run as 'root'. This is a security hazard. If an attacker can control a process running as root, they may have control over the container. Ensure that the last USER in a Dockerfile is a USER other than 'root'.
- **Rule ID:** dockerfile.security.missing-user-entrypoint.missing-user-entrypoint
- **Severity:** MEDIUM
- **File:** Dockerfile
- **Lines Affected:** 34 - 34

This change is necessary to protect the application from potential security risks associated with this vulnerability.

**Solution Implemented:**

The automated remediation process has applied the necessary changes to the affected code in `Dockerfile` to resolve the identified issue.

Please review the changes to ensure they are correct and integrate as expected.