### PR TITLE
Add tags to .desktop

### DIFF
--- a/resources/packaging/linux/sniffnet.desktop
+++ b/resources/packaging/linux/sniffnet.desktop
@@ -8,4 +8,4 @@ Icon=sniffnet
 Exec=/usr/bin/sniffnet
 StartupWMClass=sniffnet
 Terminal=false
-Keywords=traffic;inspect;
+Keywords=traffic;inspect;monitor;

--- a/resources/packaging/linux/sniffnet.desktop
+++ b/resources/packaging/linux/sniffnet.desktop
@@ -8,4 +8,4 @@ Icon=sniffnet
 Exec=/usr/bin/sniffnet
 StartupWMClass=sniffnet
 Terminal=false
-Keywords=traffic;inspect;monitor;
+Keywords=traffic;inspect;monitor;inspect;internet;network;

--- a/resources/packaging/linux/sniffnet.desktop
+++ b/resources/packaging/linux/sniffnet.desktop
@@ -8,3 +8,4 @@ Icon=sniffnet
 Exec=/usr/bin/sniffnet
 StartupWMClass=sniffnet
 Terminal=false
+Keywords=traffic;inspect;

--- a/resources/packaging/linux/sniffnet.desktop
+++ b/resources/packaging/linux/sniffnet.desktop
@@ -8,4 +8,4 @@ Icon=sniffnet
 Exec=/usr/bin/sniffnet
 StartupWMClass=sniffnet
 Terminal=false
-Keywords=traffic;inspect;monitor;inspect;internet;network;
+Keywords=traffic;inspect;monitor;internet;network;


### PR DESCRIPTION
My DE can't find application in start menu by description
<img width="481" height="134" alt="2" src="https://github.com/user-attachments/assets/dce5477f-47c1-4d09-94c0-39e19038296f" />

so I attached keywords, and now it can.
<img width="572" height="130" alt="1" src="https://github.com/user-attachments/assets/e65d861a-3ea3-4ec4-9bcd-c59b64c50081" />
