### PR TITLE
Parse and show VLAN ID for 802.1Q tagged connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All Sniffnet releases with the relative changes are documented in this file.
 
 ## [UNRELEASED]
+- Parse and show the VLAN ID of IEEE 802.1Q tagged connections (fixes [#1070](https://github.com/GyulyVGC/sniffnet/issues/1070))
 - Correctly filter by favorites-only before rDNS completes ([#1275](https://github.com/GyulyVGC/sniffnet/pull/1275))
 - Set `Content-Type: application/json` header on remote notifications ([#1266](https://github.com/GyulyVGC/sniffnet/pull/1266))
 

--- a/src/gui/pages/connection_details_page.rs
+++ b/src/gui/pages/connection_details_page.rs
@@ -38,7 +38,7 @@ use crate::translations::translations_3::{
     copy_translation, messages_translation, service_translation,
 };
 use crate::translations::translations_5::program_translation;
-use crate::translations::translations_6::latency_translation;
+use crate::translations::translations_6::{latency_translation, vlan_id_translation};
 use crate::utils::formatted_strings::{get_formatted_timestamp, get_socket_address};
 use crate::utils::types::icon::Icon;
 use crate::{Language, Protocol, Sniffer, StyleType};
@@ -199,6 +199,13 @@ fn col_info<'a>(
             protocol_translation(language),
             &key.protocol.to_string(),
         ));
+
+    if let Some(vlan_id) = val.vlan_id {
+        ret_val = ret_val.push(TextType::highlighted_subtitle_with_desc(
+            vlan_id_translation(language),
+            &vlan_id.to_string(),
+        ));
+    }
 
     if !is_icmp && !is_arp {
         ret_val = ret_val

--- a/src/networking/manage_packets.rs
+++ b/src/networking/manage_packets.rs
@@ -2,7 +2,8 @@ use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use etherparse::{
-    ArpHardwareId, EtherType, LaxPacketHeaders, LinkHeader, NetHeaders, TransportHeader,
+    ArpHardwareId, EtherType, LaxPacketHeaders, LinkExtHeader, LinkHeader, NetHeaders,
+    TransportHeader,
 };
 use pcap::Address;
 
@@ -33,6 +34,7 @@ pub fn analyze_headers(
     exchanged_bytes: &mut u128,
     icmp_type: &mut IcmpType,
     arp_type: &mut ArpType,
+    vlan_id: &mut Option<u16>,
 ) -> Option<AddressPortPair> {
     let mut retval = AddressPortPair::default();
 
@@ -42,6 +44,8 @@ pub fn analyze_headers(
         &mut mac_addresses.1,
         exchanged_bytes,
     );
+
+    *vlan_id = get_vlan_id(&headers.link_exts);
 
     let is_arp = matches!(&headers.net, Some(NetHeaders::Arp(_)));
 
@@ -102,6 +106,17 @@ fn analyze_link_header(
             *mac_address2 = None;
         }
     }
+}
+
+/// Returns the VLAN identifier carried by the outermost IEEE 802.1Q VLAN tag, if present.
+///
+/// Frames with double (`QinQ`) VLAN tagging only report the identifier of the
+/// outer tag, which is the one relevant for traffic segmentation.
+fn get_vlan_id(link_exts: &[LinkExtHeader]) -> Option<u16> {
+    link_exts.iter().find_map(|link_ext| match link_ext {
+        LinkExtHeader::Vlan(vlan_header) => Some(vlan_header.vlan_id.value()),
+        LinkExtHeader::Macsec(_) => None,
+    })
 }
 
 /// This function analyzes the network layer header passed as parameter and updates variables
@@ -269,6 +284,7 @@ pub fn modify_or_insert_in_map(
     mac_addresses: (Option<String>, Option<String>),
     icmp_type: IcmpType,
     arp_type: ArpType,
+    vlan_id: Option<u16>,
     exchanged_bytes: u128,
     ip_blacklist: &IpBlacklist,
 ) -> (TrafficDirection, Service) {
@@ -322,6 +338,7 @@ pub fn modify_or_insert_in_map(
         .or_insert_with(|| InfoAddressPortPair {
             mac_address1: mac_addresses.0,
             mac_address2: mac_addresses.1,
+            vlan_id,
             transmitted_bytes: exchanged_bytes,
             transmitted_packets: 1,
             initial_timestamp: timestamp,
@@ -530,6 +547,7 @@ pub fn get_local_port(
 
 #[cfg(test)]
 mod tests {
+    use etherparse::{LaxPacketHeaders, LinkExtHeader, PacketBuilder, SingleVlanHeader, VlanId};
     use pcap::Address;
     use std::collections::HashSet;
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
@@ -538,10 +556,12 @@ mod tests {
     use crate::Protocol;
     use crate::Service;
     use crate::networking::manage_packets::{
-        get_service, get_traffic_direction, get_traffic_type, is_local_connection,
-        mac_from_dec_to_hex,
+        analyze_headers, get_service, get_traffic_direction, get_traffic_type, get_vlan_id,
+        is_local_connection, mac_from_dec_to_hex,
     };
     use crate::networking::types::address_port_pair::AddressPortPair;
+    use crate::networking::types::arp_type::ArpType;
+    use crate::networking::types::icmp_type::IcmpType;
     use crate::networking::types::service_query::ServiceQuery;
     use crate::networking::types::traffic_direction::TrafficDirection;
     use crate::networking::types::traffic_type::TrafficType;
@@ -552,6 +572,100 @@ mod tests {
     fn mac_simple_test() {
         let result = mac_from_dec_to_hex([255, 255, 10, 177, 9, 15]);
         assert_eq!(result, "ff:ff:0a:b1:09:0f".to_string());
+    }
+
+    #[test]
+    fn get_vlan_id_returns_none_when_no_link_extensions() {
+        assert_eq!(get_vlan_id(&[]), None);
+    }
+
+    #[test]
+    fn get_vlan_id_returns_outer_tag_identifier() {
+        let vlan_id = VlanId::try_new(42).unwrap();
+        let link_exts = [LinkExtHeader::Vlan(SingleVlanHeader {
+            vlan_id,
+            ..Default::default()
+        })];
+        assert_eq!(get_vlan_id(&link_exts), Some(42));
+    }
+
+    #[test]
+    fn get_vlan_id_returns_first_tag_for_double_vlan_tagging() {
+        let outer_vlan_id = VlanId::try_new(100).unwrap();
+        let inner_vlan_id = VlanId::try_new(200).unwrap();
+        let link_exts = [
+            LinkExtHeader::Vlan(SingleVlanHeader {
+                vlan_id: outer_vlan_id,
+                ..Default::default()
+            }),
+            LinkExtHeader::Vlan(SingleVlanHeader {
+                vlan_id: inner_vlan_id,
+                ..Default::default()
+            }),
+        ];
+        assert_eq!(get_vlan_id(&link_exts), Some(100));
+    }
+
+    #[test]
+    fn analyze_headers_parses_vlan_tagged_ethernet_frame() {
+        // build a synthetic VLAN-tagged (IEEE 802.1Q) ethernet frame carrying a UDP/IPv4 packet
+        let builder = PacketBuilder::ethernet2([1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12])
+            .single_vlan(VlanId::try_new(123).unwrap())
+            .ipv4([192, 168, 1, 1], [192, 168, 1, 2], 20)
+            .udp(21, 1234);
+        let payload = [1, 2, 3, 4, 5, 6, 7, 8];
+        let mut packet = Vec::with_capacity(builder.size(payload.len()));
+        builder.write(&mut packet, &payload).unwrap();
+
+        let headers = LaxPacketHeaders::from_ethernet(&packet).unwrap();
+
+        let mut mac_addresses = (None, None);
+        let mut exchanged_bytes = 0;
+        let mut icmp_type = IcmpType::default();
+        let mut arp_type = ArpType::default();
+        let mut vlan_id = None;
+
+        let key = analyze_headers(
+            headers,
+            &mut mac_addresses,
+            &mut exchanged_bytes,
+            &mut icmp_type,
+            &mut arp_type,
+            &mut vlan_id,
+        );
+
+        assert!(key.is_some());
+        assert_eq!(vlan_id, Some(123));
+    }
+
+    #[test]
+    fn analyze_headers_returns_no_vlan_id_for_untagged_frame() {
+        let builder = PacketBuilder::ethernet2([1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12])
+            .ipv4([192, 168, 1, 1], [192, 168, 1, 2], 20)
+            .udp(21, 1234);
+        let payload = [1, 2, 3, 4, 5, 6, 7, 8];
+        let mut packet = Vec::with_capacity(builder.size(payload.len()));
+        builder.write(&mut packet, &payload).unwrap();
+
+        let headers = LaxPacketHeaders::from_ethernet(&packet).unwrap();
+
+        let mut mac_addresses = (None, None);
+        let mut exchanged_bytes = 0;
+        let mut icmp_type = IcmpType::default();
+        let mut arp_type = ArpType::default();
+        let mut vlan_id = None;
+
+        let key = analyze_headers(
+            headers,
+            &mut mac_addresses,
+            &mut exchanged_bytes,
+            &mut icmp_type,
+            &mut arp_type,
+            &mut vlan_id,
+        );
+
+        assert!(key.is_some());
+        assert_eq!(vlan_id, None);
     }
 
     #[test]

--- a/src/networking/parse_packets.rs
+++ b/src/networking/parse_packets.rs
@@ -162,6 +162,7 @@ pub fn parse_packets(
                     let mut mac_addresses = (None, None);
                     let mut icmp_type = IcmpType::default();
                     let mut arp_type = ArpType::default();
+                    let mut vlan_id = None;
 
                     let key_option = analyze_headers(
                         headers,
@@ -169,6 +170,7 @@ pub fn parse_packets(
                         &mut exchanged_bytes,
                         &mut icmp_type,
                         &mut arp_type,
+                        &mut vlan_id,
                     );
 
                     let Some(key) = key_option else {
@@ -190,6 +192,7 @@ pub fn parse_packets(
                         mac_addresses,
                         icmp_type,
                         arp_type,
+                        vlan_id,
                         exchanged_bytes,
                         ip_blacklist,
                     );

--- a/src/networking/traffic_preview.rs
+++ b/src/networking/traffic_preview.rs
@@ -52,6 +52,7 @@ pub fn traffic_preview(tx: &Sender<TrafficPreview>) {
                     &mut 0,
                     &mut IcmpType::default(),
                     &mut ArpType::default(),
+                    &mut None,
                 )
                 .is_some()
             {

--- a/src/networking/types/info_address_port_pair.rs
+++ b/src/networking/types/info_address_port_pair.rs
@@ -23,6 +23,8 @@ pub struct InfoAddressPortPair {
     pub mac_address1: Option<String>,
     /// Destination MAC address
     pub mac_address2: Option<String>,
+    /// VLAN identifier carried by the IEEE 802.1Q tag of the exchanged frames, if any.
+    pub vlan_id: Option<u16>,
     /// Amount of bytes transmitted between the pair.
     pub transmitted_bytes: u128,
     /// Amount of packets transmitted between the pair.
@@ -108,6 +110,7 @@ impl Default for InfoAddressPortPair {
         Self {
             mac_address1: None,
             mac_address2: None,
+            vlan_id: None,
             transmitted_bytes: 0,
             transmitted_packets: 0,
             initial_timestamp: Timestamp::default(),

--- a/src/translations/translations_6.rs
+++ b/src/translations/translations_6.rs
@@ -9,3 +9,10 @@ pub fn latency_translation(language: Language) -> &'static str {
         _ => "Latency",
     }
 }
+
+pub fn vlan_id_translation(language: Language) -> &'static str {
+    match language {
+        Language::EN => "VLAN ID",
+        _ => "VLAN ID",
+    }
+}


### PR DESCRIPTION
## Summary

Sniffnet already captures VLAN-tagged (IEEE 802.1Q) packets but never
parsed the VLAN header, so no VLAN information was ever shown to the user.

## Change

Added `get_vlan_id()` in `src/networking/manage_packets.rs`, using
`etherparse::LaxPacketHeaders`'s existing `link_exts` field (previously
ignored) to read the outermost VLAN tag's ID. For QinQ double-tagged
frames, only the outer tag is kept, since that's the one relevant for
segmentation.

`analyze_headers()` and `modify_or_insert_in_map()` gained a `vlan_id`
parameter/field, following the exact pattern already used for
`mac_address1`/`mac_address2`. The connection details page shows a new
"VLAN ID" row (right after Protocol) when a connection has one, using the
existing `TextType::highlighted_subtitle_with_desc` pattern. English
translation only added, per CONTRIBUTING.md (I don't speak the other
supported languages).

Scope matches the issue as filed — parsing and displaying the VLAN ID —
with no changes to filtering, sorting, reports, or CSV export.

## Tests

- 5 new unit tests in `src/networking/manage_packets.rs`: two on
  `get_vlan_id()` directly, two building real synthetic packet bytes via
  `etherparse::PacketBuilder` (one VLAN-tagged, one untagged) run through
  `analyze_headers`, and one for QinQ double-tagging.
- `cargo test` — 181/181 passing (including the 5 new tests).
- `cargo clippy -- -D warnings` (the command CONTRIBUTING.md and CI both
  use) — clean.
- `cargo fmt --all -- --check` — clean.
- `CHANGELOG.md` updated under `[UNRELEASED]` per CONTRIBUTING.md.

## AI-assisted contribution disclosure

This change (implementation and tests) was produced with AI assistance
(Claude Code) and reviewed by me before submitting, per CONTRIBUTING.md's
AI-assistance policy. I can explain and defend the change: it follows the
existing `mac_address1`/`mac_address2` field-threading pattern already used
throughout `analyze_headers`/`modify_or_insert_in_map` for exactly this
kind of per-connection metadata.

## Related issue

Fixes #1070
