### PR TITLE
Traffic chart is broken in GUI #1150

### DIFF
--- a/resources/packaging/linux/sniffnet.desktop
+++ b/resources/packaging/linux/sniffnet.desktop
@@ -5,6 +5,6 @@ Name=Sniffnet
 Comment=Application to comfortably monitor your network traffic
 Categories=Network;Utility;
 Icon=sniffnet
-Exec=/usr/bin/sniffnet
+Exec=WGPU_BACKEND=vulkan /usr/bin/sniffnet
 StartupWMClass=sniffnet
 Terminal=false


### PR DESCRIPTION
Workaround for the failed detection of the wgpu backend on Linux systems, leading to falling back to the broken tiny-skia backend (which unable to correctly render the chart areas).

Note that this applies only in the cases where the application is started from its icon (e.g. from the applications/start menu).

Considering that, as per the wgpu documentation, the support is Linux and Android (using Vulkan), the side-effect of adding WGPU_BACKEND=vulkan to the Exec configuration would be, at most, to end up using the broken fallback tiny-skia (in case the vulkan backend is not available). Without that it would always end up using the fallback tiny-skia...

https://github.com/GyulyVGC/sniffnet/issues/1150