### PR TITLE
feat(docker): publish multi-architecture images for amd64 and arm64

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,13 +1,9 @@
-# Ignore everything
 *
-
-# Explicitly allow files
-!src/**/*.rs
-!build.rs
 !Cargo.toml
 !Cargo.lock
-!Dockerfile
+!build.rs
 !services.txt
+!src/**/*.rs
 !resources/embedded_icons/**/*.svg
 !resources/DB/*.mmdb
 !resources/fonts/subset/*.ttf

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,13 +3,18 @@ name: Docker
 on:
   workflow_dispatch:
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
-  docker:
-    name: Docker Build
+  check-version:
+    name: Check version
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
+    outputs:
+      version: ${{ steps.cargo-version.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -21,15 +26,23 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Check there is no existing image with the same version
-        run: |
-          if docker manifest inspect ghcr.io/gyulyvgc/sniffnet:${{ env.VERSION }}; then
-            echo "Image with version ${{ env.VERSION }} already exists"
-            exit 1
-          fi
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+  build:
+    name: Build ${{ matrix.arch }}
+    needs: check-version
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -37,16 +50,43 @@ jobs:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4
         with:
-          registry: ghcr.io
-          username: GyulyVGC
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v7
         with:
           context: .
-          platforms: linux/amd64
+          platforms: linux/${{ matrix.arch }}
           push: true
           tags: |
-            ghcr.io/gyulyvgc/sniffnet:latest
-            ghcr.io/gyulyvgc/sniffnet:${{ env.VERSION }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.check-version.outputs.version }}-${{ matrix.arch }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  merge-manifest:
+    name: Merge multi-arch manifest
+    needs: [check-version, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push multi-arch manifest
+        run: |
+          VERSION=${{ needs.check-version.outputs.version }}
+          BASE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+          docker buildx imagetools create -t "${BASE}:latest" \
+            "${BASE}:${VERSION}-amd64" \
+            "${BASE}:${VERSION}-arm64"
+          docker buildx imagetools create -t "${BASE}:${VERSION}" \
+            "${BASE}:${VERSION}-amd64" \
+            "${BASE}:${VERSION}-arm64"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,10 +2,14 @@ name: Docker
 
 on:
   workflow_dispatch:
+    inputs:
+      force_publish:
+        description: 'Skip version existence check'
+        type: boolean
+        default: false
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   check-version:
@@ -13,8 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: read
     outputs:
       version: ${{ steps.cargo-version.outputs.version }}
+      image: ${{ steps.image-name.outputs.image }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -25,6 +31,21 @@ jobs:
           VERSION=v$(grep -m1 "^version" Cargo.toml | cut -d'"' -f2)
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Compute lowercase image name
+        id: image-name
+        run: |
+          IMAGE="ghcr.io/${GITHUB_REPOSITORY,,}"
+          echo "image=$IMAGE" >> $GITHUB_OUTPUT
+
+      - name: Check existing version
+        if: inputs.force_publish != true
+        run: |
+          if docker buildx imagetools inspect "${{ steps.image-name.outputs.image }}:${{ steps.cargo-version.outputs.version }}" > /dev/null 2>&1; then
+            echo "Image with version ${{ steps.cargo-version.outputs.version }} already exists"
+            echo "Re-run with force_publish=true to overwrite"
+            exit 1
+          fi
 
   build:
     name: Build ${{ matrix.arch }}
@@ -61,9 +82,9 @@ jobs:
           platforms: linux/${{ matrix.arch }}
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.check-version.outputs.version }}-${{ matrix.arch }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+            ${{ needs.check-version.outputs.image }}:${{ needs.check-version.outputs.version }}-${{ matrix.arch }}
+          cache-from: type=gha,scope=sniffnet-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=sniffnet-${{ matrix.arch }}
 
   merge-manifest:
     name: Merge multi-arch manifest
@@ -83,10 +104,18 @@ jobs:
       - name: Create and push multi-arch manifest
         run: |
           VERSION=${{ needs.check-version.outputs.version }}
-          BASE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
-          docker buildx imagetools create -t "${BASE}:latest" \
-            "${BASE}:${VERSION}-amd64" \
-            "${BASE}:${VERSION}-arm64"
-          docker buildx imagetools create -t "${BASE}:${VERSION}" \
-            "${BASE}:${VERSION}-amd64" \
-            "${BASE}:${VERSION}-arm64"
+          IMAGE=${{ needs.check-version.outputs.image }}
+          docker buildx imagetools create \
+            -t "${IMAGE}:latest" \
+            -t "${IMAGE}:${VERSION}" \
+            "${IMAGE}:${VERSION}-amd64" \
+            "${IMAGE}:${VERSION}-arm64"
+
+      - name: Verify manifest
+        run: |
+          IMAGE=${{ needs.check-version.outputs.image }}
+          VERSION=${{ needs.check-version.outputs.version }}
+          echo "=== Manifest: ${IMAGE}:${VERSION} ==="
+          docker buildx imagetools inspect "${IMAGE}:${VERSION}"
+          echo "=== Manifest: ${IMAGE}:latest ==="
+          docker buildx imagetools inspect "${IMAGE}:latest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM rust:1.88-slim AS builder
 
-# Install build dependencies for both X11 and Wayland
 RUN apt-get update && apt-get install -y \
     libfreetype6-dev \
     libexpat1-dev \
@@ -11,15 +10,20 @@ RUN apt-get update && apt-get install -y \
     pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /usr/src/sniffnet
+WORKDIR /app
+
+COPY Cargo.toml Cargo.lock build.rs services.txt ./
+COPY src/networking/types/service_query.rs src/networking/types/service_query.rs
+COPY src/networking/types/protocol.rs src/networking/types/protocol.rs
+RUN mkdir -p src && echo 'fn main() {}' > src/main.rs
+RUN cargo build --release --config 'profile.release.lto="thin"'
+RUN rm -rf src
+
 COPY . .
+RUN cargo build --release --config 'profile.release.lto="thin"'
 
-RUN cargo build --release
-
-# Runtime stage
 FROM debian:bookworm-slim
 
-# Install runtime dependencies for both X11 and Wayland
 RUN apt-get update && apt-get install -y \
     libfreetype6 \
     libexpat1 \
@@ -29,6 +33,9 @@ RUN apt-get update && apt-get install -y \
     libgtk-3-0 \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /usr/src/sniffnet/target/release/sniffnet /usr/local/bin/sniffnet
+RUN useradd -m -u 1000 sniffnet
+USER sniffnet
+
+COPY --from=builder /app/target/release/sniffnet /usr/local/bin/sniffnet
 
 ENTRYPOINT ["sniffnet"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,6 @@ RUN apt-get update && apt-get install -y \
     libgtk-3-0 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN useradd -m -u 1000 sniffnet
-USER sniffnet
-
 COPY --from=builder /app/target/release/sniffnet /usr/local/bin/sniffnet
 
 ENTRYPOINT ["sniffnet"]


### PR DESCRIPTION
Closes #1252

## Summary

Publish Docker images as a multi-platform OCI manifest for `linux/amd64` and `linux/arm64`.

## Changes

- Build each platform on its native GitHub-hosted runner.
- Push architecture-specific images, then merge them under the version and `latest` tags.
- Isolate GitHub Actions BuildKit caches per architecture.
- Normalize the GHCR image name to lowercase.
- Add a dependency-cache layer and thin LTO to keep ARM64 builds within runner resources.
- Preserve the existing root runtime user so packet capture retains its required capabilities.
- Refuse version-tag overwrites by default; `force_publish` explicitly enables an existing amd64-only version to be migrated.

## Validation

- The workflow completed successfully in this fork.
- `ghcr.io/luojiyin1987/sniffnet:v1.5.0` was inspected and contains `linux/amd64` and `linux/arm64` manifests.
- `docker buildx build --check` completed for `linux/amd64` and `linux/arm64`.
- `git diff --check` passed.