### PR TITLE
Fix #639: disable background tooltips

### DIFF
--- a/src/countries/country_utils.rs
+++ b/src/countries/country_utils.rs
@@ -1,5 +1,5 @@
 use iced::Font;
-use iced::widget::Tooltip;
+use iced::{Element};
 use iced::widget::svg::Handle;
 use iced::widget::tooltip::Position;
 use iced::widget::{Svg, Text};
@@ -22,6 +22,7 @@ use crate::countries::types::country::Country;
 use crate::gui::styles::container::ContainerType;
 use crate::gui::styles::svg::SvgType;
 use crate::gui::types::message::Message;
+use crate::gui::components::types::my_tooltip::MyTooltip;
 use crate::networking::types::data_info_host::DataInfoHost;
 use crate::networking::types::traffic_type::TrafficType;
 use crate::translations::translations_2::{
@@ -324,7 +325,8 @@ pub fn get_flag_tooltip<'a>(
     language: Language,
     font: Font,
     thumbnail: bool,
-) -> Tooltip<'a, Message, StyleType> {
+    show_tooltip: bool,
+) -> Element<'a, Message, StyleType> {
     let width = if thumbnail {
         FLAGS_WIDTH_SMALL
     } else {
@@ -350,17 +352,16 @@ pub fn get_flag_tooltip<'a>(
     } else {
         ContainerType::Tooltip
     };
-    let mut tooltip = Tooltip::new(
+    let tooltip = MyTooltip::new(
         content,
         Text::new(actual_tooltip).font(font),
-        Position::FollowCursor,
     )
-    .snap_within_viewport(true)
-    .class(tooltip_style);
-
-    if width == FLAGS_WIDTH_SMALL {
-        tooltip = tooltip.padding(3);
-    }
+    .enabled(show_tooltip)
+    .position(Position::FollowCursor)
+    .style(tooltip_style)
+    .snap_within_viewport()
+    .padding(if width == FLAGS_WIDTH_SMALL { 3.0 } else { 5.0 })
+    .build();
 
     tooltip
 }
@@ -372,7 +373,8 @@ pub fn get_computer_tooltip<'a>(
     traffic_type: TrafficType,
     language: Language,
     font: Font,
-) -> Tooltip<'a, Message, StyleType> {
+    show_tooltip: bool,
+) -> Element<'a, Message, StyleType> {
     let content = Svg::new(Handle::from_memory(Vec::from(
         match (is_my_address, is_local, is_bogon, traffic_type) {
             (true, _, _, _) => COMPUTER,
@@ -396,11 +398,10 @@ pub fn get_computer_tooltip<'a>(
         (false, false, None, TrafficType::Unicast) => unknown_translation(language).to_string(),
     };
 
-    Tooltip::new(
-        content,
-        Text::new(tooltip).font(font),
-        Position::FollowCursor,
-    )
-    .snap_within_viewport(true)
-    .class(ContainerType::Tooltip)
+    MyTooltip::new(content, Text::new(tooltip).font(font))
+        .enabled(show_tooltip)
+        .position(Position::FollowCursor)
+        .style(ContainerType::Tooltip)
+        .snap_within_viewport()
+        .build()
 }

--- a/src/gui/components/button.rs
+++ b/src/gui/components/button.rs
@@ -1,10 +1,12 @@
 #![allow(clippy::module_name_repetitions)]
 
+use iced::Element;
 use iced::widget::text::LineHeight;
 use iced::widget::tooltip::Position;
-use iced::widget::{Row, Text, Tooltip, button};
+use iced::widget::{Row, Text, button};
 use iced::{Alignment, Font};
 
+use crate::gui::components::types::my_tooltip::MyTooltip;
 use crate::gui::styles::container::ContainerType;
 use crate::gui::styles::text::TextType;
 use crate::gui::types::message::Message;
@@ -17,25 +19,28 @@ pub fn button_hide<'a>(
     message: Message,
     language: Language,
     font: Font,
-) -> Tooltip<'a, Message, StyleType> {
-    Tooltip::new(
-        button(
-            Text::new("×")
-                .font(font)
-                .align_y(Alignment::Center)
-                .align_x(Alignment::Center)
-                .size(15)
-                .line_height(LineHeight::Relative(1.0)),
-        )
-        .padding(2)
-        .height(20)
-        .width(20)
-        .on_press(message),
-        Text::new(hide_translation(language)).font(font),
-        Position::Right,
+    show_tooltip: bool,
+) -> Element<'a, Message, StyleType> {
+    let content = button(
+        Text::new("×")
+            .font(font)
+            .align_y(Alignment::Center)
+            .align_x(Alignment::Center)
+            .size(15)
+            .line_height(LineHeight::Relative(1.0)),
     )
-    .gap(5)
-    .class(ContainerType::Tooltip)
+    .padding(2)
+    .height(20)
+    .width(20)
+    .on_press(message);
+
+    MyTooltip::new(content, Text::new(hide_translation(language)).font(font))
+        .enabled(true)
+        .position(Position::Right)
+        .gap(5.0)
+        .style(ContainerType::Tooltip)
+        .enabled(show_tooltip)
+        .build()
 }
 
 pub fn button_open_file<'a>(
@@ -45,7 +50,8 @@ pub fn button_open_file<'a>(
     font: Font,
     is_editable: bool,
     action: fn(String) -> Message,
-) -> Tooltip<'a, Message, StyleType> {
+    show_tooltip: bool,
+) -> Element<'a, Message, StyleType> {
     let mut tooltip_str = "";
     let mut tooltip_style = ContainerType::Standard;
 
@@ -66,9 +72,12 @@ pub fn button_open_file<'a>(
         button = button.on_press(Message::OpenFile(old_file, file_info, action));
     }
 
-    Tooltip::new(button, Text::new(tooltip_str).font(font), Position::Right)
-        .gap(5)
-        .class(tooltip_style)
+    MyTooltip::new(button, Text::new(tooltip_str).font(font))
+        .enabled(show_tooltip)
+        .position(Position::Right)
+        .gap(5.0)
+        .style(tooltip_style)
+        .build()
 }
 
 pub fn row_open_link_tooltip<'a>(text: &'static str, font: Font) -> Row<'a, Message, StyleType> {

--- a/src/gui/components/footer.rs
+++ b/src/gui/components/footer.rs
@@ -1,12 +1,14 @@
 //! GUI bottom footer
 
+use iced::Element;
 use iced::widget::text::LineHeight;
 use iced::widget::tooltip::Position;
-use iced::widget::{Column, Container, Row, Text, Tooltip, button, rich_text, span};
+use iced::widget::{Column, Container, Row, Text, button, rich_text, span};
 use iced::widget::{Space, horizontal_space};
 use iced::{Alignment, Font, Length, Padding};
 
 use crate::gui::components::button::row_open_link_tooltip;
+use crate::gui::components::types::my_tooltip::MyTooltip;
 use crate::gui::styles::button::ButtonType;
 use crate::gui::styles::container::ContainerType;
 use crate::gui::styles::style_constants::{FONT_SIZE_FOOTER, FONT_SIZE_SUBTITLE};
@@ -28,6 +30,7 @@ pub fn footer<'a>(
     font_footer: Font,
     newer_release_available: Option<bool>,
     dots_pulse: &(String, u8),
+    show_tooltips: bool,
 ) -> Container<'a, Message, StyleType> {
     if thumbnail {
         return thumbnail_footer();
@@ -39,6 +42,7 @@ pub fn footer<'a>(
         font_footer,
         newer_release_available,
         &dots_pulse.0,
+        show_tooltips,
     );
 
     let heart_size = match dots_pulse.1 {
@@ -52,11 +56,11 @@ pub fn footer<'a>(
         .padding([0, 20])
         .align_y(Alignment::Center)
         .push(release_details_row)
-        .push(get_button_feedback(font))
-        .push(get_button_wiki(font))
-        .push(get_button_github(font))
-        .push(get_button_news(font))
-        .push(get_button_sponsor(font))
+        .push(get_button_feedback(font, show_tooltips))
+        .push(get_button_wiki(font, show_tooltips))
+        .push(get_button_github(font, show_tooltips))
+        .push(get_button_news(font, show_tooltips))
+        .push(get_button_sponsor(font, show_tooltips))
         .push(
             Column::new()
                 .width(Length::Fill)
@@ -97,7 +101,7 @@ pub fn footer<'a>(
         .class(ContainerType::Gradient(color_gradient))
 }
 
-fn get_button_feedback<'a>(font: Font) -> Tooltip<'a, Message, StyleType> {
+fn get_button_feedback<'a>(font: Font, show_tooltip: bool) -> Element<'a, Message, StyleType> {
     let content = button(
         Icon::Roadmap
             .to_text()
@@ -111,16 +115,15 @@ fn get_button_feedback<'a>(font: Font) -> Tooltip<'a, Message, StyleType> {
     .width(30)
     .on_press(Message::OpenWebPage(WebPage::Roadmap));
 
-    Tooltip::new(
-        content,
-        row_open_link_tooltip("Roadmap", font),
-        Position::Top,
-    )
-    .gap(10)
-    .class(ContainerType::Tooltip)
+    MyTooltip::new(content, row_open_link_tooltip("Roadmap", font))
+        .enabled(show_tooltip)
+        .position(Position::Top)
+        .gap(10.0)
+        .style(ContainerType::Tooltip)
+        .build()
 }
 
-fn get_button_wiki<'a>(font: Font) -> Tooltip<'a, Message, StyleType> {
+fn get_button_wiki<'a>(font: Font, show_tooltip: bool) -> Element<'a, Message, StyleType> {
     let content = button(
         Icon::Book
             .to_text()
@@ -134,12 +137,15 @@ fn get_button_wiki<'a>(font: Font) -> Tooltip<'a, Message, StyleType> {
     .width(35)
     .on_press(Message::OpenWebPage(WebPage::Wiki));
 
-    Tooltip::new(content, row_open_link_tooltip("Wiki", font), Position::Top)
+    MyTooltip::new(content, row_open_link_tooltip("Wiki", font))
+        .enabled(show_tooltip)
+        .position(Position::Top)
         .gap(7.5)
-        .class(ContainerType::Tooltip)
+        .style(ContainerType::Tooltip)
+        .build()
 }
 
-fn get_button_github<'a>(font: Font) -> Tooltip<'a, Message, StyleType> {
+fn get_button_github<'a>(font: Font, show_tooltip: bool) -> Element<'a, Message, StyleType> {
     let content = button(
         Icon::GitHub
             .to_text()
@@ -152,16 +158,15 @@ fn get_button_github<'a>(font: Font) -> Tooltip<'a, Message, StyleType> {
     .width(40)
     .on_press(Message::OpenWebPage(WebPage::Repo));
 
-    Tooltip::new(
-        content,
-        row_open_link_tooltip("GitHub", font),
-        Position::Top,
-    )
-    .gap(5)
-    .class(ContainerType::Tooltip)
+    MyTooltip::new(content, row_open_link_tooltip("Github", font))
+        .enabled(show_tooltip)
+        .position(Position::Top)
+        .gap(5.0)
+        .style(ContainerType::Tooltip)
+        .build()
 }
 
-fn get_button_news<'a>(font: Font) -> Tooltip<'a, Message, StyleType> {
+fn get_button_news<'a>(font: Font, show_tooltip: bool) -> Element<'a, Message, StyleType> {
     let content = button(
         Icon::News
             .to_text()
@@ -174,12 +179,15 @@ fn get_button_news<'a>(font: Font) -> Tooltip<'a, Message, StyleType> {
     .width(35)
     .on_press(Message::OpenWebPage(WebPage::WebsiteNews));
 
-    Tooltip::new(content, row_open_link_tooltip("News", font), Position::Top)
+    MyTooltip::new(content, row_open_link_tooltip("News", font))
+        .enabled(show_tooltip)
+        .position(Position::Top)
         .gap(7.5)
-        .class(ContainerType::Tooltip)
+        .style(ContainerType::Tooltip)
+        .build()
 }
 
-fn get_button_sponsor<'a>(font: Font) -> Tooltip<'a, Message, StyleType> {
+fn get_button_sponsor<'a>(font: Font, show_tooltip: bool) -> Element<'a, Message, StyleType> {
     let content = button(
         Text::new('❤'.to_string())
             .font(font)
@@ -194,13 +202,12 @@ fn get_button_sponsor<'a>(font: Font) -> Tooltip<'a, Message, StyleType> {
     .width(30)
     .on_press(Message::OpenWebPage(WebPage::WebsiteSponsor));
 
-    Tooltip::new(
-        content,
-        row_open_link_tooltip("Sponsor", font),
-        Position::Top,
-    )
-    .gap(10)
-    .class(ContainerType::Tooltip)
+    MyTooltip::new(content, row_open_link_tooltip("Sponsor", font))
+        .enabled(show_tooltip)
+        .position(Position::Top)
+        .gap(10.0)
+        .style(ContainerType::Tooltip)
+        .build()
 }
 
 fn get_release_details<'a>(
@@ -209,6 +216,7 @@ fn get_release_details<'a>(
     font_footer: Font,
     newer_release_available: Option<bool>,
     dots: &str,
+    show_tooltip: bool,
 ) -> Row<'a, Message, StyleType> {
     let mut ret_val = Row::new()
         .align_y(Alignment::Center)
@@ -240,13 +248,17 @@ fn get_release_details<'a>(
             .width(35)
             .class(ButtonType::Alert)
             .on_press(Message::OpenWebPage(WebPage::WebsiteDownload));
-            let tooltip = Tooltip::new(
+
+            let tooltip = MyTooltip::new(
                 button,
                 row_open_link_tooltip(new_version_available_translation(language), font),
-                Position::Top,
             )
+            .enabled(show_tooltip)
+            .position(Position::Top)
             .gap(7.5)
-            .class(ContainerType::Tooltip);
+            .style(ContainerType::Tooltip)
+            .build();
+
             ret_val = ret_val.push(Space::with_width(10)).push(tooltip);
         } else {
             // this is the latest release

--- a/src/gui/components/modal.rs
+++ b/src/gui/components/modal.rs
@@ -100,7 +100,7 @@ fn get_modal_header<'a>(
                     .align_x(Alignment::Center),
             )
             .push(
-                Container::new(button_hide(Message::HideModal, language, font))
+                Container::new(button_hide(Message::HideModal, language, font, true))
                     .width(Length::Fill)
                     .align_x(Alignment::Center),
             ),

--- a/src/gui/components/types/mod.rs
+++ b/src/gui/components/types/mod.rs
@@ -1,1 +1,2 @@
 pub mod my_modal;
+pub mod my_tooltip;

--- a/src/gui/components/types/my_tooltip.rs
+++ b/src/gui/components/types/my_tooltip.rs
@@ -1,0 +1,81 @@
+use iced::widget::{Tooltip, Container};
+use iced::widget::tooltip::Position;
+use iced::Element;
+
+use crate::gui::styles::container::ContainerType;
+use crate::gui::types::message::Message;
+use crate::gui::styles::types::style_type::StyleType;
+
+pub struct MyTooltip<'a> {
+    content: Element<'a, Message, StyleType>,
+    label: Element<'a, Message, StyleType>,
+    position: Position,
+    gap: f32,
+    padding: f32,
+    enabled: bool,
+    style: ContainerType,
+    snap_within_viewport: bool,
+}
+
+impl<'a> MyTooltip<'a> {
+    pub fn new(
+        content: impl Into<Element<'a, Message, StyleType>>,
+        label: impl Into<Element<'a, Message, StyleType>>,
+    ) -> Self {
+        Self {
+            content: content.into(),
+            label: label.into(),
+            position: Position::Right,
+            gap: 0.0,
+            padding: 5.0,
+            enabled: true,
+            style: ContainerType::Tooltip,
+            snap_within_viewport: false,
+        }
+    }
+
+    pub fn position(mut self, position: Position) -> Self {
+        self.position = position;
+        self
+    }
+
+    pub fn gap(mut self, gap: f32) -> Self {
+        self.gap = gap;
+        self
+    }
+
+    pub fn enabled(mut self, enabled: bool) -> Self {
+        self.enabled = enabled;
+        self
+    }
+
+    pub fn style(mut self, style: ContainerType) -> Self {
+        self.style = style;
+        self
+    }
+
+    pub fn padding(mut self, padding: f32) -> Self {
+        self.padding = padding;
+        self
+    }
+
+    pub fn snap_within_viewport(mut self) -> Self {
+        self.snap_within_viewport = true;
+        self
+    }
+
+    pub fn build(self) -> Element<'a, Message, StyleType> {
+        if self.enabled {
+            Tooltip::new(self.content, self.label, self.position)
+                .gap(self.gap)
+                .class(self.style)
+                .padding(self.padding)
+                .snap_within_viewport(self.snap_within_viewport)
+                .into()
+        } else {
+            Container::new(self.content)
+                .class(ContainerType::Transparent)
+                .into()
+        }
+    }
+}

--- a/src/gui/pages/initial_page.rs
+++ b/src/gui/pages/initial_page.rs
@@ -49,6 +49,7 @@ pub fn initial_page(sniffer: &Sniffer) -> Container<'_, Message, StyleType> {
     let font_headers = style.get_extension().font_headers;
 
     let col_data_source = get_col_data_source(sniffer, font, language);
+    let show_tooltips = sniffer.settings_page.is_none() && sniffer.modal.is_none();
 
     let col_checkboxes = Column::new()
         .spacing(10)
@@ -58,6 +59,7 @@ pub fn initial_page(sniffer: &Sniffer) -> Container<'_, Message, StyleType> {
             &sniffer.conf.export_pcap,
             language,
             font,
+            show_tooltips,
         ));
 
     let is_capture_source_consistent = sniffer.is_capture_source_consistent();
@@ -119,6 +121,7 @@ fn get_col_data_source(
     } else {
         capture_file_translation(language)
     };
+    let show_tooltip = sniffer.settings_page.is_none() && sniffer.modal.is_none();
     let picklist = PickList::new(
         [
             network_adapter_translation(language),
@@ -164,6 +167,7 @@ fn get_col_data_source(
                 font,
                 &sniffer.capture_source,
                 &sniffer.conf.import_pcap_path,
+                show_tooltip,
             ));
         }
     }
@@ -258,7 +262,7 @@ fn get_col_adapter(
                                     ButtonType::BorderedRound
                                 },
                             )
-                            .on_press(Message::DeviceSelection(name.clone())),
+                            .on_press(Message::DeviceSelection(name.to_string())),
                         )
                     },
                 ),
@@ -272,7 +276,8 @@ fn get_col_import_pcap<'a>(
     language: Language,
     font: Font,
     cs: &CaptureSource,
-    path: &str,
+    path: &String,
+    show_tooltip: bool,
 ) -> Column<'a, Message, StyleType> {
     let is_import_pcap_set = matches!(cs, CaptureSource::File(_));
 
@@ -280,12 +285,13 @@ fn get_col_import_pcap<'a>(
         .align_y(Alignment::Center)
         .push(Text::new(get_path_termination_string(path, 25)).font(font))
         .push(button_open_file(
-            path.to_string(),
+            path.clone(),
             FileInfo::PcapImport,
             language,
             font,
             true,
             Message::SetPcapImport,
+            show_tooltip,
         ));
 
     let content = Column::new()
@@ -355,6 +361,7 @@ fn get_export_pcap_group_maybe<'a>(
     export_pcap: &ExportPcap,
     language: Language,
     font: Font,
+    show_tooltip: bool,
 ) -> Option<Container<'a, Message, StyleType>> {
     if cs_pick == CaptureSourcePicklist::File {
         return None;
@@ -401,6 +408,7 @@ fn get_export_pcap_group_maybe<'a>(
                         font,
                         true,
                         Message::OutputPcapDir,
+                        show_tooltip,
                     )),
             );
         ret_val = ret_val.push(inner_col);

--- a/src/gui/pages/inspect_page.rs
+++ b/src/gui/pages/inspect_page.rs
@@ -6,13 +6,14 @@ use iced::widget::text_input::Side;
 use iced::widget::tooltip::Position;
 use iced::widget::{Button, Column, Container, Row, Scrollable, Text, TextInput};
 use iced::widget::{
-    ComboBox, Rule, Space, Toggler, Tooltip, button, combo_box, horizontal_space, text_input,
+    ComboBox, Rule, Space, Toggler, button, combo_box, horizontal_space, text_input,
     vertical_space,
 };
 use iced::{Alignment, Font, Length, Padding, Pixels, alignment};
 
 use crate::gui::components::tab::get_pages_tabs;
 use crate::gui::components::types::my_modal::MyModal;
+use crate::gui::components::types::my_tooltip::MyTooltip;
 use crate::gui::pages::overview_page::{get_bars, get_bars_length};
 use crate::gui::styles::button::ButtonType;
 use crate::gui::styles::container::ContainerType;
@@ -78,6 +79,7 @@ pub fn inspect_page(sniffer: &Sniffer) -> Container<'_, Message, StyleType> {
             font,
             sniffer.conf.report_sort_type,
             sniffer.traffic_chart.data_repr,
+            sniffer.settings_page.is_none() && sniffer.modal.is_none(),
         ))
         .push(Space::with_height(4))
         .push(Rule::horizontal(5))
@@ -187,6 +189,7 @@ fn report_header_row(
     font: Font,
     sort_type: SortType,
     data_repr: DataRepr,
+    show_tooltip: bool,
 ) -> Row<'_, Message, StyleType> {
     let mut ret_val = Row::new().padding([0, 2]).align_y(Alignment::Center);
     for report_col in ReportCol::ALL {
@@ -205,12 +208,15 @@ fn report_header_row(
         } else {
             ContainerType::Tooltip
         };
-        let title_tooltip = Tooltip::new(
-            title_row,
-            Text::new(tooltip_val).font(font),
-            Position::FollowCursor,
-        )
-        .class(tooltip_style);
+
+        let title_tooltip = MyTooltip::new(
+                title_row,
+                Text::new(tooltip_val).font(font),
+            )
+            .position(Position::FollowCursor)
+            .style(tooltip_style)
+            .enabled(show_tooltip)
+            .build();
 
         let mut col_header = Column::new()
             .align_x(Alignment::Center)

--- a/src/gui/pages/settings_general_page.rs
+++ b/src/gui/pages/settings_general_page.rs
@@ -1,12 +1,14 @@
+use iced::Element;
 use iced::widget::text::LineHeight;
 use iced::widget::tooltip::Position;
 use iced::widget::{
-    Column, Container, PickList, Row, Rule, Slider, Space, Text, Tooltip, button, vertical_space,
+    Column, Container, PickList, Row, Rule, Slider, Space, Text, button, vertical_space,
 };
 use iced::{Alignment, Font, Length, Padding};
 
 use crate::gui::components::button::{button_open_file, row_open_link_tooltip};
 use crate::gui::components::tab::get_settings_tabs;
+use crate::gui::components::types::my_tooltip::MyTooltip;
 use crate::gui::pages::settings_notifications_page::settings_header;
 use crate::gui::pages::types::settings_page::SettingsPage;
 use crate::gui::styles::button::ButtonType;
@@ -117,29 +119,32 @@ fn language_picklist<'a>(language: Language, font: Font) -> Container<'a, Messag
         .spacing(10)
         .push(language.get_flag());
     if !language.is_up_to_date() {
+        let button = button(
+            Text::new("!")
+                .class(TextType::Danger)
+                .font(font)
+                .align_y(Alignment::Center)
+                .align_x(Alignment::Center)
+                .size(15)
+                .line_height(LineHeight::Relative(1.0)),
+        )
+        .on_press(Message::OpenWebPage(WebPage::IssueLanguages))
+        .padding(2)
+        .height(20)
+        .width(20)
+        .class(ButtonType::Alert);
+
         flag_row = flag_row.push(
-            Tooltip::new(
-                button(
-                    Text::new("!")
-                        .class(TextType::Danger)
-                        .font(font)
-                        .align_y(Alignment::Center)
-                        .align_x(Alignment::Center)
-                        .size(15)
-                        .line_height(LineHeight::Relative(1.0)),
-                )
-                .on_press(Message::OpenWebPage(WebPage::IssueLanguages))
-                .padding(2)
-                .height(20)
-                .width(20)
-                .class(ButtonType::Alert),
+            MyTooltip::new(
+                button,
                 row_open_link_tooltip(
                     "The selected language is not\nfully updated to version 1.4",
                     font,
                 ),
-                Position::FollowCursor,
             )
-            .class(ContainerType::Tooltip),
+            .position(Position::FollowCursor)
+            .style(ContainerType::Tooltip)
+            .build(),
         );
     }
 
@@ -214,7 +219,7 @@ fn need_help<'a>(language: Language, font: Font) -> Container<'a, Message, Style
         )
         .push(vertical_space())
         .push(
-            Tooltip::new(
+            MyTooltip::new(
                 button(
                     Icon::Feedback
                         .to_text()
@@ -228,10 +233,11 @@ fn need_help<'a>(language: Language, font: Font) -> Container<'a, Message, Style
                 .height(40)
                 .width(60),
                 row_open_link_tooltip("GitHub Issues", font),
-                Position::Right,
             )
-            .gap(5)
-            .class(ContainerType::Tooltip),
+            .position(Position::Right)
+            .gap(5.0)
+            .style(ContainerType::Tooltip)
+            .build()
         )
         .push(vertical_space());
 
@@ -316,6 +322,7 @@ fn mmdb_selection_row<'a>(
                 font,
                 is_editable,
                 message,
+                true,
             )
         } else {
             button_clear_mmdb(message, font, is_editable)
@@ -326,7 +333,7 @@ fn button_clear_mmdb<'a>(
     message: fn(String) -> Message,
     font: Font,
     is_editable: bool,
-) -> Tooltip<'a, Message, StyleType> {
+) -> Element<'a, Message, StyleType> {
     let mut button = button(
         Text::new("×")
             .font(font)
@@ -343,5 +350,9 @@ fn button_clear_mmdb<'a>(
         button = button.on_press(message(String::new()));
     }
 
-    Tooltip::new(button, "", Position::Right)
+    MyTooltip::new(button, Text::new("").font(font))
+        .enabled(true)
+        .position(Position::Right)
+        .style(ContainerType::Tooltip)
+        .build()
 }

--- a/src/gui/pages/settings_notifications_page.rs
+++ b/src/gui/pages/settings_notifications_page.rs
@@ -403,7 +403,7 @@ pub fn settings_header<'a>(
                     .align_x(Alignment::Center),
             )
             .push(
-                Container::new(button_hide(Message::CloseSettings, language, font))
+                Container::new(button_hide(Message::CloseSettings, language, font, true))
                     .width(Length::Fill)
                     .align_x(Alignment::Center),
             ),

--- a/src/gui/pages/settings_style_page.rs
+++ b/src/gui/pages/settings_style_page.rs
@@ -311,6 +311,7 @@ fn lazy_custom_style_input<'a>(
             font,
             true,
             Message::LoadStyle,
+            true,
         ));
 
     let mut content = Column::new()

--- a/src/gui/pages/thumbnail_page.rs
+++ b/src/gui/pages/thumbnail_page.rs
@@ -27,6 +27,8 @@ pub fn thumbnail_page(sniffer: &Sniffer) -> Container<'_, Message, StyleType> {
     let Settings { style, .. } = sniffer.conf.settings;
     let font = style.get_extension().font;
 
+    let show_tooltips = sniffer.settings_page.is_none() && sniffer.modal.is_none();
+
     let tot_packets = sniffer
         .info_traffic
         .tot_data_info
@@ -76,6 +78,7 @@ pub fn thumbnail_page(sniffer: &Sniffer) -> Container<'_, Message, StyleType> {
             data_repr,
             font,
             sniffer.conf.host_sort_type,
+            show_tooltips,
         ))
         .push(Rule::vertical(10))
         .push(service_col(
@@ -98,6 +101,7 @@ fn host_col<'a>(
     data_repr: DataRepr,
     font: Font,
     sort_type: SortType,
+    show_tooltip: bool,
 ) -> Column<'a, Message, StyleType> {
     let mut host_col = Column::new()
         .padding([0, 5])
@@ -120,7 +124,7 @@ fn host_col<'a>(
 
         thumbnail_hosts.push(thumbnail_host);
 
-        let flag = get_flag_tooltip(country, data_info_host, Language::default(), font, true);
+        let flag = get_flag_tooltip(country, data_info_host, Language::default(), font, true, show_tooltip);
         let host_row = Row::new()
             .align_y(Alignment::Center)
             .spacing(5)

--- a/src/gui/sniffer.rs
+++ b/src/gui/sniffer.rs
@@ -598,6 +598,7 @@ impl Sniffer {
             font_headers,
             self.newer_release_available,
             &self.dots_pulse,
+            self.settings_page.is_none() && self.modal.is_none(),
         );
 
         let content: Element<Message, StyleType> =

--- a/src/gui/styles/container.rs
+++ b/src/gui/styles/container.rs
@@ -24,6 +24,7 @@ pub enum ContainerType {
     Highlighted,
     HighlightedOnHeader,
     ModalBackground,
+    Transparent,
 }
 
 impl ContainerType {
@@ -54,7 +55,7 @@ impl ContainerType {
                 ContainerType::Modal | ContainerType::HighlightedOnHeader => {
                     Background::Color(colors.primary)
                 }
-                ContainerType::Standard | ContainerType::Palette => {
+                ContainerType::Standard | ContainerType::Palette | ContainerType::Transparent => {
                     Background::Color(Color::TRANSPARENT)
                 }
                 ContainerType::ModalBackground => Background::Color(Color {
@@ -78,7 +79,8 @@ impl ContainerType {
                     | ContainerType::ModalBackground
                     | ContainerType::Gradient(_)
                     | ContainerType::HighlightedOnHeader
-                    | ContainerType::Highlighted => 0.0,
+                    | ContainerType::Highlighted
+                    | ContainerType::Transparent => 0.0,
                     ContainerType::Tooltip => BORDER_WIDTH / 2.0,
                     ContainerType::BorderedRound => BORDER_WIDTH * 2.0,
                     _ => BORDER_WIDTH,


### PR DESCRIPTION
This PR addresses issue #639 .

Before, when a modal was opened, the tooltips in the background would still be visible:
![unsolved](https://github.com/user-attachments/assets/b978a1a5-9e8b-4bcd-bfb1-0ede828260a1)



And after being solved here is the result:
![solved](https://github.com/user-attachments/assets/99656f41-07b8-42b3-bdac-e822a334f6d8)


## Solution
I created a wrapper around the iced Tooltip widget, that given a control parameter (`enabled`) either gives out a tooltip like before or a transparent one which has no visual effect, as shown in the gif above.

All tooltips were changed to the new version to maintain consistency and I used the Builder design pattern to make the tooltip creation as flexible as possible.

Let me know what you think and what else could be changed regarding this issue.