### PR TITLE
Support IGMP packets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All Sniffnet releases with the relative changes are documented in this file.
 - Show output file path in Overview page when exporting a PCAP file ([`3f2c42c`](https://github.com/GyulyVGC/sniffnet/pull/1290/commits/3f2c42c70f06d5d29ddad80dde956281c6705511))
 - Fix the app freezing and exhausting memory when importing a PCAP file containing a large time gap between consecutive packets ([`4605ec7`](https://github.com/GyulyVGC/sniffnet/pull/1290/commits/4605ec717bbaf8fa34268805814d5585f084201e))
 - Restrict the PCAP export file to have a valid PCAP extension, so that files of other types can't be overwritten ([`5b4801b`](https://github.com/GyulyVGC/sniffnet/pull/1290/commits/5b4801b438ff1c7968cfac423a8e8585778309a8))
+- Support IGMP packets: they are now recognized as their own protocol instead of being discarded, and the connection details report the IGMP message types exchanged ([#1269](https://github.com/GyulyVGC/sniffnet/issues/1269))
 - Correctly filter by favorites-only before rDNS completes ([#1275](https://github.com/GyulyVGC/sniffnet/pull/1275))
 - Set `Content-Type: application/json` header on remote notifications ([#1266](https://github.com/GyulyVGC/sniffnet/pull/1266))
 

--- a/src/gui/pages/connection_details_page.rs
+++ b/src/gui/pages/connection_details_page.rs
@@ -20,6 +20,7 @@ use crate::networking::types::bogon::is_bogon;
 use crate::networking::types::data_representation::DataRepr;
 use crate::networking::types::host::Host;
 use crate::networking::types::icmp_type::IcmpType;
+use crate::networking::types::igmp_type::IgmpType;
 use crate::networking::types::info_address_port_pair::InfoAddressPortPair;
 use crate::networking::types::latency::LatencyStatus;
 use crate::networking::types::traffic_direction::TrafficDirection;
@@ -163,7 +164,7 @@ fn page_header<'a>(
     .class(ContainerType::Gradient(color_gradient))
 }
 
-#[allow(clippy::too_many_lines)]
+#[allow(clippy::too_many_lines, clippy::similar_names)]
 fn col_info<'a>(
     sniffer: &Sniffer,
     key: &AddressPortPair,
@@ -179,6 +180,7 @@ fn col_info<'a>(
     ) == TrafficType::Unicast;
     let measure_latency = sniffer.capture_source.supports_latency() && is_unicast;
     let is_icmp = key.protocol.eq(&Protocol::ICMP);
+    let is_igmp = key.protocol.eq(&Protocol::IGMP);
     let is_arp = key.protocol.eq(&Protocol::ARP);
 
     let mut ret_val = Column::new()
@@ -211,7 +213,7 @@ fn col_info<'a>(
         &key.protocol.to_string(),
     ));
 
-    if !is_icmp && !is_arp {
+    if !is_icmp && !is_igmp && !is_arp {
         ret_val = ret_val.push(TextType::highlighted_subtitle_with_desc(
             service_translation(language),
             &val.service.to_string(),
@@ -256,6 +258,8 @@ fn col_info<'a>(
 
     let messages = if is_icmp {
         IcmpType::pretty_print_types(&val.icmp_types)
+    } else if is_igmp {
+        IgmpType::pretty_print_types(&val.igmp_types)
     } else if is_arp {
         ArpType::pretty_print_types(&val.arp_types)
     } else {

--- a/src/networking/ipfix/collect.rs
+++ b/src/networking/ipfix/collect.rs
@@ -237,6 +237,7 @@ fn ingest_flow_record(
         &[],
         mac_addresses,
         None,
+        None,
         ArpType::default(),
         exchanged_packets,
         exchanged_bytes,

--- a/src/networking/manage_packets.rs
+++ b/src/networking/manage_packets.rs
@@ -14,6 +14,7 @@ use crate::networking::types::bogon::is_bogon;
 use crate::networking::types::data_info::DataInfo;
 use crate::networking::types::data_info_host::DataInfoHost;
 use crate::networking::types::icmp_type::{IcmpType, IcmpTypeV4, IcmpTypeV6};
+use crate::networking::types::igmp_type::IgmpType;
 use crate::networking::types::info_address_port_pair::InfoAddressPortPair;
 use crate::networking::types::info_traffic::InfoTraffic;
 use crate::networking::types::ip_blacklist::IpBlacklist;
@@ -29,11 +30,13 @@ include!(concat!(env!("OUT_DIR"), "/services.rs"));
 
 /// Calls methods to analyze link, network, and transport headers.
 /// Returns the relevant collected information.
+#[allow(clippy::similar_names)]
 pub fn analyze_headers(
     headers: LaxPacketHeaders,
     mac_addresses: &mut (Option<[u8; 6]>, Option<[u8; 6]>),
     exchanged_bytes: &mut u128,
     icmp_type: &mut IcmpType,
+    igmp_type: &mut IgmpType,
     arp_type: &mut ArpType,
 ) -> Option<AddressPortPair> {
     let mut retval = AddressPortPair::default();
@@ -64,6 +67,7 @@ pub fn analyze_headers(
             &mut retval.dport,
             &mut retval.protocol,
             icmp_type,
+            igmp_type,
         )
     {
         return None;
@@ -168,12 +172,14 @@ fn analyze_network_header(
 /// This function analyzes the transport layer header passed as parameter and updates variables
 /// passed by reference on the basis of the packet header content.
 /// Returns false if packet has to be skipped.
+#[allow(clippy::similar_names)]
 fn analyze_transport_header(
     transport_header: Option<TransportHeader>,
     port1: &mut Option<u16>,
     port2: &mut Option<u16>,
     protocol: &mut Protocol,
     icmp_type: &mut IcmpType,
+    igmp_type: &mut IgmpType,
 ) -> bool {
     match transport_header {
         Some(TransportHeader::Udp(udp_header)) => {
@@ -202,10 +208,12 @@ fn analyze_transport_header(
             *icmp_type = IcmpTypeV6::from_etherparse(&icmpv6_header.icmp_type);
             true
         }
-        Some(TransportHeader::Igmp(_)) => {
-            #[allow(clippy::match_same_arms)]
-            // TODO!
-            false
+        Some(TransportHeader::Igmp(igmp_header)) => {
+            *port1 = None;
+            *port2 = None;
+            *protocol = Protocol::IGMP;
+            *igmp_type = IgmpType::from_etherparse(&igmp_header.igmp_type);
+            true
         }
         None => false,
     }
@@ -216,7 +224,10 @@ pub fn get_service(
     traffic_direction: TrafficDirection,
     my_interface_addresses: &[Address],
 ) -> Service {
-    if key.protocol == Protocol::ICMP || key.protocol == Protocol::ARP {
+    if key.protocol == Protocol::ICMP
+        || key.protocol == Protocol::IGMP
+        || key.protocol == Protocol::ARP
+    {
         return Service::NotApplicable;
     }
 
@@ -263,13 +274,14 @@ pub fn get_service(
 }
 
 /// Function to insert the source and destination of a packet into the map containing the analyzed traffic
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::similar_names)]
 pub fn modify_or_insert_in_map(
     info_traffic_msg: &mut InfoTraffic,
     key: &AddressPortPair,
     my_interface_addresses: &[Address],
     mac_addresses: (Option<[u8; 6]>, Option<[u8; 6]>),
     icmp_type: Option<IcmpType>,
+    igmp_type: Option<IgmpType>,
     arp_type: ArpType,
     exchanged_packets: u128,
     exchanged_bytes: u128,
@@ -326,6 +338,14 @@ pub fn modify_or_insert_in_map(
                     .and_modify(|n| *n += 1)
                     .or_insert(1);
             }
+            if key.protocol.eq(&Protocol::IGMP)
+                && let Some(igmp_type) = igmp_type
+            {
+                info.igmp_types
+                    .entry(igmp_type)
+                    .and_modify(|n| *n += 1)
+                    .or_insert(1);
+            }
             if key.protocol.eq(&Protocol::ARP) {
                 info.arp_types
                     .entry(arp_type)
@@ -347,6 +367,13 @@ pub fn modify_or_insert_in_map(
                 && let Some(icmp_type) = icmp_type
             {
                 HashMap::from([(icmp_type, 1)])
+            } else {
+                HashMap::new()
+            },
+            igmp_types: if key.protocol.eq(&Protocol::IGMP)
+                && let Some(igmp_type) = igmp_type
+            {
+                HashMap::from([(igmp_type, 1)])
             } else {
                 HashMap::new()
             },

--- a/src/networking/parse_packets.rs
+++ b/src/networking/parse_packets.rs
@@ -12,6 +12,7 @@ use crate::networking::manage_packets::{
 use crate::networking::types::arp_type::ArpType;
 use crate::networking::types::capture_context::{CaptureContext, CaptureSource, CaptureType};
 use crate::networking::types::icmp_type::IcmpType;
+use crate::networking::types::igmp_type::IgmpType;
 use crate::networking::types::info_traffic::InfoTraffic;
 use crate::networking::types::ip_blacklist::IpBlacklist;
 use crate::networking::types::my_link_type::MyLinkType;
@@ -25,7 +26,11 @@ use std::time::{Duration, Instant};
 use tokio::sync::broadcast::Receiver;
 
 /// The calling thread enters a loop in which it waits for network packets
-#[allow(clippy::too_many_lines, clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_lines,
+    clippy::too_many_arguments,
+    clippy::similar_names
+)]
 pub fn parse_packets(
     cap_id: usize,
     mut cs: CaptureSource,
@@ -137,6 +142,7 @@ pub fn parse_packets(
                     let mut exchanged_bytes = 0;
                     let mut mac_addresses = (None, None);
                     let mut icmp_type = IcmpType::default();
+                    let mut igmp_type = IgmpType::default();
                     let mut arp_type = ArpType::default();
 
                     let key_option = analyze_headers(
@@ -144,6 +150,7 @@ pub fn parse_packets(
                         &mut mac_addresses,
                         &mut exchanged_bytes,
                         &mut icmp_type,
+                        &mut igmp_type,
                         &mut arp_type,
                     );
 
@@ -166,6 +173,7 @@ pub fn parse_packets(
                         cs.get_addresses(),
                         mac_addresses,
                         Some(icmp_type),
+                        Some(igmp_type),
                         arp_type,
                         1,
                         exchanged_bytes,

--- a/src/networking/traffic_preview.rs
+++ b/src/networking/traffic_preview.rs
@@ -5,6 +5,7 @@ use crate::networking::parse_packets::get_sniffable_headers;
 use crate::networking::types::arp_type::ArpType;
 use crate::networking::types::capture_context::{CaptureContext, CaptureSource, CaptureType};
 use crate::networking::types::icmp_type::IcmpType;
+use crate::networking::types::igmp_type::IgmpType;
 use crate::networking::types::my_device::MyDevice;
 use crate::networking::types::my_link_type::MyLinkType;
 use crate::utils::error_logger::{ErrorLogger, Location};
@@ -51,6 +52,7 @@ pub fn traffic_preview(tx: &Sender<TrafficPreview>) {
                     &mut (None, None),
                     &mut 0,
                     &mut IcmpType::default(),
+                    &mut IgmpType::default(),
                     &mut ArpType::default(),
                 )
                 .is_some()

--- a/src/networking/types/igmp_type.rs
+++ b/src/networking/types/igmp_type.rs
@@ -1,0 +1,119 @@
+use std::collections::HashMap;
+use std::fmt::Write;
+use std::fmt::{Display, Formatter};
+
+use etherparse::IgmpType as EtherparseIgmpType;
+
+/// Type of an IGMP (Internet Group Management Protocol) message.
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Default, Debug)]
+#[allow(clippy::module_name_repetitions)]
+pub enum IgmpType {
+    /// Membership Query (IGMP v1 and v2).
+    MembershipQuery,
+    /// Membership Query with sources (IGMP v3).
+    MembershipQueryV3,
+    /// Membership Report (introduced in IGMP v1).
+    MembershipReportV1,
+    /// Membership Report (introduced in IGMP v2).
+    MembershipReportV2,
+    /// Membership Report (introduced in IGMP v3).
+    MembershipReportV3,
+    /// Leave Group (introduced in IGMP v2).
+    LeaveGroup,
+    /// Unknown IGMP message type.
+    #[default]
+    Unknown,
+}
+
+impl IgmpType {
+    pub fn from_etherparse(igmp_type: &EtherparseIgmpType) -> IgmpType {
+        match igmp_type {
+            EtherparseIgmpType::MembershipQuery(_) => Self::MembershipQuery,
+            EtherparseIgmpType::MembershipQueryWithSources(_) => Self::MembershipQueryV3,
+            EtherparseIgmpType::MembershipReportV1(_) => Self::MembershipReportV1,
+            EtherparseIgmpType::MembershipReportV2(_) => Self::MembershipReportV2,
+            EtherparseIgmpType::MembershipReportV3(_) => Self::MembershipReportV3,
+            EtherparseIgmpType::LeaveGroup(_) => Self::LeaveGroup,
+            EtherparseIgmpType::Unknown(_) => Self::Unknown,
+        }
+    }
+
+    pub fn pretty_print_types(map: &HashMap<IgmpType, usize>) -> String {
+        let mut ret_val = String::new();
+
+        let mut vec: Vec<(&IgmpType, &usize)> = map.iter().collect();
+        vec.sort_by(|(_, a), (_, b)| b.cmp(a));
+
+        for (igmp_type, n) in vec {
+            let _ = writeln!(ret_val, "   {igmp_type} ({n})");
+        }
+        ret_val
+    }
+}
+
+impl Display for IgmpType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                IgmpType::MembershipQuery => "Membership Query",
+                IgmpType::MembershipQueryV3 => "Membership Query (v3)",
+                IgmpType::MembershipReportV1 => "Membership Report (v1)",
+                IgmpType::MembershipReportV2 => "Membership Report (v2)",
+                IgmpType::MembershipReportV3 => "Membership Report (v3)",
+                IgmpType::LeaveGroup => "Leave Group",
+                IgmpType::Unknown => "?",
+            }
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use crate::networking::types::igmp_type::IgmpType;
+
+    #[test]
+    fn test_igmp_type_default_is_unknown() {
+        assert_eq!(IgmpType::default(), IgmpType::Unknown);
+    }
+
+    #[test]
+    fn test_igmp_type_display() {
+        assert_eq!(IgmpType::MembershipQuery.to_string(), "Membership Query");
+        assert_eq!(
+            IgmpType::MembershipQueryV3.to_string(),
+            "Membership Query (v3)"
+        );
+        assert_eq!(
+            IgmpType::MembershipReportV1.to_string(),
+            "Membership Report (v1)"
+        );
+        assert_eq!(
+            IgmpType::MembershipReportV2.to_string(),
+            "Membership Report (v2)"
+        );
+        assert_eq!(
+            IgmpType::MembershipReportV3.to_string(),
+            "Membership Report (v3)"
+        );
+        assert_eq!(IgmpType::LeaveGroup.to_string(), "Leave Group");
+        assert_eq!(IgmpType::Unknown.to_string(), "?");
+    }
+
+    #[test]
+    fn test_igmp_pretty_print_types_sorted_by_count_desc() {
+        let map = HashMap::from([
+            (IgmpType::MembershipReportV2, 2),
+            (IgmpType::LeaveGroup, 5),
+            (IgmpType::MembershipQuery, 1),
+        ]);
+        let pretty = IgmpType::pretty_print_types(&map);
+        assert_eq!(
+            pretty,
+            "   Leave Group (5)\n   Membership Report (v2) (2)\n   Membership Query (1)\n"
+        );
+    }
+}

--- a/src/networking/types/info_address_port_pair.rs
+++ b/src/networking/types/info_address_port_pair.rs
@@ -6,6 +6,7 @@ use crate::networking::types::arp_type::ArpType;
 use crate::networking::types::data_info::DataInfo;
 use crate::networking::types::data_representation::DataRepr;
 use crate::networking::types::icmp_type::IcmpType;
+use crate::networking::types::igmp_type::IgmpType;
 use crate::networking::types::program::Program;
 use crate::networking::types::traffic_direction::TrafficDirection;
 use crate::report::types::sort_type::SortType;
@@ -39,6 +40,8 @@ pub struct InfoAddressPortPair {
     pub traffic_direction: TrafficDirection,
     /// Types of the ICMP messages exchanged, with the relative count (this is empty if not ICMP)
     pub icmp_types: HashMap<IcmpType, usize>,
+    /// Types of the IGMP messages exchanged, with the relative count (this is empty if not IGMP)
+    pub igmp_types: HashMap<IgmpType, usize>,
     /// Types of the ARP operations, with the relative count (this is empty if not ARP)
     pub arp_types: HashMap<ArpType, usize>,
     /// Whether the remote address is blacklisted
@@ -67,6 +70,12 @@ impl InfoAddressPortPair {
         for (icmp_type, count) in &other.icmp_types {
             self.icmp_types
                 .entry(*icmp_type)
+                .and_modify(|v| *v += count)
+                .or_insert(*count);
+        }
+        for (igmp_type, count) in &other.igmp_types {
+            self.igmp_types
+                .entry(*igmp_type)
                 .and_modify(|v| *v += count)
                 .or_insert(*count);
         }
@@ -123,6 +132,7 @@ impl Default for InfoAddressPortPair {
             service: Service::default(),
             traffic_direction: TrafficDirection::default(),
             icmp_types: HashMap::new(),
+            igmp_types: HashMap::new(),
             arp_types: HashMap::new(),
             is_blacklisted: false,
             program: Program::default(),

--- a/src/networking/types/mod.rs
+++ b/src/networking/types/mod.rs
@@ -10,6 +10,7 @@ pub mod data_info_host;
 pub mod data_representation;
 pub mod host;
 pub mod icmp_type;
+pub mod igmp_type;
 pub mod info_address_port_pair;
 pub mod info_traffic;
 pub mod ip_blacklist;

--- a/src/networking/types/protocol.rs
+++ b/src/networking/types/protocol.rs
@@ -10,6 +10,8 @@ pub enum Protocol {
     UDP,
     /// Internet Control Message Protocol
     ICMP,
+    /// Internet Group Management Protocol
+    IGMP,
     /// Address Resolution Protocol
     ARP,
 }


### PR DESCRIPTION
## What

Closes #1269 — adds IGMP support.

IGMP packets were already matched in `analyze_transport_header`, but the arm returned `false` with a `// TODO!`, so every IGMP packet was silently discarded and never showed up in Sniffnet. This PR recognizes IGMP as its own protocol and records the IGMP message type per connection, mirroring the existing ICMP/ARP handling.

## Changes

- Added `Protocol::IGMP` and a new `IgmpType` (`src/networking/types/igmp_type.rs`) that maps etherparse's `IgmpType` to the message categories (Membership Query v1/v2 and v3, Membership Report v1/v2/v3, Leave Group, Unknown), with `Display`/`pretty_print_types` matching the ICMP type module.
- `analyze_transport_header` now returns `true` for IGMP, sets the protocol, and records the message type; the type is threaded through `analyze_headers` → `modify_or_insert_in_map` → `InfoAddressPortPair.igmp_types` exactly like `icmp_types`/`arp_types`.
- `get_service` treats IGMP as `NotApplicable` (no ports), and the connection details page shows the IGMP message-type breakdown under the existing "Messages" label (no new translation string needed).
- Added unit tests for the `IgmpType` display, default, and aggregation ordering, and a CHANGELOG entry.

`cargo test`, `cargo clippy -- -D warnings`, and `cargo fmt --all -- --check` all pass locally.

## Disclosure

Per the contributing manifesto: I used AI assistance while writing this change. I've reviewed and understand every line, verified it against the existing ICMP/ARP code paths, and I'm happy to walk through or adjust any part of it. Flagging early in case you'd rather scope IGMP differently (e.g. message-type granularity) before it goes further.
