### PR TITLE
Fix infinite spinning loop when a captured interface goes down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All Sniffnet releases with the relative changes are documented in this file.
 
 ## [UNRELEASED]
 - IPFIX collector capabilities: receive and analyze network traffic from remote devices ([#1270](https://github.com/GyulyVGC/sniffnet/pull/1270) — fixes [#303](https://github.com/GyulyVGC/sniffnet/issues/303))
-- Fix infinite spinning loop when the captured network interface goes down (fixes [#1028](https://github.com/GyulyVGC/sniffnet/issues/1028))
+- Fix infinite spinning loop when the captured network interface goes down ([#1287](https://github.com/GyulyVGC/sniffnet/pull/1287) — fixes [#1028](https://github.com/GyulyVGC/sniffnet/issues/1028))
 - Correctly filter by favorites-only before rDNS completes ([#1275](https://github.com/GyulyVGC/sniffnet/pull/1275))
 - Set `Content-Type: application/json` header on remote notifications ([#1266](https://github.com/GyulyVGC/sniffnet/pull/1266))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All Sniffnet releases with the relative changes are documented in this file.
 
 ## [UNRELEASED]
 - IPFIX collector capabilities: receive and analyze network traffic from remote devices ([#1270](https://github.com/GyulyVGC/sniffnet/pull/1270) — fixes [#303](https://github.com/GyulyVGC/sniffnet/issues/303))
+- Fix infinite spinning loop when the captured network interface goes down (fixes [#1028](https://github.com/GyulyVGC/sniffnet/issues/1028))
 - Correctly filter by favorites-only before rDNS completes ([#1275](https://github.com/GyulyVGC/sniffnet/pull/1275))
 - Set `Content-Type: application/json` header on remote notifications ([#1266](https://github.com/GyulyVGC/sniffnet/pull/1266))
 

--- a/src/gui/pages/waiting_page.rs
+++ b/src/gui/pages/waiting_page.rs
@@ -31,7 +31,9 @@ pub fn waiting_page(sniffer: &Sniffer) -> Option<Container<'_, Message, StyleTyp
         .tot_data_info
         .tot_data(DataRepr::Packets);
 
-    if tot_packets > 0 {
+    // a fatal capture error must be shown even if traffic was already flowing
+    // (e.g. the interface being captured on went down mid-capture)
+    if tot_packets > 0 && !matches!(capture_error, Some(CaptureError::Fatal(_))) {
         return None;
     }
 

--- a/src/gui/sniffer.rs
+++ b/src/gui/sniffer.rs
@@ -365,6 +365,7 @@ impl Sniffer {
             Message::PendingHosts(cap_id, host_msgs) => self.pending_hosts(cap_id, host_msgs),
             Message::OfflineGap(cap_id, gap) => self.offline_gap(cap_id, gap),
             Message::IpfixUndecodable(cap_id) => self.ipfix_undecodable(cap_id),
+            Message::CaptureError(cap_id, err) => self.handle_capture_error(cap_id, err),
             Message::Periodic => self.periodic(),
             Message::ExpandNotification(id, expand) => self.expand_notification(id, expand),
             Message::ToggleRemoteNotifications => self.toggle_remote_notifications(),
@@ -870,6 +871,12 @@ impl Sniffer {
         }
     }
 
+    fn handle_capture_error(&mut self, cap_id: usize, err: String) {
+        if cap_id == self.current_capture_rx.0 {
+            self.capture_error = Some(CaptureError::Fatal(err));
+        }
+    }
+
     fn periodic(&mut self) {
         self.update_waiting_dots();
         self.capture_source.set_addresses();
@@ -1101,6 +1108,9 @@ impl Sniffer {
                     }
                     BackendTrafficMessage::IpfixUndecodable(cap_id) => {
                         Message::IpfixUndecodable(cap_id)
+                    }
+                    BackendTrafficMessage::CaptureError(cap_id, err) => {
+                        Message::CaptureError(cap_id, err)
                     }
                 });
             }

--- a/src/gui/types/message.rs
+++ b/src/gui/types/message.rs
@@ -160,6 +160,9 @@ pub enum Message {
     OfflineGap(usize, u32),
     /// Sent by the IPFIX collector: incoming datagrams aren't decodable as IPFIX
     IpfixUndecodable(usize),
+    /// Sent by the backend capturing packets: the capture hit an unrecoverable error
+    /// (e.g. the network interface went down) and had to stop
+    CaptureError(usize, String),
     /// Emitted every second to repeat certain tasks (such as fetching the network devices)
     Periodic,
     /// Expand or collapse the given logged notification

--- a/src/networking/capture.rs
+++ b/src/networking/capture.rs
@@ -237,4 +237,7 @@ pub enum BackendTrafficMessage {
     PendingHosts(usize, Vec<HostMessage>),
     OfflineGap(usize, u32),
     IpfixUndecodable(usize),
+    /// The capture backend hit an unrecoverable error while running (e.g. the network
+    /// interface being captured on went down) and had to stop.
+    CaptureError(usize, String),
 }

--- a/src/networking/parse_packets.rs
+++ b/src/networking/parse_packets.rs
@@ -110,6 +110,12 @@ pub fn parse_packets(
                     let _ = tx
                         .send_blocking(BackendTrafficMessage::PendingHosts(cap_id, pending_hosts));
                     return;
+                } else if CaptureType::is_fatal_error(&e) {
+                    // the capture became unusable (e.g. the network interface went down):
+                    // report the failure and stop, instead of spinning on the same error forever
+                    let _ = tx
+                        .send_blocking(BackendTrafficMessage::CaptureError(cap_id, e.to_string()));
+                    return;
                 }
             }
             Ok(packet) => {
@@ -309,11 +315,14 @@ fn packet_stream(
         }
 
         let packet_res = cap.next_packet();
+        let is_fatal = matches!(&packet_res, Err(e) if CaptureType::is_fatal_error(e));
         let packet_owned = packet_res.map(|p| PacketOwned {
             header: *p.header,
             data: p.data.into(),
         });
-        if tx.send((packet_owned, cap.stats().ok())).is_err() {
+        if tx.send((packet_owned, cap.stats().ok())).is_err() || is_fatal {
+            // stop polling a capture that has become unusable (e.g. interface down),
+            // instead of spinning on the same error forever
             return;
         }
     }

--- a/src/networking/traffic_preview.rs
+++ b/src/networking/traffic_preview.rs
@@ -113,11 +113,14 @@ fn packet_stream(
 ) {
     loop {
         let packet_res = cap.next_packet();
+        let is_fatal = matches!(&packet_res, Err(e) if CaptureType::is_fatal_error(e));
         let packet_owned = packet_res.map(|p| PacketOwned {
             data: p.data.into(),
             dev_info: dev_info.clone(),
         });
-        if tx.send((packet_owned, cap.stats().ok())).is_err() {
+        if tx.send((packet_owned, cap.stats().ok())).is_err() || is_fatal {
+            // stop polling a capture that has become unusable (e.g. interface down),
+            // instead of spinning on the same error forever
             return;
         }
     }

--- a/src/networking/types/capture_context.rs
+++ b/src/networking/types/capture_context.rs
@@ -178,6 +178,14 @@ impl CaptureType {
         }
     }
 
+    /// Whether a `next_packet` error means the capture has become permanently unusable
+    /// (e.g. the network interface went down) and must stop being polled, as opposed to
+    /// a benign/expected condition such as a read timeout on a live capture or reaching
+    /// the end of an offline file.
+    pub fn is_fatal_error(e: &Error) -> bool {
+        !matches!(e, Error::TimeoutExpired | Error::NoMorePackets)
+    }
+
     fn from_device(device: &MyDevice, pcap_out_path: Option<&String>) -> Result<Self, String> {
         let inactive = Capture::from_device(device.to_pcap_device()).map_err(|e| e.to_string())?;
         let cap = inactive
@@ -473,5 +481,43 @@ impl CaptureSourcePicklist {
             Self::Device => true,
             Self::Ipfix | Self::File => false,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // `pcap::Error::PcapError` is the variant `next_packet` returns for a wide range of
+    // OS-level libpcap failures, including the interface disappearing while a live
+    // capture is running (see https://github.com/GyulyVGC/sniffnet/issues/1028 and
+    // https://github.com/rust-pcap/pcap/issues/393). It must be treated as fatal so the
+    // capture loop stops instead of spinning on the same error forever.
+    #[test]
+    fn test_interface_disappeared_is_a_fatal_error() {
+        let interface_disappeared = Error::PcapError("The interface disappeared".to_string());
+        assert!(CaptureType::is_fatal_error(&interface_disappeared));
+    }
+
+    #[test]
+    fn test_other_pcap_errors_are_fatal() {
+        assert!(CaptureType::is_fatal_error(&Error::InvalidLinktype));
+        assert!(CaptureType::is_fatal_error(&Error::InsufficientMemory));
+        assert!(CaptureType::is_fatal_error(&Error::NonNonBlock));
+        assert!(CaptureType::is_fatal_error(&Error::PcapError(
+            "any other libpcap failure".to_string()
+        )));
+    }
+
+    #[test]
+    fn test_timeout_expired_is_not_fatal() {
+        // a benign, expected condition on a live capture with no traffic in the last read window
+        assert!(!CaptureType::is_fatal_error(&Error::TimeoutExpired));
+    }
+
+    #[test]
+    fn test_no_more_packets_is_not_fatal() {
+        // the expected end-of-file condition when importing an offline capture
+        assert!(!CaptureType::is_fatal_error(&Error::NoMorePackets));
     }
 }


### PR DESCRIPTION
## Summary

`pcap`'s `next_packet()` keeps returning a fatal `PcapError` (e.g. `"The interface disappeared"` on macOS, see also [rust-pcap/pcap#393](https://github.com/rust-pcap/pcap/issues/393)) once the network interface being captured on is taken down. Both packet-capture loops (`parse_packets::packet_stream` and `traffic_preview::packet_stream`) treated any non-`NoMorePackets` error as transient and kept calling `next_packet()` in a tight loop, pegging a CPU core forever instead of stopping.

## Changes

- Added `CaptureType::is_fatal_error`, classifying every `pcap::Error` as fatal except the two expected conditions: `TimeoutExpired` (no traffic in the last read window on a live capture) and `NoMorePackets` (EOF on an offline import).
- Both `packet_stream` threads (device capture and traffic-preview capture) now stop polling as soon as a fatal error is hit, instead of spinning on the same error indefinitely.
- `parse_packets`'s main loop reports the fatal error via a new `BackendTrafficMessage::CaptureError` / `Message::CaptureError`, reusing the existing `CaptureError::Fatal` mechanism already used for capture-start failures, so the failure is surfaced to the user instead of silently spinning.
- `waiting_page` now shows this fatal error even if traffic had already been captured in the session (previously it only showed pre-capture errors, since it bails out early once packets have been seen).

## Notes

- This does not add automatic re-instantiation of the capture once the interface comes back up (the issue mentions this is a separate, not-yet-implemented follow-up); the immediate bug (the busy-loop) is fixed and the failure is now surfaced instead of silently spinning.
- I could only unit-test the error-classification logic (`is_fatal_error`); actually simulating an OS-level interface-down event isn't practical in CI, so that part is verified by manual reasoning about the loop's exit conditions rather than an automated test.
- Disclosure: I used AI assistance (an LLM-based coding agent) to help investigate this issue and draft the fix; I reviewed and tested the change myself before opening this PR.

Fixes #1028

## Test plan
- [x] `cargo build`
- [x] `cargo test` (233 passed)
- [x] `cargo clippy -- -D warnings` (matches CI invocation)
- [x] `cargo fmt --all -- --check`
- [x] Manual review of the loop's exit/continue conditions to confirm the fatal-error path actually breaks the spin