### PR TITLE
Add AppImage Packaging to CI

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -81,14 +81,13 @@ jobs:
 
       - name: Test (release mode)
         if: matrix.os == 'macos' || matrix.os == 'ubuntu' || matrix.os == 'windows' && matrix.arch == 'amd64'
-        run: cargo test --release --verbose -- --nocapture &&
+        run: |
+          cargo test --release --verbose -- --nocapture &&
+          cargo clean
 
       - name: Install Cross
         if: matrix.os == 'ubuntu'
         run: cargo install cross --git https://github.com/cross-rs/cross
-
-      - name: Clean
-        run: cargo clean
 
       - name: Build binary (Linux)
         if: matrix.os == 'ubuntu'

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -177,7 +177,6 @@ jobs:
           - arch: armhf
             appimgarch: armhf
 
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -195,7 +194,7 @@ jobs:
         shell: bash
         run: git clone https://github.com/AppImageCommunity/pkg2appimage.git
 
-      - name: Replace placeholders. pkg2appimage bundled implementation of apt update does not allow download of packages for different architectures by default. Override this.
+      - name: Replace placeholders
         shell: bash
         run: |
           sed -i -e 's/REPLACE_TAG/Sniffnet_LinuxDEB_${{ matrix.arch }}.deb/g' resources/packaging/linux/AppImage/sniffnet.yml
@@ -208,8 +207,6 @@ jobs:
           ARCH=${{ matrix.appimgarch }} FUNCTIONS_SH=$(pwd)/functions.sh ./pkg2appimage ../resources/packaging/linux/AppImage/sniffnet.yml
           mkdir /out
           mv out/*.AppImage /out/Sniffnet_LinuxAppImage_${{ matrix.arch }}.AppImage
-          ls -lah /out
-          pwd
 
       - name: Upload package artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -81,13 +81,14 @@ jobs:
 
       - name: Test (release mode)
         if: matrix.os == 'macos' || matrix.os == 'ubuntu' || matrix.os == 'windows' && matrix.arch == 'amd64'
-        run: |
-          cargo test --release --verbose -- --nocapture &&
-          cargo clean
+        run: cargo test --release --verbose -- --nocapture &&
 
       - name: Install Cross
         if: matrix.os == 'ubuntu'
         run: cargo install cross --git https://github.com/cross-rs/cross
+
+      - name: Clean
+        run: cargo clean
 
       - name: Build binary (Linux)
         if: matrix.os == 'ubuntu'
@@ -156,6 +157,66 @@ jobs:
         with:
           name: deb-${{ matrix.arch }}
           path: artifacts/
+          if-no-files-found: error
+
+  appimage:
+    runs-on: ubuntu-latest
+    container:
+      image: debian:latest
+      options: --privileged
+    needs: deb
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - arch: amd64
+            appimgarch: x86_64
+          - arch: arm64
+            appimgarch: aarch64
+          - arch: i386
+            appimgarch: i686
+          - arch: armhf
+            appimgarch: armhf
+
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: apt-get update -y && apt-get install -y git build-essential graphicsmagick-imagemagick-compat wget file desktop-file-utils libfuse2
+
+      - name: Download Debian package
+        uses: actions/download-artifact@v4
+        with:
+          name: deb-${{ matrix.arch }}
+          path: /target/
+
+      - name: Download pkg2appimage
+        shell: bash
+        run: git clone https://github.com/AppImageCommunity/pkg2appimage.git
+
+      - name: Replace placeholders. pkg2appimage bundled implementation of apt update does not allow download of packages for different architectures by default. Override this.
+        shell: bash
+        run: |
+          sed -i -e 's/REPLACE_TAG/Sniffnet_LinuxDEB_${{ matrix.arch }}.deb/g' resources/packaging/linux/AppImage/sniffnet.yml
+          sed -i -e 's/binary-${arch}/binary-${{ matrix.arch }}/g' pkg2appimage/functions.sh
+
+      - name: Repackage for AppImage
+        shell: bash
+        run: |
+          cd pkg2appimage
+          ARCH=${{ matrix.appimgarch }} FUNCTIONS_SH=$(pwd)/functions.sh ./pkg2appimage ../resources/packaging/linux/AppImage/sniffnet.yml
+          mkdir /out
+          mv out/*.AppImage /out/Sniffnet_LinuxAppImage_${{ matrix.arch }}.AppImage
+          ls -lah /out
+          pwd
+
+      - name: Upload package artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: appimage-${{ matrix.arch }}
+          path: /out/
           if-no-files-found: error
 
   rpm:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All Sniffnet releases with the relative changes are documented in this file.
 
 ## [UNRELEASED]
+- An AppImage of Sniffnet is now available ([#859](https://github.com/GyulyVGC/sniffnet/pull/859) — fixes [#900](https://github.com/GyulyVGC/sniffnet/issues/900))
 - Added Dutch translation 🇳🇱 ([#854](https://github.com/GyulyVGC/sniffnet/pull/854))
 - The Windows Installer is now signed with a code signing certificate provided by the [SignPath Foundation](https://signpath.org/) ([#897](https://github.com/GyulyVGC/sniffnet/pull/897) — fixes [#894](https://github.com/GyulyVGC/sniffnet/issues/894))
 - Updated some of the existing translations to v1.4: 

--- a/resources/packaging/linux/AppImage/sniffnet.yml
+++ b/resources/packaging/linux/AppImage/sniffnet.yml
@@ -1,0 +1,9 @@
+app: Sniffnet
+ingredients:
+  dist: bookworm
+  packages:
+    - libpcap0.8
+  sources:
+    - deb https://deb.debian.org/debian stable main
+  debs:
+    - /target/REPLACE_TAG


### PR DESCRIPTION
AppImage packaging using pkg2appimage to convert the Debian package into an AppImage as part of the packaging workflow.

As mentioned in #252 