### PR TITLE
fix wrapper script to use relative path on macos

### DIFF
--- a/resources/packaging/macos/wrapper.sh
+++ b/resources/packaging/macos/wrapper.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env zsh
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
 SNIFFNET_PATH="$SCRIPT_DIR/sniffnet"
 osascript -e "do shell script \"'$SNIFFNET_PATH' >/dev/null 2>&1 &\" with prompt \"Comfortably monitor your Internet traffic.\" with administrator privileges"

--- a/resources/packaging/macos/wrapper.sh
+++ b/resources/packaging/macos/wrapper.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env zsh
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SNIFFNET_PATH="$SCRIPT_DIR/sniffnet"
-osascript -e "do shell script \"'$(realpath "$SNIFFNET_PATH")' >/dev/null 2>&1 &\" with prompt \"Comfortably monitor your Internet traffic.\" with administrator privileges"
+osascript -e "do shell script \"'$SNIFFNET_PATH' >/dev/null 2>&1 &\" with prompt \"Comfortably monitor your Internet traffic.\" with administrator privileges"

--- a/resources/packaging/macos/wrapper.sh
+++ b/resources/packaging/macos/wrapper.sh
@@ -1,2 +1,4 @@
 #!/usr/bin/env zsh
-osascript -e 'do shell script "/*/Sniffnet.app/Contents/MacOS/sniffnet >/dev/null 2>&1 &" with prompt "Comfortably monitor your Internet traffic." with administrator privileges'
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SNIFFNET_PATH="$SCRIPT_DIR/sniffnet"
+osascript -e "do shell script \"'$(realpath "$SNIFFNET_PATH")' >/dev/null 2>&1 &\" with prompt \"Comfortably monitor your Internet traffic.\" with administrator privileges"


### PR DESCRIPTION
## Summary

Fixes the macOS wrapper script to use relative paths instead of absolute paths, allowing the Sniffnet app to run from any location without requiring installation in the Applications folder.

## Changes

1. Modified wrapper.sh to dynamically detect script directory using $(cd "$(dirname "$0")" && pwd)
2. Changed from hardcoded /*/Sniffnet.app/Contents/MacOS/sniffnet to relative path resolution
3. Used realpath to properly expand the path before passing to osascript to avoid variable expansion issues

## Test plan

1. Verified path resolution works correctly from different directories
2. Confirmed osascript command formation is valid
3. Tested that the script no longer depends on specific installation location


Fixes: #898 