### PR TITLE
IPFIX collector: support multiple exporters

### DIFF
--- a/src/gui/pages/connection_details_page.rs
+++ b/src/gui/pages/connection_details_page.rs
@@ -37,7 +37,7 @@ use crate::translations::translations_3::{
     copy_translation, messages_translation, service_translation,
 };
 use crate::translations::translations_5::program_translation;
-use crate::translations::translations_6::latency_translation;
+use crate::translations::translations_6::{exporter_translation, latency_translation};
 use crate::utils::formatted_strings::{
     get_formatted_timestamp, get_socket_address, mac_from_dec_to_hex,
 };
@@ -163,6 +163,7 @@ fn page_header<'a>(
     .class(ContainerType::Gradient(color_gradient))
 }
 
+#[allow(clippy::too_many_lines)]
 fn col_info<'a>(
     sniffer: &Sniffer,
     key: &AddressPortPair,
@@ -212,6 +213,14 @@ fn col_info<'a>(
                 &val.program.to_string(),
             ));
         }
+    }
+
+    // only IPFIX flows are reported by an exporter
+    if let Some(exporter) = key.exporter {
+        ret_val = ret_val.push(TextType::highlighted_subtitle_with_desc(
+            exporter_translation(language),
+            &exporter.to_string(),
+        ));
     }
 
     ret_val = ret_val.push(TextType::highlighted_subtitle_with_desc(

--- a/src/gui/pages/connection_details_page.rs
+++ b/src/gui/pages/connection_details_page.rs
@@ -37,7 +37,7 @@ use crate::translations::translations_3::{
     copy_translation, messages_translation, service_translation,
 };
 use crate::translations::translations_5::program_translation;
-use crate::translations::translations_6::{exporter_translation, latency_translation};
+use crate::translations::translations_6::{ipfix_exporter_translation, latency_translation};
 use crate::utils::formatted_strings::{
     get_formatted_timestamp, get_socket_address, mac_from_dec_to_hex,
 };
@@ -196,11 +196,20 @@ fn col_info<'a>(
                     get_formatted_timestamp(val.initial_timestamp),
                     get_formatted_timestamp(val.final_timestamp)
                 ))),
-        )
-        .push(TextType::highlighted_subtitle_with_desc(
-            protocol_translation(language),
-            &key.protocol.to_string(),
+        );
+
+    // only IPFIX flows are reported by an exporter
+    if let Some(exporter) = key.exporter {
+        ret_val = ret_val.push(TextType::highlighted_subtitle_with_desc(
+            ipfix_exporter_translation(language),
+            &exporter.to_string(),
         ));
+    }
+
+    ret_val = ret_val.push(TextType::highlighted_subtitle_with_desc(
+        protocol_translation(language),
+        &key.protocol.to_string(),
+    ));
 
     if !is_icmp && !is_arp {
         ret_val = ret_val.push(TextType::highlighted_subtitle_with_desc(
@@ -213,14 +222,6 @@ fn col_info<'a>(
                 &val.program.to_string(),
             ));
         }
-    }
-
-    // only IPFIX flows are reported by an exporter
-    if let Some(exporter) = key.exporter {
-        ret_val = ret_val.push(TextType::highlighted_subtitle_with_desc(
-            exporter_translation(language),
-            &exporter.to_string(),
-        ));
     }
 
     ret_val = ret_val.push(TextType::highlighted_subtitle_with_desc(

--- a/src/gui/pages/inspect_page.rs
+++ b/src/gui/pages/inspect_page.rs
@@ -36,6 +36,7 @@ use crate::translations::translations_2::{
     only_show_favorites_translation, showing_results_translation,
 };
 use crate::translations::translations_5::{only_show_blacklisted_translation, program_translation};
+use crate::translations::translations_6::exporter_translation;
 use crate::utils::formatted_strings::clip_text;
 use crate::utils::types::icon::Icon;
 use crate::{Language, RunningPage, Sniffer, StyleType};
@@ -78,6 +79,7 @@ pub fn inspect_page(sniffer: &Sniffer) -> Container<'_, Message, StyleType> {
             &sniffer.combobox_data_states.states,
             language,
             sniffer.program_lookup.as_ref(),
+            sniffer.capture_source.supports_exporters(),
         ))
         .push(
             Container::new(col_report)
@@ -278,6 +280,7 @@ fn additional_filters_row<'a>(
     combobox_states: &'a ComboboxStates,
     language: Language,
     program_lookup: Option<&'a ProgramLookup>,
+    supports_exporters: bool,
 ) -> Row<'a, Message, StyleType> {
     let clear_all_filters: Element<'a, Message, StyleType> =
         if SearchParameters::default().eq(search_params) {
@@ -329,6 +332,15 @@ fn additional_filters_row<'a>(
         .width(160)
     });
 
+    let combobox_exporter = supports_exporters.then(|| {
+        filter_combobox(
+            FilterInputType::Exporter,
+            &combobox_states.exporters,
+            search_params.clone(),
+        )
+        .width(200)
+    });
+
     let container_country = Row::new()
         .spacing(5)
         .align_y(Alignment::Center)
@@ -353,6 +365,14 @@ fn additional_filters_row<'a>(
             .align_y(Alignment::Center)
             .push(Text::new(format!("{}:", program_translation(language))))
             .push(combobox_program)
+    });
+
+    let container_exporter = combobox_exporter.map(|combobox_exporter| {
+        Row::new()
+            .spacing(5)
+            .align_y(Alignment::Center)
+            .push(Text::new(format!("{}:", exporter_translation(language))))
+            .push(combobox_exporter)
     });
 
     let favorites_only = toggler_filter(
@@ -389,6 +409,7 @@ fn additional_filters_row<'a>(
             .push(container_domain)
             .push(container_as_name)
             .push(container_program)
+            .push(container_exporter)
             .wrap()
             .vertical_spacing(5),
     )

--- a/src/gui/pages/inspect_page.rs
+++ b/src/gui/pages/inspect_page.rs
@@ -36,7 +36,7 @@ use crate::translations::translations_2::{
     only_show_favorites_translation, showing_results_translation,
 };
 use crate::translations::translations_5::{only_show_blacklisted_translation, program_translation};
-use crate::translations::translations_6::exporter_translation;
+use crate::translations::translations_6::ipfix_exporter_translation;
 use crate::utils::formatted_strings::clip_text;
 use crate::utils::types::icon::Icon;
 use crate::{Language, RunningPage, Sniffer, StyleType};
@@ -338,7 +338,7 @@ fn additional_filters_row<'a>(
             &combobox_states.exporters,
             search_params.clone(),
         )
-        .width(200)
+        .width(240)
     });
 
     let container_country = Row::new()
@@ -371,7 +371,10 @@ fn additional_filters_row<'a>(
         Row::new()
             .spacing(5)
             .align_y(Alignment::Center)
-            .push(Text::new(format!("{}:", exporter_translation(language))))
+            .push(Text::new(format!(
+                "{}:",
+                ipfix_exporter_translation(language)
+            )))
             .push(combobox_exporter)
     });
 
@@ -400,18 +403,19 @@ fn additional_filters_row<'a>(
     );
 
     let container = Container::new(
-        Row::new()
-            .align_y(Alignment::Center)
-            .spacing(25)
-            .push(blacklisted_only)
-            .push(favorites_only)
-            .push(container_country)
-            .push(container_domain)
-            .push(container_as_name)
-            .push(container_program)
-            .push(container_exporter)
-            .wrap()
-            .vertical_spacing(5),
+        Column::new().spacing(5).push(container_exporter).push(
+            Row::new()
+                .align_y(Alignment::Center)
+                .spacing(25)
+                .push(blacklisted_only)
+                .push(favorites_only)
+                .push(container_country)
+                .push(container_domain)
+                .push(container_as_name)
+                .push(container_program)
+                .wrap()
+                .vertical_spacing(5),
+        ),
     )
     .padding(10)
     .class(ContainerType::BorderedRound);

--- a/src/gui/pages/overview_page.rs
+++ b/src/gui/pages/overview_page.rs
@@ -22,6 +22,7 @@ use crate::gui::types::settings::Settings;
 use crate::networking::types::capture_context::CaptureSource;
 use crate::networking::types::data_info::DataInfo;
 use crate::networking::types::data_representation::DataRepr;
+use crate::networking::types::ipfix_exporter::IpfixExporter;
 use crate::report::types::sort_type::SortType;
 use crate::translations::translations::{
     active_filters_translation, incoming_translation, none_translation, outgoing_translation,
@@ -31,6 +32,7 @@ use crate::translations::translations_2::{
     data_representation_translation, dropped_translation, only_top_30_items_translation,
 };
 use crate::translations::translations_5::no_favorites_saved_translation;
+use crate::translations::translations_6::ipfix_exporters_translation;
 use crate::utils::types::icon::Icon;
 use crate::{Language, RunningPage, StyleType};
 use iced::Length::Fill;
@@ -38,8 +40,9 @@ use iced::alignment::{Horizontal, Vertical};
 use iced::widget::scrollable::Direction;
 use iced::widget::text::{LineHeight, Wrapping};
 use iced::widget::tooltip::Position;
-use iced::widget::{Button, Column, Container, Row, Scrollable, Space, Text, Tooltip, button};
+use iced::widget::{Button, Column, Container, Row, Scrollable, Space, Text, Tooltip, button, row};
 use iced::{Alignment, Element, Length, Padding};
+use std::collections::BTreeSet;
 
 /// Computes the body of gui overview page
 pub fn overview_page(sniffer: &Sniffer) -> Container<'_, Message, StyleType> {
@@ -261,7 +264,12 @@ pub fn item_bar<'a>(
 fn col_info(sniffer: &Sniffer) -> Container<'_, Message, StyleType> {
     let Settings { language, .. } = sniffer.conf.settings;
 
-    let col_device = col_device(language, &sniffer.capture_source, &sniffer.conf.filters);
+    let col_device = col_device(
+        language,
+        &sniffer.capture_source,
+        &sniffer.conf.filters,
+        &sniffer.combobox_data_states.data.exporters.0,
+    );
 
     let col_data_representation = col_data_representation(language, sniffer.conf.data_repr);
 
@@ -319,6 +327,7 @@ pub(crate) fn col_device<'a>(
     language: Language,
     cs: &'a CaptureSource,
     filters: &'a Filters,
+    exporters: &'a BTreeSet<IpfixExporter>,
 ) -> Column<'a, Message, StyleType> {
     let link_type = cs.get_link_type();
     #[cfg(not(target_os = "windows"))]
@@ -349,6 +358,12 @@ pub(crate) fn col_device<'a>(
         Text::new(none_translation(language)).into()
     };
 
+    let exporters_desc: Element<Message, StyleType> = if exporters.is_empty() {
+        Text::new(none_translation(language)).into()
+    } else {
+        get_exporters_row(exporters).into()
+    };
+
     Column::new()
         .height(Length::Fill)
         .spacing(10)
@@ -362,6 +377,18 @@ pub(crate) fn col_device<'a>(
                         .push(tooltip_content.map(get_info_tooltip)),
                 ),
         )
+        .push(if cs.supports_exporters() {
+            Some(
+                Column::new()
+                    .push(
+                        Text::new(format!("{}:", ipfix_exporters_translation(language)))
+                            .class(TextType::Subtitle),
+                    )
+                    .push(Row::new().push(Text::new("   ")).push(exporters_desc)),
+            )
+        } else {
+            None
+        })
         .push(if cs.supports_filters() {
             Some(
                 Column::new()
@@ -374,6 +401,21 @@ pub(crate) fn col_device<'a>(
         } else {
             None
         })
+}
+
+/// The exporters flow records have been received from, in the same style as the adapter addresses
+fn get_exporters_row<'a>(
+    exporters: &BTreeSet<IpfixExporter>,
+) -> row::Wrapping<'a, Message, StyleType> {
+    let mut row = Row::new().spacing(5);
+    for exporter in exporters {
+        row = row.push(
+            Container::new(Text::new(exporter.to_string()).size(FONT_SIZE_FOOTER))
+                .padding(Padding::new(5.0).left(10).right(10))
+                .class(ContainerType::AdapterAddress),
+        );
+    }
+    row.wrap()
 }
 
 fn col_data_representation<'a>(

--- a/src/gui/pages/overview_page.rs
+++ b/src/gui/pages/overview_page.rs
@@ -32,7 +32,7 @@ use crate::translations::translations_2::{
     data_representation_translation, dropped_translation, only_top_30_items_translation,
 };
 use crate::translations::translations_5::no_favorites_saved_translation;
-use crate::translations::translations_6::ipfix_exporters_translation;
+use crate::translations::translations_6::ipfix_exporter_translation;
 use crate::utils::types::icon::Icon;
 use crate::{Language, RunningPage, StyleType};
 use iced::Length::Fill;
@@ -421,7 +421,7 @@ fn get_exporters_col<'a>(
 
     Column::new()
         .push(
-            Text::new(format!("{}:", ipfix_exporters_translation(language)))
+            Text::new(format!("{}:", ipfix_exporter_translation(language)))
                 .class(TextType::Subtitle),
         )
         .push(info)

--- a/src/gui/pages/overview_page.rs
+++ b/src/gui/pages/overview_page.rs
@@ -40,7 +40,7 @@ use iced::alignment::{Horizontal, Vertical};
 use iced::widget::scrollable::Direction;
 use iced::widget::text::{LineHeight, Wrapping};
 use iced::widget::tooltip::Position;
-use iced::widget::{Button, Column, Container, Row, Scrollable, Space, Text, Tooltip, button, row};
+use iced::widget::{Button, Column, Container, Row, Scrollable, Space, Text, Tooltip, button};
 use iced::{Alignment, Element, Length, Padding};
 use std::collections::BTreeSet;
 
@@ -339,7 +339,7 @@ pub(crate) fn col_device<'a>(
         Some(
             Column::new()
                 .spacing(10)
-                .push(Text::new(link_type.full_print_on_one_line(language)))
+                .push(Text::new(link_type.full_print_on_one_line(language)).size(FONT_SIZE_FOOTER))
                 .push(get_addresses_row(link_type, cs.get_addresses()))
                 .into(),
         )
@@ -352,16 +352,12 @@ pub(crate) fn col_device<'a>(
         Row::new()
             .spacing(10)
             .push(Text::new("BPF"))
-            .push(get_info_tooltip(Text::new(filters.bpf()).into()))
+            .push(get_info_tooltip(
+                Text::new(filters.bpf()).size(FONT_SIZE_FOOTER).into(),
+            ))
             .into()
     } else {
         Text::new(none_translation(language)).into()
-    };
-
-    let exporters_desc: Element<Message, StyleType> = if exporters.is_empty() {
-        Text::new(none_translation(language)).into()
-    } else {
-        get_exporters_row(exporters).into()
     };
 
     Column::new()
@@ -377,15 +373,8 @@ pub(crate) fn col_device<'a>(
                         .push(tooltip_content.map(get_info_tooltip)),
                 ),
         )
-        .push(if cs.supports_exporters() {
-            Some(
-                Column::new()
-                    .push(
-                        Text::new(format!("{}:", ipfix_exporters_translation(language)))
-                            .class(TextType::Subtitle),
-                    )
-                    .push(Row::new().push(Text::new("   ")).push(exporters_desc)),
-            )
+        .push(if cs.supports_exporters() && !exporters.is_empty() {
+            Some(get_exporters_col(language, exporters))
         } else {
             None
         })
@@ -403,19 +392,39 @@ pub(crate) fn col_device<'a>(
         })
 }
 
-/// The exporters flow records have been received from, in the same style as the adapter addresses
-fn get_exporters_row<'a>(
+fn get_exporters_col<'a>(
+    language: Language,
     exporters: &BTreeSet<IpfixExporter>,
-) -> row::Wrapping<'a, Message, StyleType> {
-    let mut row = Row::new().spacing(5);
-    for exporter in exporters {
-        row = row.push(
-            Container::new(Text::new(exporter.to_string()).size(FONT_SIZE_FOOTER))
-                .padding(Padding::new(5.0).left(10).right(10))
-                .class(ContainerType::AdapterAddress),
-        );
-    }
-    row.wrap()
+) -> Column<'a, Message, StyleType> {
+    let info: Element<Message, StyleType> = if exporters.len() == 1 {
+        Text::new(format!(
+            "   {}",
+            exporters
+                .iter()
+                .next()
+                .map(ToString::to_string)
+                .unwrap_or_default()
+        ))
+        .into()
+    } else {
+        let mut exporters_info = Column::new().spacing(5);
+        for exporter in exporters {
+            exporters_info =
+                exporters_info.push(Text::new(exporter.to_string()).size(FONT_SIZE_FOOTER));
+        }
+        Row::new()
+            .spacing(10)
+            .push(Text::new(format!("   ({})", exporters.len())))
+            .push(get_info_tooltip(exporters_info.into()))
+            .into()
+    };
+
+    Column::new()
+        .push(
+            Text::new(format!("{}:", ipfix_exporters_translation(language)))
+                .class(TextType::Subtitle),
+        )
+        .push(info)
 }
 
 fn col_data_representation<'a>(

--- a/src/gui/pages/waiting_page.rs
+++ b/src/gui/pages/waiting_page.rs
@@ -96,7 +96,13 @@ pub fn waiting_page(sniffer: &Sniffer) -> Option<Container<'_, Message, StyleTyp
             .push(Space::new().height(Length::Fill))
             .push(
                 Container::new(
-                    col_device(language, cs, &sniffer.conf.filters).height(Length::Shrink),
+                    col_device(
+                        language,
+                        cs,
+                        &sniffer.conf.filters,
+                        &sniffer.combobox_data_states.data.exporters.0,
+                    )
+                    .height(Length::Shrink),
                 )
                 .padding([15, 30])
                 .class(ContainerType::BorderedRound),

--- a/src/gui/sniffer.rs
+++ b/src/gui/sniffer.rs
@@ -607,6 +607,7 @@ impl Sniffer {
         combobox_data.asns.1 = self.search.as_name != parameters.as_name;
         combobox_data.domains.1 = self.search.domain != parameters.domain;
         combobox_data.programs.1 = self.search.program != parameters.program;
+        combobox_data.exporters.1 = self.search.exporter != parameters.exporter;
         self.combobox_data_states.update_states(&parameters);
 
         self.page_number = 1;
@@ -975,6 +976,9 @@ impl Sniffer {
         }
         self.traffic_chart.update_charts_data(&msg, no_more_packets);
 
+        self.combobox_data_states
+            .data
+            .update_exporters(msg.map.keys().filter_map(|k| k.exporter));
         // update combobox dropdowns
         self.combobox_data_states.update_states(&self.search);
     }

--- a/src/networking/ipfix/baseline_cache.rs
+++ b/src/networking/ipfix/baseline_cache.rs
@@ -83,6 +83,7 @@ mod tests {
             dest: IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)),
             dport: Some(443),
             protocol: Protocol::TCP,
+            exporter: None,
         }
     }
 

--- a/src/networking/ipfix/baseline_cache.rs
+++ b/src/networking/ipfix/baseline_cache.rs
@@ -1,4 +1,3 @@
-use std::net::SocketAddr;
 use std::time::Instant;
 
 use crate::networking::ipfix::ttl_map::TtlMap;
@@ -7,9 +6,9 @@ use crate::networking::types::address_port_pair::AddressPortPair;
 /// Per-exporter flow cumulative counter tracking.
 /// Useful because some exporters report `octetTotalCount` / `packetTotalCount` instead of the delta counters,
 /// and we need to convert them to deltas for our own processing.
-/// The cache is keyed by `(peer, observation_domain, flow)`.
+/// The cache is keyed by `AddressPortPair`, which already includes the exporter identity.
 pub(super) struct BaselineCache {
-    map: TtlMap<(SocketAddr, u32, AddressPortPair), Baseline>,
+    map: TtlMap<AddressPortPair, Baseline>,
 }
 
 #[derive(Debug, Default)]
@@ -28,8 +27,6 @@ impl BaselineCache {
     /// Turn a record's cumulative counters into the increment since the same flow's previous report
     pub(super) fn delta(
         &mut self,
-        peer: SocketAddr,
-        observation_domain_id: u32,
         key: &AddressPortPair,
         bytes_total: Option<u128>,
         packets_total: Option<u128>,
@@ -40,11 +37,7 @@ impl BaselineCache {
             return (0, 0);
         }
 
-        let baseline = self.map.get_or_insert_with(
-            (peer, observation_domain_id, *key),
-            now,
-            Baseline::default,
-        );
+        let baseline = self.map.get_or_insert_with(*key, now, Baseline::default);
 
         // advance stored baseline and return the increment it implies
         let step = |baseline: &mut u128, total: Option<u128>| {
@@ -68,22 +61,22 @@ impl BaselineCache {
 mod tests {
     use super::*;
     use crate::networking::ipfix::ttl_map::{ENTRY_TTL, PRUNE_INTERVAL};
+    use crate::networking::types::ipfix_exporter::IpfixExporter;
     use crate::networking::types::protocol::Protocol;
     use std::net::{IpAddr, Ipv4Addr};
     use std::time::Duration;
 
-    fn peer(port: u16) -> SocketAddr {
-        format!("203.0.113.9:{port}").parse().unwrap()
-    }
-
-    fn key(sport: u16) -> AddressPortPair {
+    fn key(sport: u16, exporter_addr: u8, odid: u32) -> AddressPortPair {
         AddressPortPair {
             source: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
             sport: Some(sport),
             dest: IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)),
             dport: Some(443),
             protocol: Protocol::TCP,
-            exporter: None,
+            exporter: Some(IpfixExporter {
+                addr: IpAddr::V4(Ipv4Addr::new(203, 0, 113, exporter_addr)),
+                observation_domain_id: odid,
+            }),
         }
     }
 
@@ -94,44 +87,44 @@ mod tests {
 
         // initial report: the delta is the total itself
         assert_eq!(
-            cache.delta(peer(1), 0, &key(1000), Some(1500), Some(10), now),
+            cache.delta(&key(1000, 1, 0), Some(1500), Some(10), now),
             (1500, 10)
         );
         // subsequent report: the delta is the difference from the previous total
         assert_eq!(
-            cache.delta(peer(1), 0, &key(1000), Some(4000), Some(25), now),
+            cache.delta(&key(1000, 1, 0), Some(4000), Some(25), now),
             (2500, 15)
         );
         // no change in totals: the delta is zero
         assert_eq!(
-            cache.delta(peer(1), 0, &key(1000), Some(4000), Some(25), now),
+            cache.delta(&key(1000, 1, 0), Some(4000), Some(25), now),
             (0, 0)
         );
         // the flow was restarted and the total went backwards: the delta is the new total in full
         assert_eq!(
-            cache.delta(peer(1), 0, &key(1000), Some(200), Some(2), now),
+            cache.delta(&key(1000, 1, 0), Some(200), Some(2), now),
             (200, 2)
         );
         // new increment: the delta is the difference from the previous total
         assert_eq!(
-            cache.delta(peer(1), 0, &key(1000), Some(500), Some(5), now),
+            cache.delta(&key(1000, 1, 0), Some(500), Some(5), now),
             (300, 3)
         );
         assert_eq!(cache.map.len(), 1);
 
         // same flow and domain, different exporter: not the same counter
         assert_eq!(
-            cache.delta(peer(2), 0, &key(1000), Some(1500), Some(10), now),
+            cache.delta(&key(1000, 2, 0), Some(1500), Some(10), now),
             (1500, 10)
         );
         // same exporter and flow, different observation domain: not the same counter
         assert_eq!(
-            cache.delta(peer(1), 7, &key(1000), Some(2000), Some(10), now),
+            cache.delta(&key(1000, 1, 7), Some(2000), Some(10), now),
             (2000, 10)
         );
         // same exporter and domain, different flow: not the same counter
         assert_eq!(
-            cache.delta(peer(1), 0, &key(1001), Some(1000), Some(54), now),
+            cache.delta(&key(1001, 1, 0), Some(1000), Some(54), now),
             (1000, 54)
         );
         assert_eq!(cache.map.len(), 4);
@@ -141,7 +134,7 @@ mod tests {
     fn test_baseline_cache_records_without_totals_are_ignored() {
         let now = Instant::now();
         let mut cache = BaselineCache::new(now);
-        assert_eq!(cache.delta(peer(1), 0, &key(1000), None, None, now), (0, 0));
+        assert_eq!(cache.delta(&key(1000, 1, 0), None, None, now), (0, 0));
         assert_eq!(cache.map.len(), 0);
     }
 
@@ -149,23 +142,20 @@ mod tests {
     fn test_baseline_cache_missing_one_counter_leaves_it_untouched() {
         let now = Instant::now();
         let mut cache = BaselineCache::new(now);
-        cache.delta(peer(1), 0, &key(1000), Some(1500), Some(10), now);
+        cache.delta(&key(1000, 1, 0), Some(1500), Some(10), now);
         // byte totals only: the packet baseline must not be reset to zero
         assert_eq!(
-            cache.delta(peer(1), 0, &key(1000), Some(2000), None, now),
+            cache.delta(&key(1000, 1, 0), Some(2000), None, now),
             (500, 0)
         );
         assert_eq!(
-            cache.delta(peer(1), 0, &key(1000), Some(2000), Some(12), now),
+            cache.delta(&key(1000, 1, 0), Some(2000), Some(12), now),
             (0, 2)
         );
         // packet totals only: the byte baseline must not be reset to zero
+        assert_eq!(cache.delta(&key(1000, 1, 0), None, Some(15), now), (0, 3));
         assert_eq!(
-            cache.delta(peer(1), 0, &key(1000), None, Some(15), now),
-            (0, 3)
-        );
-        assert_eq!(
-            cache.delta(peer(1), 0, &key(1000), Some(2500), Some(15), now),
+            cache.delta(&key(1000, 1, 0), Some(2500), Some(15), now),
             (500, 0)
         );
     }
@@ -174,19 +164,19 @@ mod tests {
     fn test_baseline_cache_stale_entries_are_swept() {
         let start = Instant::now();
         let mut cache = BaselineCache::new(start);
-        cache.delta(peer(1), 0, &key(1000), Some(1500), Some(10), start);
+        cache.delta(&key(1000, 1, 0), Some(1500), Some(10), start);
 
         // before the TTL: still differencing against the stored baseline
         let fresh = start + PRUNE_INTERVAL + Duration::from_secs(1);
         assert_eq!(
-            cache.delta(peer(1), 0, &key(1000), Some(2000), Some(12), fresh),
+            cache.delta(&key(1000, 1, 0), Some(2000), Some(12), fresh),
             (500, 2)
         );
 
         // past the TTL with no reports in between: the entry is swept
         let stale = fresh + ENTRY_TTL + Duration::from_secs(1);
         assert_eq!(
-            cache.delta(peer(1), 0, &key(1000), Some(3000), Some(20), stale),
+            cache.delta(&key(1000, 1, 0), Some(3000), Some(20), stale),
             (3000, 20)
         );
         assert_eq!(cache.map.len(), 1);

--- a/src/networking/ipfix/collect.rs
+++ b/src/networking/ipfix/collect.rs
@@ -222,8 +222,7 @@ fn ingest_flow_record(
         return;
     };
 
-    let (exchanged_bytes, exchanged_packets) =
-        resolve_data_amounts(record, peer, observation_domain_id, &key, baselines, now);
+    let (exchanged_bytes, exchanged_packets) = resolve_data_amounts(record, &key, baselines, now);
 
     if exchanged_bytes == 0 || exchanged_packets == 0 {
         return;
@@ -261,21 +260,13 @@ fn ingest_flow_record(
 /// Find out how much data this flow actually carries
 fn resolve_data_amounts(
     record: &FlowRecord,
-    peer: SocketAddr,
-    observation_domain_id: u32,
     key: &AddressPortPair,
     baselines: &mut BaselineCache,
     now: Instant,
 ) -> (u128, u128) {
     // update baseline in any case for potential future delta computations
-    let (bytes_from_baseline, packets_from_baseline) = baselines.delta(
-        peer,
-        observation_domain_id,
-        key,
-        record.bytes_total,
-        record.packets_total,
-        now,
-    );
+    let (bytes_from_baseline, packets_from_baseline) =
+        baselines.delta(key, record.bytes_total, record.packets_total, now);
 
     let bytes = if let Some(bytes_delta) = record.bytes_delta {
         bytes_delta
@@ -797,9 +788,8 @@ mod tests {
         let now = Instant::now();
         let key = totals_key();
         let mut baselines = BaselineCache::new(now);
-        let mut resolve = |record: &FlowRecord| {
-            resolve_data_amounts(record, peer(), 0, &key, &mut baselines, now)
-        };
+        let mut resolve =
+            |record: &FlowRecord| resolve_data_amounts(record, &key, &mut baselines, now);
 
         // deltas are already increments, so they're used as they stand
         assert_eq!(resolve(&flow_record(Some(1500), Some(10))), (1500, 10));

--- a/src/networking/ipfix/collect.rs
+++ b/src/networking/ipfix/collect.rs
@@ -146,7 +146,7 @@ fn process_datagram(
     };
 
     let now = Instant::now();
-    let od_id = message.header.observation_domain_id;
+    let odid = message.header.observation_domain_id;
 
     // first pass: parse templates so that later data sets in this datagram can reference them
     for set in &message.sets {
@@ -154,7 +154,7 @@ fn process_datagram(
             for record in records {
                 state
                     .templates
-                    .insert(peer, od_id, record.template_id, record.fields.clone(), now);
+                    .insert(peer, odid, record.template_id, record.fields.clone(), now);
             }
         }
     }
@@ -166,7 +166,7 @@ fn process_datagram(
             payload,
         } = *set
         {
-            let Some(template) = state.templates.get(peer, od_id, template_id, now) else {
+            let Some(template) = state.templates.get(peer, odid, template_id, now) else {
                 // no such template seen
                 continue;
             };
@@ -186,7 +186,7 @@ fn process_datagram(
                     ingest_flow_record(
                         &flow,
                         peer,
-                        od_id,
+                        odid,
                         &mut state.baselines,
                         now,
                         info_traffic_msg,
@@ -297,9 +297,14 @@ mod tests {
 
     /// `peer`'s identity: the test datagrams all declare observation domain 0
     fn exporter() -> IpfixExporter {
+        exporter_from(peer(), 0)
+    }
+
+    /// The identity of an exporter sending from `peer` and declaring `observation_domain_id`
+    fn exporter_from(peer: SocketAddr, observation_domain_id: u32) -> IpfixExporter {
         IpfixExporter {
-            addr: peer().ip(),
-            observation_domain_id: 0,
+            addr: peer.ip(),
+            observation_domain_id,
         }
     }
 
@@ -375,11 +380,16 @@ mod tests {
     }
 
     fn datagram(sets: &[Vec<u8>]) -> Vec<u8> {
+        datagram_from_domain(0, sets)
+    }
+
+    /// A datagram declaring a specific observation domain in its header
+    fn datagram_from_domain(observation_domain_id: u32, sets: &[Vec<u8>]) -> Vec<u8> {
         let mut out = IPFIX_VERSION.to_be_bytes().to_vec();
         out.extend_from_slice(&[0, 0]); // length placeholder
         out.extend_from_slice(&[0; 4]); // export time
         out.extend_from_slice(&[0; 4]); // sequence number
-        out.extend_from_slice(&[0; 4]); // observation domain
+        out.extend_from_slice(&observation_domain_id.to_be_bytes()); // observation domain
         for s in sets {
             out.extend_from_slice(s);
         }
@@ -429,6 +439,14 @@ mod tests {
         }
     }
 
+    /// `totals_key`'s same flow, as reported by another exporter
+    fn totals_key_from(exporter: IpfixExporter) -> AddressPortPair {
+        AddressPortPair {
+            exporter: Some(exporter),
+            ..totals_key()
+        }
+    }
+
     /// `totals_key`'s flow as an already-decoded record
     fn flow_record(bytes_delta: Option<u128>, packets_delta: Option<u128>) -> FlowRecord {
         FlowRecord {
@@ -466,14 +484,23 @@ mod tests {
     /// Feed a sequence of datagrams to one collector.
     /// The last element reports whether every datagram succeeded.
     fn run_all(datagrams: &[&[u8]]) -> (InfoTraffic, AddressesResolutionState, bool) {
+        let from_peer: Vec<_> = datagrams.iter().map(|bytes| (peer(), *bytes)).collect();
+        run_all_from(&from_peer)
+    }
+
+    /// Feed a sequence of datagrams, each sent by its own peer, to one collector.
+    /// The last element reports whether every datagram succeeded.
+    fn run_all_from(
+        datagrams: &[(SocketAddr, &[u8])],
+    ) -> (InfoTraffic, AddressesResolutionState, bool) {
         let mut state = CollectorState::new(Instant::now());
         let mut info = InfoTraffic::default();
         let mut resolutions = AddressesResolutionState::new_for_tests();
         let mut all_succeeded = true;
-        for bytes in datagrams {
+        for (peer, bytes) in datagrams {
             all_succeeded &= process_datagram(
                 bytes,
-                peer(),
+                *peer,
                 &mut state,
                 &mut info,
                 &IpBlacklist::default(),
@@ -653,6 +680,74 @@ mod tests {
         // 10 + 15 + 0 + 5
         assert_eq!(entry.transmitted_packets, 30);
         assert_eq!(info.tot_data_info.tot_data(DataRepr::Packets), 30);
+    }
+
+    #[test]
+    fn test_process_datagram_separates_exporters() {
+        let totals = |observation_domain_id, bytes, packets| {
+            datagram_from_domain(
+                observation_domain_id,
+                &[
+                    template_set(300, &TOTALS_FIELDS),
+                    set(300, &totals_record(bytes, packets)),
+                ],
+            )
+        };
+        let other_peer: SocketAddr = "198.51.100.7:4739".parse().unwrap();
+
+        let (info, _, succeeded) = run_all_from(&[
+            (peer(), &totals(0, 1500, 10)),
+            (other_peer, &totals(0, 4000, 25)),
+            (peer(), &totals(7, 800, 4)),
+        ]);
+        assert!(succeeded);
+
+        assert_eq!(info.map.len(), 3);
+
+        let entry = info.map.get(&totals_key()).unwrap();
+        assert_eq!(entry.transmitted_bytes, 1500);
+        assert_eq!(entry.transmitted_packets, 10);
+
+        let entry = info
+            .map
+            .get(&totals_key_from(exporter_from(other_peer, 0)))
+            .unwrap();
+        assert_eq!(entry.transmitted_bytes, 4000);
+        assert_eq!(entry.transmitted_packets, 25);
+
+        let entry = info
+            .map
+            .get(&totals_key_from(exporter_from(peer(), 7)))
+            .unwrap();
+        assert_eq!(entry.transmitted_bytes, 800);
+        assert_eq!(entry.transmitted_packets, 4);
+
+        assert_eq!(info.tot_data_info.tot_data(DataRepr::Bytes), 6300);
+        assert_eq!(info.tot_data_info.tot_data(DataRepr::Packets), 39);
+    }
+
+    #[test]
+    fn test_process_datagram_ignores_exporter_source_port() {
+        let totals = |bytes, packets| {
+            datagram(&[
+                template_set(300, &TOTALS_FIELDS),
+                set(300, &totals_record(bytes, packets)),
+            ])
+        };
+        // the same device coming back after a restart: same address, new ephemeral port
+        let restarted = SocketAddr::new(peer().ip(), 55_000);
+
+        let (info, _, succeeded) =
+            run_all_from(&[(peer(), &totals(1500, 10)), (restarted, &totals(4000, 25))]);
+        assert!(succeeded);
+
+        assert_eq!(info.map.len(), 1);
+
+        let entry = info.map.get(&totals_key()).unwrap();
+        assert_eq!(entry.transmitted_bytes, 4000);
+        assert_eq!(entry.transmitted_packets, 25);
+        assert_eq!(info.tot_data_info.tot_data(DataRepr::Bytes), 4000);
+        assert_eq!(info.tot_data_info.tot_data(DataRepr::Packets), 25);
     }
 
     #[test]

--- a/src/networking/ipfix/collect.rs
+++ b/src/networking/ipfix/collect.rs
@@ -18,6 +18,7 @@ use crate::networking::types::address_port_pair::AddressPortPair;
 use crate::networking::types::arp_type::ArpType;
 use crate::networking::types::info_traffic::InfoTraffic;
 use crate::networking::types::ip_blacklist::IpBlacklist;
+use crate::networking::types::ipfix_exporter::IpfixExporter;
 use crate::utils::types::timestamp::Timestamp;
 
 /// Buffer size for a single UDP datagram
@@ -212,7 +213,12 @@ fn ingest_flow_record(
     ip_blacklist: &IpBlacklist,
     resolutions_state: &mut AddressesResolutionState,
 ) {
-    let Some(key) = record.get_key() else {
+    let exporter = IpfixExporter {
+        addr: peer.ip(),
+        observation_domain_id,
+    };
+
+    let Some(key) = record.get_key(exporter) else {
         return;
     };
 
@@ -296,6 +302,14 @@ mod tests {
 
     fn peer() -> SocketAddr {
         "203.0.113.9:4739".parse().unwrap()
+    }
+
+    /// `peer`'s identity: the test datagrams all declare observation domain 0
+    fn exporter() -> IpfixExporter {
+        IpfixExporter {
+            addr: peer().ip(),
+            observation_domain_id: 0,
+        }
     }
 
     /// The field specifiers `sniffnet-agent` puts in its templates,
@@ -420,6 +434,7 @@ mod tests {
             dest: IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)),
             dport: Some(50_000),
             protocol: Protocol::TCP,
+            exporter: Some(exporter()),
         }
     }
 
@@ -557,6 +572,7 @@ mod tests {
             dest: IpAddr::V6(dst),
             dport: Some(50_000),
             protocol: Protocol::TCP,
+            exporter: Some(exporter()),
         };
         let entry = info.map.get(&key).unwrap();
         assert_eq!(entry.transmitted_bytes, 800);
@@ -588,6 +604,7 @@ mod tests {
             dest: totals_key().source,
             dport: totals_key().sport,
             protocol: Protocol::TCP,
+            exporter: Some(exporter()),
         };
         let reverse = info.map.get(&reverse_key).unwrap();
         assert_eq!(reverse.transmitted_bytes, 9000);

--- a/src/networking/ipfix/flow_record.rs
+++ b/src/networking/ipfix/flow_record.rs
@@ -1,4 +1,5 @@
 use crate::networking::types::address_port_pair::AddressPortPair;
+use crate::networking::types::ipfix_exporter::IpfixExporter;
 use crate::networking::types::protocol::Protocol;
 use crate::networking::types::traffic_direction::TrafficDirection;
 use crate::utils::types::timestamp::Timestamp;
@@ -27,7 +28,7 @@ pub(super) struct FlowRecord {
 
 impl FlowRecord {
     /// Return the key for this record, if the record is valid
-    pub(super) fn get_key(&self) -> Option<AddressPortPair> {
+    pub(super) fn get_key(&self, exporter: IpfixExporter) -> Option<AddressPortPair> {
         let source = self.src_ip?;
         let dest = self.dst_ip?;
         let protocol = self.protocol?;
@@ -53,6 +54,7 @@ impl FlowRecord {
             dest,
             dport,
             protocol,
+            exporter: Some(exporter),
         })
     }
 
@@ -91,6 +93,14 @@ pub(super) struct ReverseCounters {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::net::Ipv4Addr;
+
+    fn exporter() -> IpfixExporter {
+        IpfixExporter {
+            addr: IpAddr::V4(Ipv4Addr::new(203, 0, 113, 9)),
+            observation_domain_id: 0,
+        }
+    }
 
     #[test]
     fn test_get_key() {
@@ -103,7 +113,7 @@ mod tests {
             ..Default::default()
         };
 
-        let key = record.get_key();
+        let key = record.get_key(exporter());
         assert_eq!(
             key,
             Some(AddressPortPair {
@@ -112,6 +122,7 @@ mod tests {
                 dest: "2.2.2.2".parse().unwrap(),
                 dport: Some(5678),
                 protocol: Protocol::TCP,
+                exporter: Some(exporter()),
             })
         );
 
@@ -119,42 +130,42 @@ mod tests {
             protocol: Some(Protocol::ICMP),
             ..record
         };
-        let key = record_2.get_key();
+        let key = record_2.get_key(exporter());
         assert!(key.is_none());
 
         let record_3 = FlowRecord {
             protocol: Some(Protocol::ARP),
             ..record
         };
-        let key = record_3.get_key();
+        let key = record_3.get_key(exporter());
         assert!(key.is_none());
 
         let record_4 = FlowRecord {
             src_port: None,
             ..record
         };
-        let key = record_4.get_key();
+        let key = record_4.get_key(exporter());
         assert!(key.is_none());
 
         let record_5 = FlowRecord {
             protocol: Some(Protocol::UDP),
             ..record
         };
-        let key = record_5.get_key();
+        let key = record_5.get_key(exporter());
         assert!(key.is_some());
 
         let record_6 = FlowRecord {
             protocol: None,
             ..record
         };
-        let key = record_6.get_key();
+        let key = record_6.get_key(exporter());
         assert!(key.is_none());
 
         let record_7 = FlowRecord {
             dst_ip: None,
             ..record
         };
-        let key = record_7.get_key();
+        let key = record_7.get_key(exporter());
         assert!(key.is_none());
 
         let record_8 = FlowRecord {
@@ -163,7 +174,7 @@ mod tests {
             dst_port: None,
             ..record
         };
-        let key = record_8.get_key();
+        let key = record_8.get_key(exporter());
         assert_eq!(
             key,
             Some(AddressPortPair {
@@ -172,6 +183,7 @@ mod tests {
                 dest: "2.2.2.2".parse().unwrap(),
                 dport: None,
                 protocol: Protocol::ICMP,
+                exporter: Some(exporter()),
             })
         );
     }

--- a/src/networking/ipfix/template_cache.rs
+++ b/src/networking/ipfix/template_cache.rs
@@ -5,7 +5,9 @@ use crate::networking::ipfix::ttl_map::TtlMap;
 use crate::networking::ipfix::wire::FieldSpec;
 
 /// Per-exporter IPFIX template cache.
-/// The cache is keyed by `(peer, observation_domain, template_id)`.
+/// The cache is keyed by `(peer, observation_domain, template_id)`:
+/// the spec requires scoping templates by transport session + ODID,
+/// so we can't use `IpfixExporter` because also the port number is needed.
 pub(super) struct TemplateCache {
     map: TtlMap<(SocketAddr, u32, u16), Vec<FieldSpec>>,
 }

--- a/src/networking/types/address_port_pair.rs
+++ b/src/networking/types/address_port_pair.rs
@@ -17,7 +17,7 @@ pub struct AddressPortPair {
     pub dport: Option<u16>,
     ///  Transport layer protocol carried through the associate address:port pair (TCP or UPD).
     pub protocol: Protocol,
-    /// Exporter the flow was reported by; `None` for packets sniffed locally (non-IPFIX captures).
+    /// Exporter the flow was reported by; `None` non-IPFIX captures.
     pub exporter: Option<IpfixExporter>,
 }
 

--- a/src/networking/types/address_port_pair.rs
+++ b/src/networking/types/address_port_pair.rs
@@ -1,6 +1,7 @@
 //! Module defining the `AddressPortPair` struct, which represents a network address:port pair.
 
 use crate::Protocol;
+use crate::networking::types::ipfix_exporter::IpfixExporter;
 use std::net::{IpAddr, Ipv4Addr};
 
 /// Struct representing a network address:port pair.
@@ -16,6 +17,8 @@ pub struct AddressPortPair {
     pub dport: Option<u16>,
     ///  Transport layer protocol carried through the associate address:port pair (TCP or UPD).
     pub protocol: Protocol,
+    /// Exporter the flow was reported by; `None` for packets sniffed locally (non-IPFIX captures).
+    pub exporter: Option<IpfixExporter>,
 }
 
 #[cfg(test)]
@@ -33,6 +36,7 @@ impl AddressPortPair {
             dest,
             dport,
             protocol,
+            exporter: None,
         }
     }
 }
@@ -45,6 +49,7 @@ impl Default for AddressPortPair {
             sport: None,
             dport: None,
             protocol: Protocol::ARP,
+            exporter: None,
         }
     }
 }

--- a/src/networking/types/capture_context.rs
+++ b/src/networking/types/capture_context.rs
@@ -355,7 +355,6 @@ impl CaptureSource {
         }
     }
 
-    /// Whether the traffic is reported by IPFIX exporters, instead of being sniffed locally
     pub fn supports_exporters(&self) -> bool {
         match self {
             Self::Ipfix(_) => true,

--- a/src/networking/types/capture_context.rs
+++ b/src/networking/types/capture_context.rs
@@ -355,6 +355,14 @@ impl CaptureSource {
         }
     }
 
+    /// Whether the traffic is reported by IPFIX exporters, instead of being sniffed locally
+    pub fn supports_exporters(&self) -> bool {
+        match self {
+            Self::Ipfix(_) => true,
+            Self::Device(_) | Self::File(_) => false,
+        }
+    }
+
     pub fn supports_programs(&self) -> bool {
         match self {
             Self::Device(_) => true,

--- a/src/networking/types/combobox_data_states.rs
+++ b/src/networking/types/combobox_data_states.rs
@@ -3,6 +3,7 @@ use std::net::IpAddr;
 
 use crate::countries::types::country::Country;
 use crate::networking::types::host::Host;
+use crate::networking::types::ipfix_exporter::IpfixExporter;
 use crate::report::types::search_parameters::SearchParameters;
 use crate::utils::types::case_insensitive_string::CaseInsensitiveString;
 use iced::widget::combo_box;
@@ -53,6 +54,14 @@ impl ComboboxDataStates {
             );
             data.programs.1 = false;
         }
+
+        if data.exporters.1 {
+            states.exporters = combo_box::State::with_selection(
+                data.exporters.0.iter().map(ToString::to_string).collect(),
+                Some(&search.exporter),
+            );
+            data.exporters.1 = false;
+        }
     }
 }
 
@@ -62,6 +71,9 @@ pub struct ComboboxData {
     pub asns: (BTreeSet<CaseInsensitiveString>, bool),
     pub countries: (BTreeSet<CaseInsensitiveString>, bool),
     pub programs: (BTreeSet<CaseInsensitiveString>, bool),
+    /// Exporters are stored as structs, and not as strings like the other sets,
+    /// so that their addresses are sorted numerically instead of lexicographically
+    pub exporters: (BTreeSet<IpfixExporter>, bool),
 }
 
 impl ComboboxData {
@@ -91,6 +103,12 @@ impl ComboboxData {
         }
     }
 
+    pub fn update_exporters(&mut self, exporters: impl Iterator<Item = IpfixExporter>) {
+        for exporter in exporters {
+            self.exporters.1 = self.exporters.0.insert(exporter) || self.exporters.1;
+        }
+    }
+
     pub fn update_program(&mut self, program: Option<&Process>) {
         if let Some(program) = program
             && !program.name.is_empty()
@@ -110,4 +128,5 @@ pub struct ComboboxStates {
     pub asns: combo_box::State<String>,
     pub countries: combo_box::State<String>,
     pub programs: combo_box::State<String>,
+    pub exporters: combo_box::State<String>,
 }

--- a/src/networking/types/combobox_data_states.rs
+++ b/src/networking/types/combobox_data_states.rs
@@ -9,7 +9,7 @@ use crate::utils::types::case_insensitive_string::CaseInsensitiveString;
 use iced::widget::combo_box;
 use listeners::Process;
 
-/// Struct to contain all the sets of data related to network hosts and programs
+/// Struct to contain all the sets of data related to network hosts, programs, and exporters
 ///
 /// It also stores combobox states for the host-related filters
 #[derive(Default)]
@@ -71,8 +71,7 @@ pub struct ComboboxData {
     pub asns: (BTreeSet<CaseInsensitiveString>, bool),
     pub countries: (BTreeSet<CaseInsensitiveString>, bool),
     pub programs: (BTreeSet<CaseInsensitiveString>, bool),
-    /// Exporters are stored as structs, and not as strings like the other sets,
-    /// so that their addresses are sorted numerically instead of lexicographically
+    /// Exporters are stored as structs so that they're sorted numerically instead of lexicographically
     pub exporters: (BTreeSet<IpfixExporter>, bool),
 }
 

--- a/src/networking/types/ipfix_exporter.rs
+++ b/src/networking/types/ipfix_exporter.rs
@@ -1,0 +1,80 @@
+//! Module defining the `IpfixExporter` struct, which identifies the origin of IPFIX flow records.
+
+use std::fmt;
+use std::net::IpAddr;
+
+/// Struct representing the identity of an IPFIX exporter, as observed by the collector.
+///
+/// An exporter is identified by the address it sends from and by the observation domain it
+/// declares in the message header: a single device can export several observation domains,
+/// which are distinct sources as far as the collector is concerned.
+///
+/// The transport source port is deliberately not part of the identity: it's ephemeral for most
+/// exporters, so including it would make the same device appear as a new one after every restart.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct IpfixExporter {
+    /// Address the flow records were received from.
+    pub addr: IpAddr,
+    /// Observation domain declared in the IPFIX message header.
+    pub observation_domain_id: u32,
+}
+
+impl fmt::Display for IpfixExporter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} (ODID {})", self.addr, self.observation_domain_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    fn exporter(addr: IpAddr, observation_domain_id: u32) -> IpfixExporter {
+        IpfixExporter {
+            addr,
+            observation_domain_id,
+        }
+    }
+
+    fn v4(a: u8, b: u8, c: u8, d: u8) -> IpAddr {
+        IpAddr::V4(Ipv4Addr::new(a, b, c, d))
+    }
+
+    #[test]
+    fn test_ipfix_exporter_display() {
+        assert_eq!(
+            exporter(v4(203, 0, 113, 9), 0).to_string(),
+            "203.0.113.9 (ODID 0)"
+        );
+        assert_eq!(
+            exporter(
+                IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)),
+                3
+            )
+            .to_string(),
+            "2001:db8::1 (ODID 3)"
+        );
+    }
+
+    #[test]
+    fn test_ipfix_exporter_sorts_by_address_then_domain() {
+        let mut exporters = vec![
+            exporter(v4(10, 0, 0, 2), 1),
+            exporter(v4(9, 0, 0, 1), 0),
+            exporter(v4(10, 0, 0, 2), 0),
+        ];
+        exporters.sort_unstable();
+
+        // addresses are ordered numerically (not lexicographically: 9.x would come last)
+        // and the domains of a same address are kept together
+        assert_eq!(
+            exporters,
+            [
+                exporter(v4(9, 0, 0, 1), 0),
+                exporter(v4(10, 0, 0, 2), 0),
+                exporter(v4(10, 0, 0, 2), 1),
+            ]
+        );
+    }
+}

--- a/src/networking/types/ipfix_exporter.rs
+++ b/src/networking/types/ipfix_exporter.rs
@@ -3,12 +3,7 @@
 use std::fmt;
 use std::net::IpAddr;
 
-/// Struct representing the identity of an IPFIX exporter, as observed by the collector.
-///
-/// An exporter is identified by the address it sends from and by the observation domain it
-/// declares in the message header: a single device can export several observation domains,
-/// which are distinct sources as far as the collector is concerned.
-///
+/// Struct representing the identity of an IPFIX exporter.
 /// The transport source port is deliberately not part of the identity: it's ephemeral for most
 /// exporters, so including it would make the same device appear as a new one after every restart.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
@@ -67,7 +62,6 @@ mod tests {
         exporters.sort_unstable();
 
         // addresses are ordered numerically (not lexicographically: 9.x would come last)
-        // and the domains of a same address are kept together
         assert_eq!(
             exporters,
             [

--- a/src/networking/types/mod.rs
+++ b/src/networking/types/mod.rs
@@ -13,6 +13,7 @@ pub mod icmp_type;
 pub mod info_address_port_pair;
 pub mod info_traffic;
 pub mod ip_blacklist;
+pub mod ipfix_exporter;
 pub mod latency;
 pub mod my_device;
 pub mod my_link_type;

--- a/src/report/types/search_parameters.rs
+++ b/src/report/types/search_parameters.rs
@@ -28,6 +28,8 @@ pub struct SearchParameters {
     pub as_name: String,
     /// Program name
     pub program: String,
+    /// IPFIX exporter
+    pub exporter: String,
     /// Whether to display only favorites
     pub only_favorites: bool,
     /// Whether to display only blacklisted
@@ -111,10 +113,11 @@ pub enum FilterInputType {
     Domain,
     AsName,
     Program,
+    Exporter,
 }
 
 impl FilterInputType {
-    pub const ALL: [FilterInputType; 10] = [
+    pub const ALL: [FilterInputType; 11] = [
         Self::AddressSrc,
         Self::PortSrc,
         Self::AddressDst,
@@ -125,6 +128,7 @@ impl FilterInputType {
         Self::Domain,
         Self::AsName,
         Self::Program,
+        Self::Exporter,
     ];
 
     pub fn matches_entry(
@@ -169,6 +173,7 @@ impl FilterInputType {
             FilterInputType::Domain => &search_params.domain,
             FilterInputType::AsName => &search_params.as_name,
             FilterInputType::Program => &search_params.program,
+            FilterInputType::Exporter => &search_params.exporter,
         }
     }
 
@@ -213,6 +218,9 @@ impl FilterInputType {
                 .name
                 .clone(),
             FilterInputType::Program => value.program.to_string(),
+            FilterInputType::Exporter => key
+                .exporter
+                .map_or_else(|| "-".to_string(), |exporter| exporter.to_string()),
         }
     }
 
@@ -229,6 +237,7 @@ impl FilterInputType {
             FilterInputType::Country => result.country = String::new(),
             FilterInputType::AsName => result.as_name = String::new(),
             FilterInputType::Program => result.program = String::new(),
+            FilterInputType::Exporter => result.exporter = String::new(),
         }
         result
     }
@@ -247,6 +256,7 @@ impl FilterInputType {
             FilterInputType::Country => result.country = trimmed,
             FilterInputType::AsName => result.as_name = trimmed,
             FilterInputType::Program => result.program = trimmed,
+            FilterInputType::Exporter => result.exporter = trimmed,
         }
         result
     }

--- a/src/report/types/search_parameters.rs
+++ b/src/report/types/search_parameters.rs
@@ -177,7 +177,7 @@ impl FilterInputType {
         }
     }
 
-    pub fn entry_value(
+    fn entry_value(
         self,
         key: &AddressPortPair,
         value: &InfoAddressPortPair,

--- a/src/translations/translations_6.rs
+++ b/src/translations/translations_6.rs
@@ -10,20 +10,11 @@ pub fn latency_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn ipfix_exporters_translation(language: Language) -> &'static str {
+pub fn ipfix_exporter_translation(language: Language) -> &'static str {
     match language {
-        Language::EN => "IPFIX exporters",
-        Language::IT => "Esportatori IPFIX",
-        _ => "IPFIX exporters",
-    }
-}
-
-/// Label of the exporter filter, in the inspect page
-pub fn exporter_translation(language: Language) -> &'static str {
-    match language {
-        Language::EN => "Exporter",
-        Language::IT => "Esportatore",
-        _ => "Exporter",
+        Language::EN => "IPFIX exporter",
+        Language::IT => "Esportatore IPFIX",
+        _ => "IPFIX exporter",
     }
 }
 

--- a/src/translations/translations_6.rs
+++ b/src/translations/translations_6.rs
@@ -10,6 +10,23 @@ pub fn latency_translation(language: Language) -> &'static str {
     }
 }
 
+pub fn ipfix_exporters_translation(language: Language) -> &'static str {
+    match language {
+        Language::EN => "IPFIX exporters",
+        Language::IT => "Esportatori IPFIX",
+        _ => "IPFIX exporters",
+    }
+}
+
+/// Label of the exporter filter, in the inspect page
+pub fn exporter_translation(language: Language) -> &'static str {
+    match language {
+        Language::EN => "Exporter",
+        Language::IT => "Esportatore",
+        _ => "Exporter",
+    }
+}
+
 pub fn ipfix_collector_translation(language: Language) -> &'static str {
     match language {
         Language::EN => "IPFIX collector",


### PR DESCRIPTION
> [!NOTE]
>
> _This will be merged to `main` as part of #1270_

Support receiving traffic from multiple IPFIX exporters simultaneously, allowing to filter collected data by exporter in real-time from the _Inspect_ page of the app.

`AddressPortPair` was extended to have an optional `IpfixExporter` field, which carries the exporter identity for IPFIX-based captures and is `None` for standard PCAP-based captures.
This way, the "_same_" 5-tuple network flow can be accounted for as many times as the different exporters observing it.

https://github.com/user-attachments/assets/1cb9e3ae-9f43-4549-b778-70df5d3c7855
