### PR TITLE
Set Content-Type on remote notification requests

### DIFF
--- a/src/notifications/notify_and_log.rs
+++ b/src/notifications/notify_and_log.rs
@@ -234,6 +234,7 @@ fn send_remote_notification(
             let Ok(response) = client
                 .post(remote_notifications.url())
                 .header("User-agent", format!("{SNIFFNET_LOWERCASE}-{APP_VERSION}"))
+                .header("Content-Type", "application/json")
                 .body(notification.to_json())
                 .send()
                 .await


### PR DESCRIPTION
### Problem

Remote notifications POST a JSON body without declaring it as JSON.

`src/notifications/notify_and_log.rs` builds the request as:

```rust
client
    .post(remote_notifications.url())
    .header("User-agent", format!("{SNIFFNET_LOWERCASE}-{APP_VERSION}"))
    .body(notification.to_json())
```

`RequestBuilder::body` only sets the payload; unlike `json()`, it does not add a `Content-Type` header. There is no other place that adds one — `grep -rn -i content.type src/` returns nothing.

The body really is JSON: `LoggedNotification::to_json` builds it with `serde_json::json!` (`src/notifications/types/logged_notification.rs`).

So the request arrives with no content type at all. The wiki page on remote notifications describes the payload as JSON and suggests IFTTT, Svix and SIGNL4 as receivers — services that dispatch on `Content-Type`. Strict receivers reject such a request, lenient ones fall back to guessing.

### Change

One header, `Content-Type: application/json`, written in the same style as the `User-agent` line right above it.

### Checks

- `cargo fmt --check` — clean
- `cargo check` — clean
- `cargo clippy --all-targets` — 57 warnings before the change and 57 after, so nothing new is introduced

I did not add a test: there is currently no harness that inspects the shape of the outgoing request, and wiring a mock HTTP server in for a one-line header felt out of proportion. Happy to add one if you would prefer it.