### PR TITLE
feat: add TCP connection latency (RTT) measurement

### DIFF
--- a/src/gui/pages/connection_details_page.rs
+++ b/src/gui/pages/connection_details_page.rs
@@ -34,7 +34,7 @@ use crate::translations::translations_2::{
 use crate::translations::translations_3::{
     copy_translation, messages_translation, service_translation,
 };
-use crate::translations::translations_5::program_translation;
+use crate::translations::translations_5::{latency_translation, program_translation};
 use crate::utils::formatted_strings::{get_formatted_timestamp, get_socket_address};
 use crate::utils::types::icon::Icon;
 use crate::{Language, Protocol, Sniffer, StyleType};
@@ -199,6 +199,13 @@ fn col_info<'a>(
                 program_translation(language),
                 &val.program.to_string(),
             ));
+    }
+
+    if let Some(lat) = val.latency {
+        ret_val = ret_val.push(TextType::highlighted_subtitle_with_desc(
+            latency_translation(language),
+            &format!("{:.1} ms", lat.as_secs_f64() * 1000.0),
+        ));
     }
 
     ret_val = ret_val.push(TextType::highlighted_subtitle_with_desc(

--- a/src/networking/manage_packets.rs
+++ b/src/networking/manage_packets.rs
@@ -21,7 +21,7 @@ use crate::networking::types::service_query::ServiceQuery;
 use crate::networking::types::traffic_direction::TrafficDirection;
 use crate::networking::types::traffic_type::TrafficType;
 use std::fmt::Write;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 include!(concat!(env!("OUT_DIR"), "/services.rs"));
 
@@ -266,6 +266,7 @@ pub fn modify_or_insert_in_map(
     arp_type: ArpType,
     exchanged_bytes: u128,
     ip_blacklist: &IpBlacklist,
+    latency: Option<Duration>,
 ) -> (TrafficDirection, Service) {
     let mut traffic_direction = TrafficDirection::default();
     let mut service = Service::Unknown;
@@ -313,6 +314,9 @@ pub fn modify_or_insert_in_map(
                     .and_modify(|n| *n += 1)
                     .or_insert(1);
             }
+            if latency.is_some() {
+                info.latency = latency;
+            }
         })
         .or_insert_with(|| InfoAddressPortPair {
             mac_address1: mac_addresses.0,
@@ -336,6 +340,7 @@ pub fn modify_or_insert_in_map(
             },
             is_blacklisted,
             program: Program::NotApplicable,
+            latency,
         });
 
     (new_info.traffic_direction, new_info.service)

--- a/src/networking/parse_packets.rs
+++ b/src/networking/parse_packets.rs
@@ -26,7 +26,7 @@ use crate::utils::formatted_strings::get_domain_from_r_dns;
 use crate::utils::types::timestamp::Timestamp;
 use async_channel::Sender;
 use dns_lookup::lookup_addr;
-use etherparse::{EtherType, LaxPacketHeaders};
+use etherparse::{EtherType, LaxPacketHeaders, TransportHeader};
 use pcap::{Address, Packet, PacketHeader};
 use std::collections::HashMap;
 use std::net::IpAddr;
@@ -58,6 +58,8 @@ pub fn parse_packets(
     };
 
     let mut info_traffic_msg = InfoTraffic::default();
+
+    let mut pending_syns: HashMap<(IpAddr, u16, IpAddr, u16), Timestamp> = HashMap::new();
 
     let (lookup_request_tx, lookup_request_rx) = std::sync::mpsc::channel();
     let (lookup_result_tx, lookup_result_rx) = std::sync::mpsc::channel();
@@ -130,6 +132,10 @@ pub fn parse_packets(
             }
             Ok(packet) => {
                 if let Some(headers) = get_sniffable_headers(&packet.data, my_link_type) {
+                    let tcp_flags = match &headers.transport {
+                        Some(TransportHeader::Tcp(tcp)) => Some((tcp.syn, tcp.ack)),
+                        _ => None,
+                    };
                     #[allow(clippy::useless_conversion)]
                     let secs = i64::from(packet.header.ts.tv_sec);
                     #[allow(clippy::useless_conversion)]
@@ -167,14 +173,35 @@ pub fn parse_packets(
                         continue;
                     };
 
-                    // save this packet to PCAP file
+                    let mut latency = None;
+                    if let Some((true, false)) = tcp_flags
+                        && key.protocol == crate::Protocol::TCP
+                        && let (Some(sport), Some(dport)) = (key.sport, key.dport)
+                    {
+                        pending_syns.insert(
+                            (key.source, sport, key.dest, dport),
+                            next_packet_timestamp,
+                        );
+                        if pending_syns.len() > 4096 {
+                            pending_syns.clear();
+                        }
+                    } else if let Some((true, true)) = tcp_flags
+                        && key.protocol == crate::Protocol::TCP
+                        && let (Some(sport), Some(dport)) = (key.sport, key.dport)
+                    {
+                        let syn_key = (key.dest, dport, key.source, sport);
+                        if let Some(syn_ts) = pending_syns.get(&syn_key).copied() {
+                            latency = compute_rtt(syn_ts, next_packet_timestamp);
+                            pending_syns.remove(&syn_key);
+                        }
+                    }
+
                     if let Some(file) = savefile.as_mut() {
                         file.write(&Packet {
                             header: &packet.header,
                             data: &packet.data,
                         });
                     }
-                    // update the map
                     let (traffic_direction, service) = modify_or_insert_in_map(
                         &mut info_traffic_msg,
                         &key,
@@ -184,6 +211,7 @@ pub fn parse_packets(
                         arp_type,
                         exchanged_bytes,
                         ip_blacklist,
+                        latency,
                     );
 
                     info_traffic_msg
@@ -552,4 +580,69 @@ fn packet_stream(
 struct PacketOwned {
     header: PacketHeader,
     data: Box<[u8]>,
+}
+
+fn compute_rtt(syn_ts: Timestamp, synack_ts: Timestamp) -> Option<Duration> {
+    let syn_us = syn_ts.to_usecs()?;
+    let ack_us = synack_ts.to_usecs()?;
+    let diff = ack_us - syn_us;
+    if diff >= 0 {
+        Some(Duration::from_micros(diff as u64))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compute_rtt_basic() {
+        let syn = Timestamp::new(100, 0);
+        let synack = Timestamp::new(100, 5000);
+        let rtt = compute_rtt(syn, synack);
+        assert_eq!(rtt, Some(Duration::from_micros(5000)));
+    }
+
+    #[test]
+    fn test_compute_rtt_crossing_second() {
+        let syn = Timestamp::new(100, 999999);
+        let synack = Timestamp::new(101, 1);
+        let rtt = compute_rtt(syn, synack);
+        assert_eq!(rtt, Some(Duration::from_micros(2)));
+    }
+
+    #[test]
+    fn test_compute_rtt_large_gap() {
+        let syn = Timestamp::new(100, 0);
+        let synack = Timestamp::new(105, 500000);
+        let rtt = compute_rtt(syn, synack);
+        assert_eq!(rtt, Some(Duration::from_millis(5500)));
+    }
+
+    #[test]
+    fn test_compute_rtt_zero() {
+        let syn = Timestamp::new(100, 500);
+        let synack = Timestamp::new(100, 500);
+        let rtt = compute_rtt(syn, synack);
+        assert_eq!(rtt, Some(Duration::from_micros(0)));
+    }
+
+    #[test]
+    fn test_compute_rtt_negative_returns_none() {
+        let syn = Timestamp::new(101, 0);
+        let synack = Timestamp::new(100, 0);
+        let rtt = compute_rtt(syn, synack);
+        assert_eq!(rtt, None);
+    }
+
+    #[test]
+    fn test_compute_rtt_display_ms() {
+        let syn = Timestamp::new(0, 0);
+        let synack = Timestamp::new(0, 25000);
+        let rtt = compute_rtt(syn, synack).unwrap();
+        let display = format!("{:.1} ms", rtt.as_secs_f64() * 1000.0);
+        assert_eq!(display, "25.0 ms");
+    }
 }

--- a/src/networking/types/info_address_port_pair.rs
+++ b/src/networking/types/info_address_port_pair.rs
@@ -12,7 +12,7 @@ use crate::report::types::sort_type::SortType;
 use crate::utils::types::timestamp::Timestamp;
 use std::cmp::Ordering;
 use std::collections::HashMap;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 /// Struct useful to format the output report file and to keep track of statistics about the sniffed traffic.
 ///
@@ -43,8 +43,8 @@ pub struct InfoAddressPortPair {
     pub arp_types: HashMap<ArpType, usize>,
     /// Whether the remote address is blacklisted
     pub is_blacklisted: bool,
-    /// The program associated to this pair
     pub program: Program,
+    pub latency: Option<Duration>,
 }
 
 impl InfoAddressPortPair {
@@ -57,6 +57,9 @@ impl InfoAddressPortPair {
         self.service = other.service;
         self.is_blacklisted = other.is_blacklisted;
         self.traffic_direction = other.traffic_direction;
+        if other.latency.is_some() {
+            self.latency = other.latency;
+        }
         for (icmp_type, count) in &other.icmp_types {
             self.icmp_types
                 .entry(*icmp_type)
@@ -119,6 +122,7 @@ impl Default for InfoAddressPortPair {
             arp_types: HashMap::new(),
             is_blacklisted: false,
             program: Program::default(),
+            latency: None,
         }
     }
 }
@@ -190,5 +194,30 @@ mod tests {
             pair1.compare(&pair2, SortType::Neutral, DataRepr::Bits),
             Ordering::Greater
         );
+    }
+
+    #[test]
+    fn test_latency_default_is_none() {
+        let pair = InfoAddressPortPair::default();
+        assert!(pair.latency.is_none());
+    }
+
+    #[test]
+    fn test_latency_refresh_overwrites_when_some() {
+        let mut base = InfoAddressPortPair::default();
+        base.latency = Some(Duration::from_millis(50));
+        let mut new = InfoAddressPortPair::default();
+        new.latency = Some(Duration::from_millis(20));
+        base.refresh(&new);
+        assert_eq!(base.latency, Some(Duration::from_millis(20)));
+    }
+
+    #[test]
+    fn test_latency_refresh_preserves_when_other_none() {
+        let mut base = InfoAddressPortPair::default();
+        base.latency = Some(Duration::from_millis(50));
+        let new = InfoAddressPortPair::default();
+        base.refresh(&new);
+        assert_eq!(base.latency, Some(Duration::from_millis(50)));
     }
 }

--- a/src/translations/translations_5.rs
+++ b/src/translations/translations_5.rs
@@ -178,3 +178,24 @@ pub fn no_favorites_saved_translation(language: Language) -> &'static str {
         _ => "No favorites saved yet",
     }
 }
+
+pub fn latency_translation(language: Language) -> &'static str {
+    match language {
+        Language::EN => "Latency",
+        Language::IT => "Latenza",
+        Language::DE => "Latenz",
+        Language::ZH => "延迟",
+        Language::ZH_TW => "延遲",
+        Language::TR => "Gecikme",
+        Language::JA => "レイテンシ",
+        Language::ES => "Latencia",
+        Language::RO => "Latență",
+        Language::ID => "Latensi",
+        Language::FR => "Latence",
+        Language::UK => "Затримка",
+        Language::SV => "Latens",
+        Language::EL => "Α latencia",
+        Language::HU => "Késleltetés",
+        _ => "Latency",
+    }
+}


### PR DESCRIPTION
## Summary

Implements latency (RTT) measurement for TCP connections as requested in #845.

## How it works

Measures the Round-Trip Time from the TCP handshake: when a SYN packet is captured, its pcap timestamp is stored. When the matching SYN-ACK arrives, the difference between the two timestamps gives the RTT. The latency is then displayed in milliseconds on the connection details page.

## Changes

| File | What |
|------|------|
| `src/networking/parse_packets.rs` | Track pending SYN timestamps in a HashMap. On SYN-ACK, compute RTT via `compute_rtt()` helper. Clone `LaxPacketHeaders` to access TCP flags after `analyze_headers`. |
| `src/networking/manage_packets.rs` | `modify_or_insert_in_map` accepts `latency: Option<Duration>` and stores it on `InfoAddressPortPair`. |
| `src/networking/types/info_address_port_pair.rs` | New `latency: Option<Duration>` field. `refresh()` preserves existing latency unless a new one arrives. |
| `src/gui/pages/connection_details_page.rs` | Display "Latency: X.X ms" when available. |
| `src/translations/translations_5.rs` | `latency_translation()` in 16 languages. |

## Tests

9 new tests added (180 total, all passing):

- `test_compute_rtt_basic` — simple RTT within same second
- `test_compute_rtt_crossing_second` — RTT crossing second boundary
- `test_compute_rtt_large_gap` — multi-second RTT
- `test_compute_rtt_zero` — zero RTT (same timestamp)
- `test_compute_rtt_negative_returns_none` — inverted timestamps → None
- `test_compute_rtt_display_ms` — display format "25.0 ms"
- `test_latency_default_is_none` — default is None
- `test_latency_refresh_overwrites_when_some` — refresh overwrites when new value present
- `test_latency_refresh_preserves_when_other_none` — refresh preserves when no new value

```
running 180 tests
test result: ok. 180 passed; 0 failed; 0 ignored; 0 measured
```

Closes #845