### PR TITLE
Support `Linux SLL` link type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All Sniffnet releases with the relative changes are documented in this file.
 
 ## [UNRELEASED]
 - Enhanced traffic filtering capabilities: Berkeley Packet Filter ([#937](https://github.com/GyulyVGC/sniffnet/pull/937) — fixes [#810](https://github.com/GyulyVGC/sniffnet/issues/810))
+- Added support for `Linux SLL` link type, enabling to monitor the `any` interface on Linux ([#945](https://github.com/GyulyVGC/sniffnet/pull/945))
 - Added _bits_ data representation ([#936](https://github.com/GyulyVGC/sniffnet/pull/936) — fixes [#506](https://github.com/GyulyVGC/sniffnet/issues/506))
 - An AppImage of Sniffnet is now available ([#859](https://github.com/GyulyVGC/sniffnet/pull/859) — fixes [#900](https://github.com/GyulyVGC/sniffnet/issues/900))
 - Added Dutch translation 🇳🇱 ([#854](https://github.com/GyulyVGC/sniffnet/pull/854))

--- a/src/gui/pages/overview_page.rs
+++ b/src/gui/pages/overview_page.rs
@@ -23,7 +23,6 @@ use crate::networking::types::data_info::DataInfo;
 use crate::networking::types::data_info_host::DataInfoHost;
 use crate::networking::types::data_representation::DataRepr;
 use crate::networking::types::host::Host;
-use crate::networking::types::my_link_type::MyLinkType;
 use crate::networking::types::service::Service;
 use crate::report::get_report_entries::{get_host_entries, get_service_entries};
 use crate::report::types::search_parameters::SearchParameters;
@@ -145,7 +144,7 @@ fn body_no_packets<'a>(
                 .align_x(Alignment::Center)
                 .font(font),
         )
-    } else if cs.get_addresses().is_empty() && !matches!(link_type, MyLinkType::LinuxSll(_)) {
+    } else if cs.get_addresses().is_empty() {
         (
             Icon::Warning.to_text().size(60),
             no_addresses_translation(language, &cs_info)

--- a/src/gui/pages/overview_page.rs
+++ b/src/gui/pages/overview_page.rs
@@ -23,6 +23,7 @@ use crate::networking::types::data_info::DataInfo;
 use crate::networking::types::data_info_host::DataInfoHost;
 use crate::networking::types::data_representation::DataRepr;
 use crate::networking::types::host::Host;
+use crate::networking::types::my_link_type::MyLinkType;
 use crate::networking::types::service::Service;
 use crate::report::get_report_entries::{get_host_entries, get_service_entries};
 use crate::report::types::search_parameters::SearchParameters;
@@ -144,7 +145,7 @@ fn body_no_packets<'a>(
                 .align_x(Alignment::Center)
                 .font(font),
         )
-    } else if cs.get_addresses().is_empty() {
+    } else if cs.get_addresses().is_empty() && !matches!(link_type, MyLinkType::LinuxSll(_)) {
         (
             Icon::Warning.to_text().size(60),
             no_addresses_translation(language, &cs_info)

--- a/src/gui/sniffer.rs
+++ b/src/gui/sniffer.rs
@@ -799,13 +799,8 @@ impl Sniffer {
 
     fn fetch_devices(&mut self) {
         self.my_devices.clear();
+        self.capture_source.set_addresses();
         for dev in Device::list().log_err(location!()).unwrap_or_default() {
-            if matches!(&self.capture_source, CaptureSource::Device(_))
-                && dev.name.eq(&self.capture_source.get_name())
-            {
-                // refresh active addresses
-                self.capture_source.set_addresses(dev.addresses.clone());
-            }
             let my_dev = MyDevice::from_pcap_device(dev);
             self.my_devices.push(my_dev);
         }

--- a/src/gui/sniffer.rs
+++ b/src/gui/sniffer.rs
@@ -731,6 +731,7 @@ impl Sniffer {
             let mmdb_readers = self.mmdb_readers.clone();
             self.capture_source
                 .set_link_type(capture_context.my_link_type());
+            self.capture_source.set_addresses();
             let capture_source = self.capture_source.clone();
             self.traffic_chart
                 .change_capture_source(matches!(capture_source, CaptureSource::Device(_)));

--- a/src/networking/parse_packets.rs
+++ b/src/networking/parse_packets.rs
@@ -26,7 +26,7 @@ use crate::utils::types::timestamp::Timestamp;
 use async_channel::Sender;
 use dns_lookup::lookup_addr;
 use etherparse::LaxPacketHeaders;
-use pcap::{Address, Device, Packet};
+use pcap::{Address, Packet};
 use std::collections::HashMap;
 use std::net::IpAddr;
 use std::sync::{Arc, Mutex};
@@ -422,12 +422,7 @@ fn maybe_send_tick_run_live(
             new_hosts_to_send.lock().unwrap().drain(..).collect(),
             false,
         ));
-        for dev in Device::list().log_err(location!()).unwrap_or_default() {
-            if dev.name.eq(&cs.get_name()) {
-                cs.set_addresses(dev.addresses);
-                break;
-            }
-        }
+        cs.set_addresses();
     }
 }
 

--- a/src/networking/types/capture_context.rs
+++ b/src/networking/types/capture_context.rs
@@ -135,7 +135,7 @@ impl CaptureType {
                     } else {
                         200 // limit stored packets slice dimension (to keep more in the buffer)
                     })
-                    .immediate_mode(true) // parse packets ASAP
+                    .immediate_mode(false)
                     .timeout(150) // ensure UI is updated even if no packets are captured
                     .open()?;
                 Ok(Self::Live(cap))

--- a/src/networking/types/capture_context.rs
+++ b/src/networking/types/capture_context.rs
@@ -190,7 +190,10 @@ impl CaptureSource {
         if let Self::Device(my_device) = self {
             let mut addresses = Vec::new();
             for dev in Device::list().log_err(location!()).unwrap_or_default() {
-                if matches!(my_device.get_link_type(), MyLinkType::LinuxSll(_)) {
+                if matches!(
+                    my_device.get_link_type(),
+                    MyLinkType::LinuxSll(_) | MyLinkType::LinuxSll2(_)
+                ) {
                     addresses.extend(dev.addresses);
                 } else if dev.name.eq(my_device.get_name()) {
                     addresses.extend(dev.addresses);

--- a/src/networking/types/capture_context.rs
+++ b/src/networking/types/capture_context.rs
@@ -1,11 +1,13 @@
 use crate::gui::types::conf::Conf;
 use crate::gui::types::filters::Filters;
+use crate::location;
 use crate::networking::types::my_device::MyDevice;
 use crate::networking::types::my_link_type::MyLinkType;
 use crate::translations::translations::network_adapter_translation;
 use crate::translations::translations_4::capture_file_translation;
 use crate::translations::types::language::Language;
-use pcap::{Active, Address, Capture, Error, Packet, Savefile, Stat};
+use crate::utils::error_logger::{ErrorLogger, Location};
+use pcap::{Active, Address, Capture, Device, Error, Packet, Savefile, Stat};
 use serde::{Deserialize, Serialize};
 
 pub enum CaptureContext {
@@ -184,9 +186,18 @@ impl CaptureSource {
         }
     }
 
-    pub fn set_addresses(&mut self, addresses: Vec<Address>) {
-        if let Self::Device(device) = self {
-            device.set_addresses(addresses);
+    pub fn set_addresses(&mut self) {
+        if let Self::Device(my_device) = self {
+            let mut addresses = Vec::new();
+            for dev in Device::list().log_err(location!()).unwrap_or_default() {
+                if matches!(my_device.get_link_type(), MyLinkType::LinuxSll(_)) {
+                    addresses.extend(dev.addresses);
+                } else if dev.name.eq(my_device.get_name()) {
+                    addresses.extend(dev.addresses);
+                    break;
+                }
+            }
+            my_device.set_addresses(addresses);
         }
     }
 

--- a/src/networking/types/my_link_type.rs
+++ b/src/networking/types/my_link_type.rs
@@ -12,6 +12,7 @@ pub enum MyLinkType {
     Loop(Linktype),
     IPv4(Linktype),
     IPv6(Linktype),
+    LinuxSll(Linktype),
     Unsupported(Linktype),
     #[default]
     NotYetAssigned,
@@ -30,6 +31,8 @@ impl MyLinkType {
             Linktype::LOOP => Self::Loop(link_type),
             Linktype::IPV4 => Self::IPv4(link_type),
             Linktype::IPV6 => Self::IPv6(link_type),
+            Linktype::LINUX_SLL => Self::LinuxSll(link_type),
+            // TODO: also add Linktype::LINUX_SLL2 (???)
             _ => Self::Unsupported(link_type),
         }
     }
@@ -42,6 +45,7 @@ impl MyLinkType {
             | Self::Loop(l)
             | Self::IPv4(l)
             | Self::IPv6(l)
+            | Self::LinuxSll(l)
             | Self::Unsupported(l) => {
                 format!(
                     "{}: {} ({})",

--- a/src/networking/types/my_link_type.rs
+++ b/src/networking/types/my_link_type.rs
@@ -13,6 +13,7 @@ pub enum MyLinkType {
     IPv4(Linktype),
     IPv6(Linktype),
     LinuxSll(Linktype),
+    LinuxSll2(Linktype),
     Unsupported(Linktype),
     #[default]
     NotYetAssigned,
@@ -32,7 +33,7 @@ impl MyLinkType {
             Linktype::IPV4 => Self::IPv4(link_type),
             Linktype::IPV6 => Self::IPv6(link_type),
             Linktype::LINUX_SLL => Self::LinuxSll(link_type),
-            // TODO: also add Linktype::LINUX_SLL2 (???)
+            Linktype::LINUX_SLL2 => Self::LinuxSll2(link_type),
             _ => Self::Unsupported(link_type),
         }
     }
@@ -46,6 +47,7 @@ impl MyLinkType {
             | Self::IPv4(l)
             | Self::IPv6(l)
             | Self::LinuxSll(l)
+            | Self::LinuxSll2(l)
             | Self::Unsupported(l) => {
                 format!(
                     "{}: {} ({})",


### PR DESCRIPTION
Support [`Linux SLL`](https://wiki.wireshark.org/SLL) link type.

This finally makes it possible for Linux users to monitor the `any` interface, which is a pseudo device allowing to capture data on all the available interfaces.

This PR partially addresses #422.

***

In the initial implementation I tried to use `etherparse`'s [`LaxPacketHeaders::from_linux_sll`](https://docs.rs/etherparse/latest/etherparse/struct.LaxPacketHeaders.html#method.from_linux_sll) method, but it has some limitations:
- only supports `Linux SLL` version 1
- doesn't work with `NULL` / `LOOPBACK` traffic

So in the end I decided to manually extract the `protocol type` field from the header to overcome such limitations.