### PR TITLE
refactor: extract REPORT_ENTRIES_PER_PAGE constant

### DIFF
--- a/src/gui/pages/inspect_page.rs
+++ b/src/gui/pages/inspect_page.rs
@@ -30,6 +30,7 @@ use crate::report::get_report_entries::get_searched_entries;
 use crate::report::types::report_col::ReportCol;
 use crate::report::types::search_parameters::{FilterInputType, SearchParameters};
 use crate::report::types::sort_type::SortType;
+use crate::report::types::REPORT_ENTRIES_PER_PAGE;
 use crate::translations::translations_2::{
     country_translation, domain_translation, no_search_results_translation,
     only_show_favorites_translation, showing_results_translation,
@@ -101,7 +102,7 @@ fn report<'a>(sniffer: &Sniffer) -> Column<'a, Message, StyleType> {
         .align_x(Alignment::Start);
 
     let mut scroll_report = Column::new().align_x(Alignment::Start);
-    let start_entry_num = (sniffer.page_number.saturating_sub(1)) * 30 + 1;
+    let start_entry_num = (sniffer.page_number.saturating_sub(1)) * REPORT_ENTRIES_PER_PAGE + 1;
     let end_entry_num = start_entry_num + search_results.len() - 1;
     for (key, val) in search_results {
         scroll_report = scroll_report.push(
@@ -590,7 +591,7 @@ fn get_change_page_row<'a>(
             end_entry_num,
             results_number,
         )))
-        .push(if page_number < results_number.div_ceil(30) {
+        .push(if page_number < results_number.div_ceil(REPORT_ENTRIES_PER_PAGE) {
             Container::new(get_button_change_page(true).width(25))
         } else {
             Container::new(Space::new().width(25))

--- a/src/gui/pages/overview_page.rs
+++ b/src/gui/pages/overview_page.rs
@@ -23,6 +23,7 @@ use crate::networking::types::capture_context::CaptureSource;
 use crate::networking::types::data_info::DataInfo;
 use crate::networking::types::data_representation::DataRepr;
 use crate::report::types::sort_type::SortType;
+use crate::report::types::REPORT_ENTRIES_PER_PAGE;
 use crate::translations::translations::{
     active_filters_translation, incoming_translation, none_translation, outgoing_translation,
     traffic_rate_translation,
@@ -148,7 +149,7 @@ fn col_favorite_item(
         );
     }
 
-    if entries.len() >= 30 {
+    if entries.len() >= REPORT_ENTRIES_PER_PAGE {
         scroll_item = scroll_item.push(
             Text::new(only_top_30_items_translation(language))
                 .height(50)

--- a/src/gui/sniffer.rs
+++ b/src/gui/sniffer.rs
@@ -50,6 +50,7 @@ use crate::notifications::types::sound::{Sound, play};
 use crate::report::get_report_entries::get_searched_entries;
 use crate::report::types::search_parameters::SearchParameters;
 use crate::report::types::sort_type::SortType;
+use crate::report::types::REPORT_ENTRIES_PER_PAGE;
 use crate::translations::types::language::Language;
 use crate::utils::check_updates::set_newer_release_status;
 use crate::utils::error_logger::{ErrorLogger, Location};
@@ -600,7 +601,7 @@ impl Sniffer {
 
     fn update_page_number(&mut self, increment: bool) {
         if increment {
-            if self.page_number < get_searched_entries(self).1.div_ceil(30) {
+            if self.page_number < get_searched_entries(self).1.div_ceil(REPORT_ENTRIES_PER_PAGE) {
                 self.page_number = self.page_number.checked_add(1).unwrap_or(1);
             }
         } else if self.page_number > 1 {

--- a/src/report/get_report_entries.rs
+++ b/src/report/get_report_entries.rs
@@ -3,6 +3,7 @@ use crate::networking::manage_packets::get_address_to_lookup;
 use crate::networking::types::address_port_pair::AddressPortPair;
 use crate::networking::types::data_info::DataInfo;
 use crate::networking::types::info_address_port_pair::InfoAddressPortPair;
+use crate::report::types::REPORT_ENTRIES_PER_PAGE;
 use std::cmp::min;
 
 /// Return the elements that satisfy the search constraints and belong to the given page,
@@ -53,11 +54,11 @@ pub fn get_searched_entries(
         a.compare(b, sniffer.conf.report_sort_type, sniffer.conf.data_repr)
     });
 
-    let upper_bound = min(sniffer.page_number * 30, all_results.len());
+    let upper_bound = min(sniffer.page_number * REPORT_ENTRIES_PER_PAGE, all_results.len());
 
     (
         all_results
-            .get((sniffer.page_number.saturating_sub(1)) * 30..upper_bound)
+            .get((sniffer.page_number.saturating_sub(1)) * REPORT_ENTRIES_PER_PAGE..upper_bound)
             .unwrap_or_default()
             .to_vec(),
         all_results.len(),

--- a/src/report/types/mod.rs
+++ b/src/report/types/mod.rs
@@ -1,3 +1,5 @@
 pub mod report_col;
 pub mod search_parameters;
 pub mod sort_type;
+
+pub const REPORT_ENTRIES_PER_PAGE: usize = 30;


### PR DESCRIPTION
Replaces the magic number `30` with a named constant `REPORT_ENTRIES_PER_PAGE` across 5 files where the same page-size value was hardcoded.

This makes the page size configurable in the future (e.g. for larger monitors) and prevents divergent values across sites.

**Files changed:**
- `report/types/mod.rs` - constant definition
- `report/get_report_entries.rs` - pagination slice bounds
- `gui/pages/inspect_page.rs` - entry numbering + page count display
- `gui/sniffer.rs` - page number bounds check
- `gui/pages/overview_page.rs` - top items threshold

```
test result: ok. 171 passed; 0 failed
``