### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   crates:
     runs-on: macos-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,9 @@ jobs:
   docker:
     name: Docker Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,5 +1,8 @@
 name: Package
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,6 +14,9 @@ on:
       CODECOV_TOKEN:
         required: true
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/GyulyVGC/sniffnet/security/code-scanning/1](https://github.com/GyulyVGC/sniffnet/security/code-scanning/1)

In general, the fix is to define an explicit `permissions:` block in the workflow, restricting the `GITHUB_TOKEN` to the minimal set needed. Since these jobs only check out code and work with artifacts, `contents: read` at the workflow root is a safe starting point. This will apply to all jobs (`build`, `deb`, `appimage`, `rpm`, etc.) that do not override `permissions`.

The best fix here is to add a single root-level `permissions:` block immediately under the workflow `name:` (or under `on:`) in `.github/workflows/package.yml`, setting `contents: read`. This documents the intended permissions and prevents accidental elevation if repo/org defaults are changed. No other behavior of the workflow changes, and no additional imports or steps are needed.

Concretely:
- Edit `.github/workflows/package.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  between line 2 and line 3 (i.e., after `name: Package` and its blank line, before the `on:` block).  
- Do not modify any existing jobs or steps.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
