### PR TITLE
Fix AppImage error with `libpcap`

### DIFF
--- a/resources/packaging/linux/AppImage/sniffnet.yml
+++ b/resources/packaging/linux/AppImage/sniffnet.yml
@@ -1,8 +1,8 @@
 app: Sniffnet
 ingredients:
-  dist: bookworm
+  dist: trixie
   packages:
-    - libpcap0.8
+    - libpcap0.8t64
   sources:
     - deb https://deb.debian.org/debian stable main
   debs:

--- a/resources/packaging/linux/AppImage/sniffnet.yml
+++ b/resources/packaging/linux/AppImage/sniffnet.yml
@@ -1,9 +1,9 @@
 app: Sniffnet
 ingredients:
-  dist: trixie
+  dist: buster
   packages:
-    - libpcap0.8t64
+    - libpcap0.8
   sources:
-    - deb https://deb.debian.org/debian stable main
+    - deb https://archive.debian.org/debian buster main
   debs:
     - /target/REPLACE_TAG


### PR DESCRIPTION
https://github.com/GyulyVGC/sniffnet/pull/859#issuecomment-3303347936 Seems to have been caused by Debian 13 changing the name of the libpcap package. I've updated the manifest to use the new name.