### PR TITLE
fix(inspect): allow favorites for unresolved hosts

### DIFF
--- a/src/report/types/search_parameters.rs
+++ b/src/report/types/search_parameters.rs
@@ -68,10 +68,7 @@ impl SearchParameters {
     }
 
     fn is_some_host_filter_active(&self) -> bool {
-        self.only_favorites
-            || !self.country.is_empty()
-            || !self.as_name.is_empty()
-            || !self.domain.is_empty()
+        !self.country.is_empty() || !self.as_name.is_empty() || !self.domain.is_empty()
     }
 
     pub fn new_host_search(host: &Host) -> Self {
@@ -99,6 +96,31 @@ impl SearchParameters {
             program: program.to_string_with_equal_prefix(),
             ..SearchParameters::default()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SearchParameters;
+
+    #[test]
+    fn favorites_only_does_not_require_reverse_dns() {
+        let search = SearchParameters {
+            only_favorites: true,
+            ..SearchParameters::default()
+        };
+
+        assert!(!search.is_some_host_filter_active());
+    }
+
+    #[test]
+    fn host_filters_still_require_reverse_dns() {
+        let search = SearchParameters {
+            domain: "example.com".to_string(),
+            ..SearchParameters::default()
+        };
+
+        assert!(search.is_some_host_filter_active());
     }
 }
 


### PR DESCRIPTION
## Summary

- allow favorites-only filtering before reverse DNS resolution completes
- keep country, ASN, and domain filters gated on resolved host data
- add focused regression tests for both behaviors

## Validation

- cargo fmt --all -- --check
- cargo test --bin sniffnet search_parameters

The current early return treats `only_favorites` as a host filter, which hides favorited service/program entries while their host metadata is still unresolved.