### PR TITLE
chore: remove dead commented-out code

### DIFF
--- a/src/chart/types/traffic_chart.rs
+++ b/src/chart/types/traffic_chart.rs
@@ -294,57 +294,6 @@ impl TrafficChart {
         AreaSeries::new(data, 0.0, color.mix(alpha.into()))
             .border_style(ShapeStyle::from(&color).stroke_width(CHARTS_LINE_BORDER))
     }
-
-    // pub fn sample_for_screenshot(style: StyleType) -> Self {
-    //     use crate::translations::types::language::Language;
-    //     use splines::{Interpolation, Key};
-    //     use std::io::Read;
-    //
-    //     let get_rand = |delta: f32| {
-    //         let mut f = std::fs::File::open("/dev/urandom").unwrap();
-    //         let mut buf = [0u8; 1];
-    //         f.read_exact(&mut buf).unwrap();
-    //         let x = buf[0];
-    //         x as f32 / 255.0 * 2.0 * delta - delta
-    //     };
-    //
-    //     let mut chart = TrafficChart::new(style, Language::default(), DataRepr::default());
-    //
-    //     chart.ticks = 5 * 60 - 2;
-    //     let x_range = chart.ticks - 30..chart.ticks;
-    //
-    //     let in_base = 35_000.0;
-    //     let in_delta = 9_000.0;
-    //     let out_base = -15_000.0;
-    //     let out_delta = 5_000.0;
-    //
-    //     chart.in_bytes.spline = Spline::from_vec(
-    //         x_range
-    //             .clone()
-    //             .map(|x| {
-    //                 Key::new(
-    //                     x as f32,
-    //                     in_base + get_rand(in_delta),
-    //                     Interpolation::Cosine,
-    //                 )
-    //             })
-    //             .collect(),
-    //     );
-    //     chart.out_bytes.spline = Spline::from_vec(
-    //         x_range
-    //             .map(|x| {
-    //                 Key::new(
-    //                     x as f32,
-    //                     out_base + get_rand(out_delta),
-    //                     Interpolation::Cosine,
-    //                 )
-    //             })
-    //             .collect(),
-    //     );
-    //     chart.min_bytes = chart.out_bytes.get_min();
-    //     chart.max_bytes = chart.in_bytes.get_max();
-    //     chart
-    // }
 }
 
 impl Chart<Message> for TrafficChart {

--- a/src/mmdb/country.rs
+++ b/src/mmdb/country.rs
@@ -82,10 +82,6 @@ mod tests {
             let res = get_country(&IpAddr::from([1, 0, 8, 0]), &reader);
             assert_eq!(res, Country::CN);
 
-            // known IPv6
-            // let res = get_country(&IpAddr::from_str("2a0e:1d80::").unwrap(), &reader);
-            // assert_eq!(res, Country::RO);
-
             // unknown IP
             let res = get_country(&IpAddr::from([127, 0, 0, 1]), &reader);
             assert_eq!(res, Country::ZZ);
@@ -115,10 +111,6 @@ mod tests {
             // another known IP
             let res = get_country(&IpAddr::from([1, 6, 230, 0]), &reader);
             assert_eq!(res, Country::IN);
-
-            // known IPv6
-            // let res = get_country(&IpAddr::from_str("2a02:6ea0:f001::").unwrap(), &reader);
-            // assert_eq!(res, Country::AR);
 
             // unknown IP
             let res = get_country(&IpAddr::from([127, 0, 0, 1]), &reader);

--- a/src/utils/formatted_strings.rs
+++ b/src/utils/formatted_strings.rs
@@ -7,19 +7,6 @@ use chrono::{Local, TimeZone};
 /// Application version number (to be displayed in gui footer)
 pub const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-// /// Computes the String representing the percentage of filtered bytes/packets
-// pub fn get_percentage_string(observed: u128, filtered: u128) -> String {
-//     #[allow(clippy::cast_precision_loss)]
-//     let filtered_float = filtered as f32;
-//     #[allow(clippy::cast_precision_loss)]
-//     let observed_float = observed as f32;
-//     if format!("{:.1}", 100.0 * filtered_float / observed_float).eq("0.0") {
-//         "<0.1%".to_string()
-//     } else {
-//         format!("{:.1}%", 100.0 * filtered_float / observed_float)
-//     }
-// }
-
 pub fn print_cli_welcome_message() {
     let ver = APP_VERSION;
     print!(


### PR DESCRIPTION
Removes ~60 lines of commented-out dead code:

- `sample_for_screenshot` in `traffic_chart.rs` (50 lines referencing `/dev/urandom`)
- `get_percentage_string` in `formatted_strings.rs` (12 lines)
- Commented-out IPv6 test cases in `mmdb/country.rs` (4 lines)

These blocks pollute `grep unwrap` audits and give false signals that code paths are live.

```
test result: ok. 171 passed; 0 failed
``