### PR TITLE
feat(docker): add arm64 platform support

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,7 +45,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/gyulyvgc/sniffnet:latest


### PR DESCRIPTION
## Summary

Add `linux/arm64` to the Docker build platforms. The CI infrastructure (QEMU, Buildx) is already set up — only the `platforms` field needed updating.

Closes #1207

## Details

| Item | Detail |
|---|---|
| QEMU (arm64 emulation) | Already configured (line 31-32) |
| Buildx (multi-platform) | Already configured (line 34-35) |
| Base images | `rust:1.88-slim` and `debian:bookworm-slim` are multi-arch |
| Code arch-safety | Zero `target_arch` cfgs in the codebase |

## Verification

- The project already cross-compiles arm64 packages via `Cross.toml` → same code path
- No `target_arch` cfg in any `.rs` file — only `target_os` (linux/macos/windows)
- `build.rs` is arch-independent (phf codegen only)

## Change

```diff
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
```