### PR TITLE
Add spanish translations to sniffnet v1.4

### DIFF
--- a/src/translations/translations_4.rs
+++ b/src/translations/translations_4.rs
@@ -13,6 +13,7 @@ pub fn reserved_address_translation(language: Language, info: &str) -> String {
         Language::UK => format!("Зарезервована адреса ({info})"),
         Language::ZH_TW => format!("保留的網路位址 ({info})"),
         Language::NL => format!("Gereserveerd adres ({info})"),
+        Language::ES => format!("Dirección reservada ({info})"),
         _ => format!("Reserved address ({info})"),
     }
 }
@@ -23,6 +24,7 @@ pub fn share_feedback_translation(language: Language) -> &'static str {
         Language::IT => "Condividi il tuo feedback",
         Language::ZH_TW => "分享您的意見回饋",
         Language::NL => "Deel uw feedback",
+        Language::ES => "Comparte tus comentarios",
         _ => "Share your feedback",
     }
 }
@@ -34,6 +36,7 @@ pub fn excluded_translation(language: Language) -> &'static str {
         Language::IT => "Esclusi",
         Language::ZH_TW => "已排除",
         Language::NL => "Uitgesloten",
+        Language::ES => "Excluidos",
         _ => "Excluded",
     }
 }
@@ -43,6 +46,7 @@ pub fn import_capture_translation(language: Language) -> &'static str {
         Language::EN => "Import capture file",
         Language::IT => "Importa file di cattura",
         Language::NL => "Importeer capture bestand",
+        Language::ES => "Importar archivo de captura",
         _ => "Import capture file",
     }
 }
@@ -52,6 +56,7 @@ pub fn select_capture_translation(language: Language) -> &'static str {
         Language::EN => "Select capture file",
         Language::IT => "Seleziona file di cattura",
         Language::NL => "Selecteer capture bestand",
+        Language::ES => "Seleccionar archivo de captura",
         _ => "Select capture file",
     }
 }
@@ -74,6 +79,11 @@ pub fn reading_from_pcap_translation<'a>(language: Language, file: &str) -> Text
                                  {file_name_translation}: {file}\n\n\
                                  Weet je zeker dat het geselecteerde bestand niet leeg is?"
         ),
+        Language::ES => format!(
+            "Leyendo paquetes desde el archivo...\n\n\
+             {file_name_translation}: {file}\n\n\
+             ¿Seguro que el archivo seleccionado no está vacío?"
+        ),
         _ => format!(
             "Reading packets from file...\n\n\
                                  {file_name_translation}: {file}\n\n\
@@ -87,6 +97,7 @@ pub fn data_exceeded_translation(language: Language) -> &'static str {
         Language::EN => "Data threshold exceeded",
         Language::IT => "Soglia di dati superata",
         Language::NL => "Gegevenslimiet overschreden",
+        Language::ES => "Umbral de datos superado",
         _ => "Data threshold exceeded",
     }
 }
@@ -97,6 +108,7 @@ pub fn bits_exceeded_translation(language: Language) -> &'static str {
         Language::EN => "Bits threshold exceeded",
         Language::IT => "Soglia di bit superata",
         Language::NL => "Bits limiet overschreden",
+        Language::ES => "Umbral de bits superado",
         _ => "Bits threshold exceeded",
     }
 }
@@ -104,7 +116,7 @@ pub fn bits_exceeded_translation(language: Language) -> &'static str {
 #[allow(dead_code)]
 pub fn bits_translation(language: Language) -> &'static str {
     match language {
-        Language::EN | Language::IT => "Bits",
+        Language::EN | Language::IT | Language::ES => "Bits",
         Language::NL => "Bits",
         _ => "Bits",
     }
@@ -114,7 +126,7 @@ pub fn bits_translation(language: Language) -> &'static str {
 pub fn pause_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "Pause",
-        Language::IT => "Pausa",
+        Language::IT | Language::ES => "Pausa",
         Language::NL => "Pauzeren",
         _ => "Pause",
     }
@@ -126,6 +138,7 @@ pub fn resume_translation(language: Language) -> &'static str {
         Language::EN => "Resume",
         Language::IT => "Riprendi",
         Language::NL => "Hervatten",
+        Language::ES => "Reanudar",
         _ => "Resume",
     }
 }


### PR DESCRIPTION
## Description
This PR introduces Spanish (Language::ES) translations across the user interface. The goal is to make Sniffnet more accessible to Spanish-speaking users while keeping translations natural and consistent with the network monitoring context.

## Changes
- Added Language::ES branches in translation functions
- Verified that terms align with network monitoring terminology (e.g. “Dirección reservada”, “Umbral de datos superado”, “Reanudar”).

- Ensured style and tone are consistent with existing Italian/Dutch/English translations.