### PR TITLE
Surface traffic preview device-list errors

### DIFF
--- a/src/gui/pages/initial_page.rs
+++ b/src/gui/pages/initial_page.rs
@@ -17,7 +17,9 @@ use crate::gui::types::settings::Settings;
 use crate::networking::types::capture_context::{CaptureSource, CaptureSourcePicklist};
 use crate::networking::types::my_device::MyDevice;
 use crate::networking::types::my_link_type::MyLinkType;
-use crate::translations::translations::{network_adapter_translation, start_translation};
+use crate::translations::translations::{
+    error_translation, network_adapter_translation, start_translation,
+};
 use crate::translations::translations_3::{
     directory_translation, export_capture_translation, file_name_translation,
 };
@@ -157,10 +159,26 @@ fn get_col_data_source(sniffer: &Sniffer, language: Language) -> Column<'_, Mess
 }
 
 fn get_col_adapter(sniffer: &Sniffer) -> Column<'_, Message, StyleType> {
-    Column::new()
-        .spacing(5)
-        .height(Length::Fill)
-        .push(if sniffer.preview_charts.is_empty() {
+    Column::new().spacing(5).height(Length::Fill).push(
+        if let Some(error) = &sniffer.traffic_preview_device_list_error {
+            Into::<iced::Element<Message, StyleType>>::into(center(
+                Column::new()
+                    .align_x(Alignment::Center)
+                    .spacing(15)
+                    .push(Icon::Error.to_text().size(60))
+                    .push(
+                        Text::new(error_translation(sniffer.conf.settings.language))
+                            .class(TextType::Danger)
+                            .size(FONT_SIZE_SUBTITLE)
+                            .align_x(alignment::Alignment::Center),
+                    )
+                    .push(
+                        Text::new(error)
+                            .width(Length::Fill)
+                            .align_x(alignment::Alignment::Center),
+                    ),
+            ))
+        } else if sniffer.preview_charts.is_empty() {
             Into::<iced::Element<Message, StyleType>>::into(center(
                 Icon::get_hourglass(sniffer.dots_pulse.0.len()).size(60),
             ))
@@ -212,7 +230,8 @@ fn get_col_adapter(sniffer: &Sniffer) -> Column<'_, Message, StyleType> {
                 Direction::Vertical(ScrollbarType::properties()),
             )
             .into()
-        })
+        },
+    )
 }
 
 pub(crate) fn get_addresses_row(

--- a/src/gui/sniffer.rs
+++ b/src/gui/sniffer.rs
@@ -106,6 +106,8 @@ pub struct Sniffer {
     pub capture_source: CaptureSource,
     /// Signals if a pcap error occurred
     pub pcap_error: Option<String>,
+    /// Signals if a traffic-preview device list error occurred
+    pub traffic_preview_device_list_error: Option<String>,
     /// Messages status
     pub dots_pulse: (String, u8),
     /// Traffic chart displayed in the Overview page
@@ -168,6 +170,7 @@ impl Sniffer {
             newer_release_available: None,
             capture_source,
             pcap_error: None,
+            traffic_preview_device_list_error: None,
             dots_pulse: (".".to_string(), 0),
             traffic_chart: TrafficChart::new(style, language, data_repr),
             preview_charts,
@@ -864,6 +867,13 @@ impl Sniffer {
     }
 
     fn traffic_preview(&mut self, msg: TrafficPreview) {
+        if let Some(error) = msg.error {
+            self.traffic_preview_device_list_error = Some(error);
+            self.preview_charts.clear();
+            return;
+        }
+
+        self.traffic_preview_device_list_error = None;
         self.preview_charts.retain(|(my_dev, _)| {
             msg.data
                 .iter()
@@ -1065,6 +1075,7 @@ impl Sniffer {
         self.addresses_resolved = HashMap::new();
         self.logged_notifications = LoggedNotifications::default();
         self.pcap_error = None;
+        self.traffic_preview_device_list_error = None;
         self.traffic_chart = TrafficChart::new(style, language, self.conf.data_repr);
         self.modal = None;
         self.settings_page = None;
@@ -1429,6 +1440,7 @@ mod tests {
     use std::path::Path;
     use std::time::Duration;
 
+    use crate::chart::types::preview_chart::PreviewChart;
     use crate::countries::types::country::Country;
     use crate::gui::components::types::my_modal::MyModal;
     use crate::gui::pages::types::settings_page::SettingsPage;
@@ -1441,11 +1453,13 @@ mod tests {
     use crate::gui::types::message::Message;
     use crate::gui::types::settings::Settings;
     use crate::gui::types::timing_events::TimingEvents;
+    use crate::networking::traffic_preview::TrafficPreview;
     use crate::networking::types::capture_context::CaptureSourcePicklist;
     use crate::networking::types::config_device::ConfigDevice;
     use crate::networking::types::data_info::DataInfo;
     use crate::networking::types::data_representation::DataRepr;
     use crate::networking::types::host::Host;
+    use crate::networking::types::my_device::MyDevice;
     use crate::networking::types::program::Program;
     use crate::networking::types::service::Service;
     use crate::networking::types::traffic_direction::TrafficDirection;
@@ -1458,6 +1472,7 @@ mod tests {
     use crate::notifications::types::sound::Sound;
     use crate::report::types::sort_type::SortType;
     use crate::{ByteMultiple, Language, RunningPage, Sniffer, StyleType};
+    use pcap::Device;
 
     // helpful to clean up files generated from tests
     impl Drop for Sniffer {
@@ -1614,6 +1629,41 @@ mod tests {
 
         sniffer.update(Message::Periodic);
         assert_eq!(sniffer.dots_pulse, ("..".to_string(), 0));
+    }
+
+    #[test]
+    #[parallel] // needed to not collide with other tests generating configs files
+    fn test_traffic_preview_error_clears_adapter_list() {
+        let mut sniffer = Sniffer::new(Conf::default());
+        let stale_device = MyDevice::from_pcap_device(Device::from("stale-device"));
+        sniffer.preview_charts =
+            vec![(stale_device, PreviewChart::new(sniffer.conf.settings.style))];
+        sniffer.pcap_error = Some("capture failed".to_string());
+
+        sniffer.update(Message::TrafficPreview(TrafficPreview {
+            data: vec![],
+            error: Some("libpcap returned invalid UTF-8".to_string()),
+        }));
+
+        assert!(sniffer.preview_charts.is_empty());
+        assert_eq!(
+            sniffer.traffic_preview_device_list_error.as_deref(),
+            Some("libpcap returned invalid UTF-8")
+        );
+        assert_eq!(sniffer.pcap_error.as_deref(), Some("capture failed"));
+
+        let recovered_device = MyDevice::from_pcap_device(Device::from("recovered-device"));
+        sniffer.update(Message::TrafficPreview(TrafficPreview {
+            data: vec![(recovered_device, 3)],
+            error: None,
+        }));
+
+        assert!(sniffer.traffic_preview_device_list_error.is_none());
+        assert_eq!(sniffer.preview_charts.len(), 1);
+        assert_eq!(
+            sniffer.preview_charts[0].0.get_name().as_str(),
+            "recovered-device"
+        );
     }
 
     #[test]

--- a/src/networking/traffic_preview.rs
+++ b/src/networking/traffic_preview.rs
@@ -17,6 +17,7 @@ use std::time::{Duration, Instant};
 #[derive(Default, Clone, Debug)]
 pub struct TrafficPreview {
     pub data: Vec<(MyDevice, u128)>,
+    pub error: Option<String>,
 }
 
 pub fn traffic_preview(tx: &Sender<TrafficPreview>) {
@@ -68,8 +69,28 @@ fn handle_devices_and_previews(
     tx: &Sender<TrafficPreview>,
     pcap_tx: &std::sync::mpsc::SyncSender<(Result<PacketOwned, pcap::Error>, Option<Stat>)>,
 ) {
+    handle_device_list_result(Device::list(), data, tx, pcap_tx);
+}
+
+fn handle_device_list_result(
+    devices: Result<Vec<Device>, pcap::Error>,
+    data: &mut HashMap<String, u128>,
+    tx: &Sender<TrafficPreview>,
+    pcap_tx: &std::sync::mpsc::SyncSender<(Result<PacketOwned, pcap::Error>, Option<Stat>)>,
+) {
     let mut traffic_preview = TrafficPreview::default();
-    for dev in Device::list().unwrap_or_default() {
+    let devices = match devices {
+        Ok(devices) => devices,
+        Err(error) => {
+            traffic_preview.error = Some(error.to_string());
+            let _ = tx.send_blocking(traffic_preview);
+            for v in data.values_mut() {
+                *v = 0;
+            }
+            return;
+        }
+    };
+    for dev in devices {
         let dev_name = dev.name.clone();
         let my_dev = MyDevice::from_pcap_device(dev);
         if let Some(n) = data.get(&dev_name) {
@@ -132,4 +153,31 @@ struct DevInfo {
 struct PacketOwned {
     data: Box<[u8]>,
     dev_info: DevInfo,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn traffic_preview_device_list_error() {
+        let (preview_tx, preview_rx) = async_channel::unbounded();
+        let (pcap_tx, _pcap_rx) = std::sync::mpsc::sync_channel(1);
+        let mut data = HashMap::from([("stale-device".to_string(), 42)]);
+
+        handle_device_list_result(
+            Err(pcap::Error::PcapError("invalid UTF-8 sequence".to_string())),
+            &mut data,
+            &preview_tx,
+            &pcap_tx,
+        );
+
+        let preview = preview_rx.try_recv().unwrap();
+        assert!(preview.data.is_empty());
+        assert_eq!(
+            preview.error.as_deref(),
+            Some("libpcap error: invalid UTF-8 sequence")
+        );
+        assert_eq!(data.get("stale-device"), Some(&0));
+    }
 }


### PR DESCRIPTION
## Summary

- Surface `Device::list()` failures from the traffic-preview path instead of treating them like an empty adapter list.
- Show the adapter picker error state when preview device enumeration fails, clearing stale adapter previews instead of showing the loading spinner forever.
- Keep preview device-list errors separate from capture-run `pcap_error`, and clear the preview error after a successful preview update or reset.
- Add focused tests for synthetic libpcap error propagation and Sniffer preview-error recovery.

## Why

Fixes #1225.

On Windows, libpcap can return invalid UTF-8 errors while enumerating adapters. In that case, the traffic-preview path previously collapsed the failure to an empty list, leaving the Network interfaces view stuck on the spinner with no user-visible error.

## Tests

- `cargo fmt --check`
- `git diff --check upstream/main..HEAD`
- `cargo test traffic_preview`
- `cargo test test_traffic_preview_error_clears_adapter_list`
- `cargo test`

## Scope / non-goals

- Does not add lossy decoding or replacement-name logic for Windows adapter names.
- Does not change packet capture behavior, capture filters, or packet parsing.
- Does not use live packet capture, admin/root privileges, VPN state, private traffic, or hardware-specific proof.
- Does not broaden the fix to unrelated `Device::list()` fallback paths outside the initial traffic-preview UI flow.

## Caveats

- Local proof uses synthetic libpcap errors rather than a real Windows 10 + Npcap invalid UTF-8 adapter environment.
- No GUI screenshot smoke was run.
- Open PR #1236 also edits `src/networking/traffic_preview.rs` to log preview-loop errors. It does not duplicate this UI error-state fix, but this branch may need a rebase if #1236 merges first.
- `cargo test` reports the existing future-incompatibility warning for dependency `block v0.1.6`; it is not introduced by this change.
