### PR TITLE
test: add pagination bounds tests for report entries

### DIFF
--- a/src/report/get_report_entries.rs
+++ b/src/report/get_report_entries.rs
@@ -3,11 +3,21 @@ use crate::networking::manage_packets::get_address_to_lookup;
 use crate::networking::types::address_port_pair::AddressPortPair;
 use crate::networking::types::data_info::DataInfo;
 use crate::networking::types::info_address_port_pair::InfoAddressPortPair;
+use crate::report::types::REPORT_ENTRIES_PER_PAGE;
 use std::cmp::min;
 
-/// Return the elements that satisfy the search constraints and belong to the given page,
-/// and the total number of elements which satisfy the search constraints,
-/// with their packets, in-bytes, and out-bytes count
+pub fn paginate<T: Clone>(
+    all_results: &[T],
+    page_number: usize,
+) -> (Vec<T>, usize) {
+    let upper_bound = min(page_number * REPORT_ENTRIES_PER_PAGE, all_results.len());
+    let page = all_results
+        .get((page_number.saturating_sub(1)) * REPORT_ENTRIES_PER_PAGE..upper_bound)
+        .unwrap_or_default()
+        .to_vec();
+    (page, all_results.len())
+}
+
 pub fn get_searched_entries(
     sniffer: &Sniffer,
 ) -> (
@@ -24,15 +34,12 @@ pub fn get_searched_entries(
         .filter(|(key, value)| {
             let address_to_lookup = &get_address_to_lookup(key, value.traffic_direction);
             let r_dns_host = sniffer.addresses_resolved.get(address_to_lookup);
-            // is this a favorite host?
             let is_favorite_host = if let Some(e) = r_dns_host {
                 favorites.contains_host(&e.1)
             } else {
                 false
             };
-            // is this a favorite service?
             let is_favorite_service = favorites.contains_service(&value.service);
-            // is this a favorite program?
             let is_favorite_program = if sniffer.program_lookup.is_some() {
                 favorites.contains_program(&value.program)
             } else {
@@ -53,14 +60,82 @@ pub fn get_searched_entries(
         a.compare(b, sniffer.conf.report_sort_type, sniffer.conf.data_repr)
     });
 
-    let upper_bound = min(sniffer.page_number * 30, all_results.len());
+    let (page, total) = paginate(&all_results, sniffer.page_number);
 
-    (
-        all_results
-            .get((sniffer.page_number.saturating_sub(1)) * 30..upper_bound)
-            .unwrap_or_default()
-            .to_vec(),
-        all_results.len(),
-        agglomerate,
-    )
+    (page, total, agglomerate)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_paginate_first_page_full() {
+        let data: Vec<i32> = (0..75).collect();
+        let (page, total) = paginate(&data, 1);
+        assert_eq!(page.len(), REPORT_ENTRIES_PER_PAGE);
+        assert_eq!(total, 75);
+        assert_eq!(page[0], 0);
+        assert_eq!(page[REPORT_ENTRIES_PER_PAGE - 1], REPORT_ENTRIES_PER_PAGE as i32 - 1);
+    }
+
+    #[test]
+    fn test_paginate_last_page_partial() {
+        let data: Vec<i32> = (0..75).collect();
+        let (page, total) = paginate(&data, 3);
+        assert_eq!(page.len(), 15);
+        assert_eq!(total, 75);
+        assert_eq!(page[0], 60);
+        assert_eq!(page[14], 74);
+    }
+
+    #[test]
+    fn test_paginate_page_zero_returns_empty() {
+        let data: Vec<i32> = (0..10).collect();
+        let (page, total) = paginate(&data, 0);
+        assert!(page.is_empty());
+        assert_eq!(total, 10);
+    }
+
+    #[test]
+    fn test_paginate_beyond_last_page_returns_empty() {
+        let data: Vec<i32> = (0..30).collect();
+        let (page, total) = paginate(&data, 100);
+        assert!(page.is_empty());
+        assert_eq!(total, 30);
+    }
+
+    #[test]
+    fn test_paginate_empty_data() {
+        let data: Vec<i32> = vec![];
+        let (page, total) = paginate(&data, 1);
+        assert!(page.is_empty());
+        assert_eq!(total, 0);
+    }
+
+    #[test]
+    fn test_paginate_exact_multiple() {
+        let data: Vec<i32> = (0..60).collect();
+        let (page, total) = paginate(&data, 2);
+        assert_eq!(page.len(), REPORT_ENTRIES_PER_PAGE);
+        assert_eq!(total, 60);
+        assert_eq!(page[0], 30);
+        assert_eq!(page[REPORT_ENTRIES_PER_PAGE - 1], 59);
+    }
+
+    #[test]
+    fn test_paginate_single_element() {
+        let data = vec![42];
+        let (page, total) = paginate(&data, 1);
+        assert_eq!(page, vec![42]);
+        assert_eq!(total, 1);
+    }
+
+    #[test]
+    fn test_paginate_page_past_end_with_partial_last() {
+        let data: Vec<i32> = (0..45).collect();
+        let (page, total) = paginate(&data, 3);
+        assert!(page.is_empty());
+        assert_eq!(total, 45);
+    }
 }

--- a/src/report/types/mod.rs
+++ b/src/report/types/mod.rs
@@ -1,3 +1,5 @@
 pub mod report_col;
 pub mod search_parameters;
 pub mod sort_type;
+
+pub const REPORT_ENTRIES_PER_PAGE: usize = 30;


### PR DESCRIPTION
Extracts the pagination math from `get_searched_entries` into a testable `paginate<T>()` helper and adds 8 tests covering all edge cases.

**Before:** `get_report_entries.rs` had zero tests. The pagination formula relied on `saturating_sub` and `unwrap_or_default` with no safety net.

**After:** `paginate()` is a generic function that takes a slice and a page number, returns the page items + total count. 8 tests cover:

| Test | Scenario | Expected |
|------|----------|----------|
| `test_paginate_first_page_full` | 75 results, page 1 | 30 items |
| `test_paginate_last_page_partial` | 75 results, page 3 | 15 items |
| `test_paginate_page_zero` | page 0 | empty |
| `test_paginate_beyond_last_page` | 30 results, page 100 | empty |
| `test_paginate_empty_data` | empty input | empty |
| `test_paginate_exact_multiple` | 60 results, page 2 | 30 items |
| `test_paginate_single_element` | 1 result, page 1 | 1 item |
| `test_paginate_page_past_end_with_partial_last` | 45 results, page 3 | empty |

```
test result: ok. 179 passed; 0 failed
``