### PR TITLE
fix: use integrated GPU on Wayland with NVIDIA Optimus setups

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,19 @@ pub fn main() -> iced::Result {
 
     print_cli_welcome_message();
 
+    // On Wayland with NVIDIA Optimus (Intel iGPU drives display, NVIDIA dGPU available),
+    // wgpu 27 defaults to the discrete NVIDIA adapter, which fails to configure a Wayland
+    // surface owned by the Intel-driven compositor → panic "Invalid surface".
+    // Force integrated GPU unless the user already set a preference via env vars.
+    #[cfg(target_os = "linux")]
+    if std::env::var("WAYLAND_DISPLAY").is_ok()
+        && std::env::var("WGPU_POWER_PREF").is_err()
+        && std::env::var("WGPU_BACKEND").is_err()
+        && std::path::Path::new("/proc/driver/nvidia").exists()
+    {
+        std::env::set_var("WGPU_POWER_PREF", "low");
+    }
+
     let size = conf.window.size();
     let position = Position::Specific(conf.window.position());
 


### PR DESCRIPTION
## Problem

Sniffnet crashes immediately on Wayland with NVIDIA Optimus laptops:

```
wgpu error: Validation Error
In Surface::configure
  Invalid surface
```

## Root cause

wgpu 27 selects the discrete NVIDIA GPU by default (high-power preference). On Optimus laptops, the display is Intel-driven. NVIDIA cannot configure a Wayland surface it does not own → panic at `Surface::configure`.

Verified via isolation:
- `WGPU_BACKEND=vulkan WGPU_POWER_PREF=high` → crashes (NVIDIA)
- `WGPU_BACKEND=vulkan WGPU_POWER_PREF=low` → works (Intel)
- `WGPU_BACKEND=gl` → works but has GUI refresh artifacts

## Fix

Detect NVIDIA Optimus + Wayland at startup and set `WGPU_POWER_PREF=low` so wgpu selects the integrated Intel GPU instead.

Only activates when **all** conditions are true:
- Linux + Wayland session (`WAYLAND_DISPLAY` set)
- NVIDIA driver loaded (`/proc/driver/nvidia` exists)
- User has not already set `WGPU_POWER_PREF` or `WGPU_BACKEND`

Users can still override with their own env vars — the fix is a safe default, not a hard lock.

## Tested on

- Debian KDE Plasma / Wayland
- Intel Iris Xe (ADL GT2) + NVIDIA RTX 3050 Laptop GPU
- NVIDIA driver 550.163.01
- wgpu 27.0.1
