### PR TITLE
perf: pre-size mac_from_dec_to_hex String with capacity

### DIFF
--- a/src/networking/manage_packets.rs
+++ b/src/networking/manage_packets.rs
@@ -492,7 +492,7 @@ pub fn is_my_address(local_address: &IpAddr, my_interface_addresses: &Vec<Addres
 
 /// Converts a MAC address in its hexadecimal form
 fn mac_from_dec_to_hex(mac_dec: [u8; 6]) -> String {
-    let mut mac_hex = String::new();
+    let mut mac_hex = String::with_capacity(17);
     for n in &mac_dec {
         let _ = write!(mac_hex, "{n:02x}:");
     }


### PR DESCRIPTION
Pre-allocates 17 bytes for the MAC address hex string instead of growing from 0 through 6 reallocations.

This function runs on every captured packet. Output is always 17 bytes: 6 pairs of hex digits separated by 5 colons.

```
test result: ok. 171 passed; 0 failed
``