### PR TITLE
Update CI/CD to sign the Windows Installer using SignPath

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -332,7 +332,7 @@ jobs:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
           organization-id: '3b533e02-73c3-4908-a018-d09a34498a6a'
           project-slug: 'sniffnet'
-          signing-policy-slug: 'test-signing'
+          signing-policy-slug: 'release-signing'
           github-artifact-id: '${{ steps.upload-unsigned-artifact.outputs.artifact-id }}'
           wait-for-completion: true
           output-artifact-directory: './artifacts'

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -318,9 +318,29 @@ jobs:
           cargo wix --no-build --nocapture --target ${{ matrix.target }}
           Move-Item -Path target\wix\sniffnet*.msi -Destination .\artifacts\Sniffnet_Windows_${{ matrix.arch }}.msi
 
-      - name: Upload package artifacts
+      - name: Upload unsigned package artifacts
+        id: upload-unsigned-artifact
         uses: actions/upload-artifact@v4
         with:
           name: msi-${{ matrix.arch }}
           path: artifacts/
           if-no-files-found: error
+
+      - name: Sign package artifacts
+        uses: signpath/github-action-submit-signing-request@v1.1
+        with:
+          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
+          organization-id: '3b533e02-73c3-4908-a018-d09a34498a6a'
+          project-slug: 'sniffnet'
+          signing-policy-slug: 'test-signing'
+          github-artifact-id: '${{ steps.upload-unsigned-artifact.outputs.artifact-id }}'
+          wait-for-completion: true
+          output-artifact-directory: './artifacts'
+
+      - name: Upload signed package artifacts (overwrite unsigned)
+        uses: actions/upload-artifact@v4
+        with:
+          name: msi-${{ matrix.arch }}
+          path: artifacts/
+          if-no-files-found: error
+          overwrite: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All Sniffnet releases with the relative changes are documented in this file.
 
 ## [UNRELEASED]
 - Added Dutch translation 🇳🇱 ([#854](https://github.com/GyulyVGC/sniffnet/pull/854))
+- The Windows Installer is now signed with a code signing certificate provided by the [SignPath Foundation](https://signpath.org/) ([#897](https://github.com/GyulyVGC/sniffnet/pull/897) — fixes [#894](https://github.com/GyulyVGC/sniffnet/issues/894))
 - Updated some of the existing translations to v1.4: 
   - German ([#833](https://github.com/GyulyVGC/sniffnet/pull/833))
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ ICED_BACKEND=tiny-skia
 - A big shout-out to [all the contributors](https://github.com/GyulyVGC/sniffnet/blob/main/CONTRIBUTORS.md) of Sniffnet!
 - The graphical user interface has been realized with [iced](https://github.com/iced-rs/iced), a cross-platform GUI library for Rust focused on simplicity and type-safety
 - IP geolocation and ASN data are provided by [MaxMind](https://www.maxmind.com)
+- Free code signing for Windows Installer is provided by [SignPath.io](https://about.signpath.io/), certificate by [SignPath Foundation](https://signpath.org/)
 - [Sniffnet](https://ads.fund/token/0xadfc251f8ef00ceaeca2b5c1882dabe5db0833df) project is supported by ADS.FUND
 - Last but not least, thanks to [every single stargazer](https://github.com/GyulyVGC/sniffnet/stargazers): all forms of support made it possible to keep improving Sniffnet!
 


### PR DESCRIPTION
For the past 3 years, Sniffnet Windows Installers were provided unsigned due to the fact that code signing certificates are quite expensive.

Today I'm so happy to announce that Sniffnet was declared eligible to receive a free code signing certificate from [SignPath](https://about.signpath.io), which as part of its activity provides  free certificates to open source projects matching some criteria.

Fixes #894.