### PR TITLE
Various improvements and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All Sniffnet releases with the relative changes are documented in this file.
 
 ## [UNRELEASED]
 - IPFIX collector capabilities: receive and analyze network traffic from remote devices ([#1270](https://github.com/GyulyVGC/sniffnet/pull/1270) — fixes [#303](https://github.com/GyulyVGC/sniffnet/issues/303))
+- Show output file path in Overview page when exporting a PCAP file ([`3f2c42c`](https://github.com/GyulyVGC/sniffnet/pull/1290/commits/3f2c42c70f06d5d29ddad80dde956281c6705511))
+- Fix the app freezing and exhausting memory when importing a PCAP file containing a large time gap between consecutive packets ([`4605ec7`](https://github.com/GyulyVGC/sniffnet/pull/1290/commits/4605ec717bbaf8fa34268805814d5585f084201e))
+- Restrict the PCAP export file to have a valid PCAP extension, so that files of other types can't be overwritten ([`5b4801b`](https://github.com/GyulyVGC/sniffnet/pull/1290/commits/5b4801b438ff1c7968cfac423a8e8585778309a8))
 - Correctly filter by favorites-only before rDNS completes ([#1275](https://github.com/GyulyVGC/sniffnet/pull/1275))
 - Set `Content-Type: application/json` header on remote notifications ([#1266](https://github.com/GyulyVGC/sniffnet/pull/1266))
 

--- a/src/chart/types/traffic_chart.rs
+++ b/src/chart/types/traffic_chart.rs
@@ -24,6 +24,9 @@ use crate::utils::formatted_strings::{get_formatted_num_seconds, get_formatted_t
 use crate::utils::types::timestamp::Timestamp;
 use crate::{Language, StyleType, location};
 
+/// Maximum number of zero-traffic points pushed to represent a gap between two offline packets
+const MAX_OFFLINE_GAP_POINTS: u32 = 86_400; // one day
+
 /// Struct defining the chart to be displayed in gui run page
 pub struct TrafficChart {
     /// Current time interval number
@@ -137,7 +140,11 @@ impl TrafficChart {
     }
 
     pub fn push_offline_gap_to_splines(&mut self, gap: u32) {
-        for i in 0..gap {
+        // an idle period is a flat line: drawing it doesn't need a point per second
+        // a capture containing a huge time jump would stall the GUI and exhaust memory
+        let step = gap.div_ceil(MAX_OFFLINE_GAP_POINTS).max(1);
+
+        for i in (0..gap).step_by(step as usize) {
             #[allow(clippy::cast_precision_loss)]
             let point = ((self.ticks + i) as f32, 0.0);
             self.in_bytes.update_series(point, false, false);
@@ -451,7 +458,28 @@ impl Chart<Message> for TrafficChart {
 mod tests {
     use splines::{Interpolation, Key, Spline};
 
-    use crate::chart::types::traffic_chart::sample_spline;
+    use crate::chart::types::traffic_chart::{MAX_OFFLINE_GAP_POINTS, sample_spline};
+    use crate::networking::types::data_representation::DataRepr;
+    use crate::{Language, StyleType, TrafficChart};
+
+    #[test]
+    fn test_offline_gap_points_are_capped() {
+        let mut chart = TrafficChart::new(StyleType::default(), Language::EN, DataRepr::Bytes);
+
+        // a gap shorter than the cap is represented one point per second
+        chart.push_offline_gap_to_splines(10);
+        assert_eq!(chart.ticks, 10);
+        assert_eq!(chart.in_bytes.all_time.len(), 10);
+        chart.push_offline_gap_to_splines(28_800);
+        assert_eq!(chart.ticks, 10 + 28_800);
+        assert_eq!(chart.in_bytes.all_time.len(), 10 + 28_800);
+
+        // the points stored stay bounded, so the GUI is not stalled
+        chart.push_offline_gap_to_splines(1_000_000_000);
+        let max_len = 10 + 28_800 + MAX_OFFLINE_GAP_POINTS as usize;
+        assert_eq!(chart.ticks, 10 + 28_800 + 1_000_000_000);
+        assert!(chart.in_bytes.all_time.len() <= max_len);
+    }
 
     #[test]
     fn test_spline_samples() {

--- a/src/gui/pages/overview_page.rs
+++ b/src/gui/pages/overview_page.rs
@@ -31,6 +31,7 @@ use crate::translations::translations::{
 use crate::translations::translations_2::{
     data_representation_translation, dropped_translation, only_top_30_items_translation,
 };
+use crate::translations::translations_3::export_capture_translation;
 use crate::translations::translations_5::no_favorites_saved_translation;
 use crate::translations::translations_6::ipfix_exporter_translation;
 use crate::utils::types::icon::Icon;
@@ -269,6 +270,7 @@ fn col_info(sniffer: &Sniffer) -> Container<'_, Message, StyleType> {
         &sniffer.capture_source,
         &sniffer.conf.filters,
         &sniffer.combobox_data_states.data.exporters.0,
+        sniffer.conf.export_pcap.full_path(),
     );
 
     let col_data_representation = col_data_representation(language, sniffer.conf.data_repr);
@@ -284,14 +286,19 @@ fn col_info(sniffer: &Sniffer) -> Container<'_, Message, StyleType> {
                 .push(
                     Scrollable::with_direction(
                         col_device,
-                        Direction::Horizontal(ScrollbarType::properties()),
+                        Direction::Both {
+                            horizontal: ScrollbarType::properties(),
+                            vertical: ScrollbarType::properties(),
+                        },
                     )
+                    .height(Length::Fill)
                     .width(Length::Fill),
                 )
-                .push(RuleType::Standard.vertical(25))
+                .push(RuleType::Standard.vertical(5))
+                .push(Space::new().width(10))
                 .push(col_data_representation.width(Length::Fill)),
         )
-        .push(RuleType::Standard.horizontal(15))
+        .push(RuleType::Standard.horizontal(5))
         .push(donut_row.height(Length::Fill));
 
     Container::new(content)
@@ -328,6 +335,7 @@ pub(crate) fn col_device<'a>(
     cs: &'a CaptureSource,
     filters: &'a Filters,
     exporters: &'a BTreeSet<IpfixExporter>,
+    export_pcap: Option<String>,
 ) -> Column<'a, Message, StyleType> {
     let link_type = cs.get_link_type();
     #[cfg(not(target_os = "windows"))]
@@ -390,6 +398,24 @@ pub(crate) fn col_device<'a>(
         } else {
             None
         })
+        .push(
+            if cs.supports_export_pcap()
+                && let Some(path) = export_pcap
+            {
+                Some(
+                    Column::new()
+                        // add some bottom padding to avoid horizontal scroller overlapping the text
+                        .padding(Padding::ZERO.bottom(10))
+                        .push(
+                            Text::new(format!("{}:", export_capture_translation(language)))
+                                .class(TextType::Subtitle),
+                        )
+                        .push(Row::new().push(Text::new("   ")).push(Text::new(path))),
+                )
+            } else {
+                None
+            },
+        )
 }
 
 fn get_exporters_col<'a>(

--- a/src/gui/pages/overview_page.rs
+++ b/src/gui/pages/overview_page.rs
@@ -25,7 +25,7 @@ use crate::networking::types::data_representation::DataRepr;
 use crate::networking::types::ipfix_exporter::IpfixExporter;
 use crate::report::types::sort_type::SortType;
 use crate::translations::translations::{
-    active_filters_translation, incoming_translation, none_translation, outgoing_translation,
+    active_filters_translation, incoming_translation, outgoing_translation,
     traffic_rate_translation,
 };
 use crate::translations::translations_2::{
@@ -286,19 +286,14 @@ fn col_info(sniffer: &Sniffer) -> Container<'_, Message, StyleType> {
                 .push(
                     Scrollable::with_direction(
                         col_device,
-                        Direction::Both {
-                            horizontal: ScrollbarType::properties(),
-                            vertical: ScrollbarType::properties(),
-                        },
+                        Direction::Horizontal(ScrollbarType::properties()),
                     )
-                    .height(Length::Fill)
                     .width(Length::Fill),
                 )
-                .push(RuleType::Standard.vertical(5))
-                .push(Space::new().width(10))
+                .push(RuleType::Standard.vertical(25))
                 .push(col_data_representation.width(Length::Fill)),
         )
-        .push(RuleType::Standard.horizontal(5))
+        .push(RuleType::Standard.horizontal(15))
         .push(donut_row.height(Length::Fill));
 
     Container::new(content)
@@ -356,18 +351,6 @@ pub(crate) fn col_device<'a>(
         get_addresses_row(link_type, cs.get_ipfix_unspecified_bound_addresses()).map(Element::from)
     };
 
-    let filters_desc: Element<Message, StyleType> = if filters.is_some_filter_active() {
-        Row::new()
-            .spacing(10)
-            .push(Text::new("BPF"))
-            .push(get_info_tooltip(
-                Text::new(filters.bpf()).size(FONT_SIZE_FOOTER).into(),
-            ))
-            .into()
-    } else {
-        Text::new(none_translation(language)).into()
-    };
-
     Column::new()
         .height(Length::Fill)
         .spacing(10)
@@ -387,14 +370,14 @@ pub(crate) fn col_device<'a>(
             None
         })
         .push(if cs.supports_filters() {
-            Some(
-                Column::new()
-                    .push(
-                        Text::new(format!("{}:", active_filters_translation(language)))
-                            .class(TextType::Subtitle),
-                    )
-                    .push(Row::new().push(Text::new("   ")).push(filters_desc)),
-            )
+            filters.is_some_filter_active().then(|| {
+                Row::new()
+                    .spacing(10)
+                    .push(Text::new(active_filters_translation(language)).class(TextType::Subtitle))
+                    .push(get_info_tooltip(
+                        Text::new(filters.bpf()).size(FONT_SIZE_FOOTER).into(),
+                    ))
+            })
         } else {
             None
         })
@@ -403,14 +386,15 @@ pub(crate) fn col_device<'a>(
                 && let Some(path) = export_pcap
             {
                 Some(
-                    Column::new()
-                        // add some bottom padding to avoid horizontal scroller overlapping the text
-                        .padding(Padding::ZERO.bottom(10))
+                    Row::new()
+                        .spacing(10)
                         .push(
-                            Text::new(format!("{}:", export_capture_translation(language)))
+                            Text::new(export_capture_translation(language))
                                 .class(TextType::Subtitle),
                         )
-                        .push(Row::new().push(Text::new("   ")).push(Text::new(path))),
+                        .push(get_info_tooltip(
+                            Text::new(path).size(FONT_SIZE_FOOTER).into(),
+                        )),
                 )
             } else {
                 None

--- a/src/gui/pages/waiting_page.rs
+++ b/src/gui/pages/waiting_page.rs
@@ -101,6 +101,7 @@ pub fn waiting_page(sniffer: &Sniffer) -> Option<Container<'_, Message, StyleTyp
                         cs,
                         &sniffer.conf.filters,
                         &sniffer.combobox_data_states.data.exporters.0,
+                        sniffer.conf.export_pcap.full_path(),
                     )
                     .height(Length::Shrink),
                 )

--- a/src/gui/sniffer.rs
+++ b/src/gui/sniffer.rs
@@ -350,7 +350,7 @@ impl Sniffer {
             Message::ProgramFavoritesFilterToggle => self.program_favorites_filter_toggle(),
             Message::ToggleExportPcap => self.toggle_export_pcap(),
             Message::OutputPcapDir(path) => self.output_pcap_dir(path),
-            Message::OutputPcapFile(name) => self.output_pcap_file(&name),
+            Message::OutputPcapFile(name) => self.output_pcap_file(name),
             Message::ToggleThumbnail(triggered_by_resize) => {
                 return self.toggle_thumbnail(triggered_by_resize);
             }
@@ -750,7 +750,7 @@ impl Sniffer {
         self.conf.export_pcap.set_directory(path);
     }
 
-    fn output_pcap_file(&mut self, name: &str) {
+    fn output_pcap_file(&mut self, name: String) {
         self.conf.export_pcap.set_file_name(name);
     }
 
@@ -1019,6 +1019,7 @@ impl Sniffer {
                 let current_device_name = &self.capture_source.get_name();
                 self.device_selection(current_device_name);
             }
+            self.conf.export_pcap.sanitize_file_name();
             let pcap_path = self.conf.export_pcap.full_path();
             let capture_context =
                 CaptureContext::new(&self.capture_source, pcap_path.as_ref(), &self.conf.filters);
@@ -2231,7 +2232,7 @@ mod tests {
         assert!(path.exists());
 
         let mut export_pcap = ExportPcap::default();
-        export_pcap.set_file_name("test.pcap");
+        export_pcap.set_file_name("test.pcap".to_string());
         export_pcap.set_directory("/test".to_string());
         export_pcap.toggle();
 

--- a/src/gui/types/conf.rs
+++ b/src/gui/types/conf.rs
@@ -155,10 +155,6 @@ impl Conf {
         // Program::NotApplicable is not allowed in favorites
         self.favorites
             .remove(&FavoriteKey::Program(Program::NotApplicable));
-
-        // PCAP export file name should not contain slashes
-        let export_pcap_file_name_conf = self.export_pcap.file_name().to_string();
-        self.export_pcap.set_file_name(&export_pcap_file_name_conf);
     }
 }
 

--- a/src/gui/types/export_pcap.rs
+++ b/src/gui/types/export_pcap.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::gui::types::conf::deserialize_or_default;
+use crate::utils::types::file_info::ALLOWED_PCAP_EXTENSIONS;
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
 #[serde(default)]
@@ -21,13 +22,35 @@ impl ExportPcap {
         self.enabled = !self.enabled;
     }
 
-    pub fn set_file_name(&mut self, file_name: &str) {
-        // remove forward and backward slashes to avoid directory traversal
-        self.file_name = file_name.replace(['/', '\\'], "");
+    pub fn set_file_name(&mut self, file_name: String) {
+        self.file_name = file_name;
     }
 
     pub fn set_directory(&mut self, directory: String) {
         self.directory = directory;
+    }
+
+    pub fn sanitize_file_name(&mut self) {
+        let file_name = self.file_name.trim();
+
+        // remove forward and backward slashes to avoid directory traversal
+        let file_name = file_name.replace(['/', '\\'], "");
+
+        // append a PCAP extension when the name doesn't already carry one
+        let has_pcap_extension = Path::new(&file_name)
+            .extension()
+            .and_then(std::ffi::OsStr::to_str)
+            .is_some_and(|ext| {
+                ALLOWED_PCAP_EXTENSIONS
+                    .iter()
+                    .any(|allowed| ext.eq_ignore_ascii_case(allowed))
+            });
+
+        self.file_name = if file_name.is_empty() || has_pcap_extension {
+            file_name
+        } else {
+            format!("{file_name}.{}", ALLOWED_PCAP_EXTENSIONS[0])
+        };
     }
 
     pub fn enabled(&self) -> bool {
@@ -72,6 +95,13 @@ impl Default for ExportPcap {
 mod tests {
     use super::*;
 
+    fn sanitized(file_name: &str) -> String {
+        let mut export_pcap = ExportPcap::default();
+        export_pcap.set_file_name(file_name.to_string());
+        export_pcap.sanitize_file_name();
+        export_pcap.file_name().to_string()
+    }
+
     #[test]
     fn test_default() {
         let export_pcap = ExportPcap::default();
@@ -100,14 +130,58 @@ mod tests {
         let mut export_pcap = ExportPcap::default();
         assert_eq!(export_pcap.file_name(), "sniffnet.pcap");
 
-        export_pcap.set_file_name("test.pcap");
+        export_pcap.set_file_name("test.pcap".to_string());
         assert_eq!(export_pcap.file_name(), "test.pcap");
 
-        export_pcap.set_file_name("./ciao/test\\hello.pcap");
-        assert_eq!(export_pcap.file_name(), ".ciaotesthello.pcap");
+        // the setter stores the name verbatim: sanitization is deferred
+        export_pcap.set_file_name("./ciao/test\\hello.pcap".to_string());
+        assert_eq!(export_pcap.file_name(), "./ciao/test\\hello.pcap");
 
-        export_pcap.set_file_name("");
+        export_pcap.set_file_name("".to_string());
         assert_eq!(export_pcap.file_name(), "");
+    }
+
+    #[test]
+    fn test_sanitize_file_name() {
+        // names already carrying an allowed extension are left untouched
+        for ext in ALLOWED_PCAP_EXTENSIONS {
+            assert_eq!(sanitized(&format!("test.{ext}")), format!("test.{ext}"));
+        }
+        // the extension check is case insensitive
+        assert_eq!(sanitized("test.PCAP"), "test.PCAP");
+        assert_eq!(sanitized("test.PcapNg"), "test.PcapNg");
+
+        // the default extension is appended when the name doesn't carry an allowed one
+        assert_eq!(sanitized("test"), "test.pcap");
+        assert_eq!(sanitized("test.txt"), "test.txt.pcap");
+        assert_eq!(sanitized("test.pcap.bak"), "test.pcap.bak.pcap");
+        assert_eq!(sanitized("my capture"), "my capture.pcap");
+        // a leading dot doesn't make an extension
+        assert_eq!(sanitized(".pcap"), ".pcap.pcap");
+
+        // surrounding whitespace is trimmed, inner whitespace is preserved
+        assert_eq!(sanitized("  test.pcap  "), "test.pcap");
+        assert_eq!(sanitized("\t test \n"), "test.pcap");
+        assert_eq!(sanitized(" my capture.cap "), "my capture.cap");
+
+        // forward and backward slashes are removed to avoid directory traversal
+        assert_eq!(sanitized("./ciao/test\\hello.pcap"), ".ciaotesthello.pcap");
+        assert_eq!(sanitized("/tmp/test.cap"), "tmptest.cap");
+        assert_eq!(sanitized("../../etc/passwd"), "....etcpasswd.pcap");
+        assert_eq!(sanitized("..\\..\\etc\\passwd.pcap"), "....etcpasswd.pcap");
+
+        // blank names are left empty, so that full_path falls back to the default one
+        assert_eq!(sanitized(""), "");
+        assert_eq!(sanitized("   "), "");
+        assert_eq!(sanitized("/\\/"), "");
+
+        // sanitization is idempotent
+        let mut export_pcap = ExportPcap::default();
+        export_pcap.set_file_name("  ./my capture  ".to_string());
+        export_pcap.sanitize_file_name();
+        assert_eq!(export_pcap.file_name(), ".my capture.pcap");
+        export_pcap.sanitize_file_name();
+        assert_eq!(export_pcap.file_name(), ".my capture.pcap");
     }
 
     #[test]
@@ -138,7 +212,7 @@ mod tests {
             Some(format!("{dir}sniffnet.pcap",))
         );
 
-        export_pcap.set_file_name("test.pcap");
+        export_pcap.set_file_name("test.pcap".to_string());
         assert_eq!(export_pcap.full_path(), Some(format!("{dir}test.pcap",)));
 
         let mut full_path = PathBuf::from("/tmp");
@@ -162,7 +236,7 @@ mod tests {
         let mut full_path = PathBuf::from("/tmp");
         full_path.push("sniffnet.pcap");
 
-        export_pcap.set_file_name("");
+        export_pcap.set_file_name("".to_string());
         assert_eq!(
             export_pcap.full_path(),
             Some(full_path.to_string_lossy().to_string())

--- a/src/networking/ipfix/baseline_cache.rs
+++ b/src/networking/ipfix/baseline_cache.rs
@@ -3,6 +3,9 @@ use std::time::Instant;
 use crate::networking::ipfix::ttl_map::TtlMap;
 use crate::networking::types::address_port_pair::AddressPortPair;
 
+/// Maximum number of baselines cached
+const MAX_BASELINES: usize = 100_000;
+
 /// Per-exporter flow cumulative counter tracking.
 /// Useful because some exporters report `octetTotalCount` / `packetTotalCount` instead of the delta counters,
 /// and we need to convert them to deltas for our own processing.
@@ -20,7 +23,7 @@ struct Baseline {
 impl BaselineCache {
     pub(super) fn new(now: Instant) -> Self {
         Self {
-            map: TtlMap::new(now),
+            map: TtlMap::new(now, MAX_BASELINES),
         }
     }
 

--- a/src/networking/ipfix/template_cache.rs
+++ b/src/networking/ipfix/template_cache.rs
@@ -4,6 +4,9 @@ use std::time::Instant;
 use crate::networking::ipfix::ttl_map::TtlMap;
 use crate::networking::ipfix::wire::FieldSpec;
 
+/// Maximum number of templates cached
+const MAX_TEMPLATES: usize = 10_000;
+
 /// Per-exporter IPFIX template cache.
 /// The cache is keyed by `(peer, observation_domain, template_id)`:
 /// the spec requires scoping templates by transport session + ODID,
@@ -15,7 +18,7 @@ pub(super) struct TemplateCache {
 impl TemplateCache {
     pub(super) fn new(now: Instant) -> Self {
         Self {
-            map: TtlMap::new(now),
+            map: TtlMap::new(now, MAX_TEMPLATES),
         }
     }
 

--- a/src/networking/ipfix/ttl_map.rs
+++ b/src/networking/ipfix/ttl_map.rs
@@ -8,10 +8,14 @@ pub(super) const ENTRY_TTL: Duration = Duration::from_mins(30);
 /// How often expired entries are checked for sweeping.
 pub(super) const PRUNE_INTERVAL: Duration = Duration::from_mins(1);
 
-/// A hash map whose entries expire after a period without use
+/// Fraction of the entries evicted at once when a full map has nothing expired to drop
+const EVICTION_FRACTION: usize = 4; // 25%
+
+/// A hash map whose entries expire after a period without use, holding at most `max_entries`
 pub(super) struct TtlMap<K, V> {
     map: HashMap<K, Aging<V>>,
     last_prune: Instant,
+    max_entries: usize,
 }
 
 struct Aging<V> {
@@ -19,16 +23,18 @@ struct Aging<V> {
     last_used: Instant,
 }
 
-impl<K: Eq + Hash, V> TtlMap<K, V> {
-    pub(super) fn new(now: Instant) -> Self {
+impl<K: Eq + Hash + Clone + Copy, V> TtlMap<K, V> {
+    pub(super) fn new(now: Instant, max_entries: usize) -> Self {
         Self {
             map: HashMap::new(),
             last_prune: now,
+            max_entries,
         }
     }
 
     pub(super) fn insert(&mut self, key: K, value: V, now: Instant) {
         self.maybe_prune(now);
+        self.make_room(&key, now);
 
         self.map.insert(
             key,
@@ -54,6 +60,7 @@ impl<K: Eq + Hash, V> TtlMap<K, V> {
         default: impl FnOnce() -> V,
     ) -> &mut V {
         self.maybe_prune(now);
+        self.make_room(&key, now);
 
         let aging = self.map.entry(key).or_insert_with(|| Aging {
             value: default(),
@@ -67,9 +74,38 @@ impl<K: Eq + Hash, V> TtlMap<K, V> {
         if now.duration_since(self.last_prune) < PRUNE_INTERVAL {
             return;
         }
+        self.prune(now);
+    }
+
+    fn prune(&mut self, now: Instant) {
         self.map
             .retain(|_, aging| now.duration_since(aging.last_used) < ENTRY_TTL);
         self.last_prune = now;
+    }
+
+    fn make_room(&mut self, key: &K, now: Instant) {
+        if self.map.len() < self.max_entries || self.map.contains_key(key) {
+            return;
+        }
+
+        // expired entries are the natural candidates, whenever the last sweep happened
+        self.prune(now);
+        if self.map.len() < self.max_entries {
+            return;
+        }
+
+        // nothing expired: drop the batch of least recently used entries
+        let to_evict =
+            self.map.len() - self.max_entries + (self.max_entries / EVICTION_FRACTION).max(1);
+        let mut by_age: Vec<(Instant, K)> = self
+            .map
+            .iter()
+            .map(|(key, aging)| (aging.last_used, *key))
+            .collect();
+        by_age.sort_unstable_by_key(|(last_used, _)| *last_used);
+        for (_, key) in by_age.iter().take(to_evict) {
+            self.map.remove(key);
+        }
     }
 
     #[cfg(test)]
@@ -93,7 +129,7 @@ mod tests {
     #[test]
     fn test_ttl_map_stores_and_reads_back() {
         let now = Instant::now();
-        let mut map = TtlMap::new(now);
+        let mut map = TtlMap::new(now, 1_000);
         assert_eq!(map.len(), 0);
         map.insert("k", 1, now);
         assert_eq!(map.get(&"k", now), Some(&1));
@@ -110,7 +146,7 @@ mod tests {
     #[test]
     fn test_ttl_map_idle_entries_are_swept() {
         let start = Instant::now();
-        let mut map = TtlMap::new(start);
+        let mut map = TtlMap::new(start, 1_000);
         map.insert("k", 1, start);
         assert_eq!(map.len(), 1);
         assert_eq!(map.get(&"k", after_entry_ttl(start)), None);
@@ -120,7 +156,7 @@ mod tests {
     #[test]
     fn test_ttl_map_reading_an_entry_keeps_it_alive() {
         let start = Instant::now();
-        let mut map = TtlMap::new(start);
+        let mut map = TtlMap::new(start, 1_000);
         map.insert("k", 1, start);
 
         let mut now = start;
@@ -136,7 +172,7 @@ mod tests {
     #[test]
     fn test_ttl_map_sweeping_spares_entries_still_in_use() {
         let start = Instant::now();
-        let mut map = TtlMap::new(start);
+        let mut map = TtlMap::new(start, 1_000);
         map.insert("used", 1, start);
         map.insert("idle", 2, start);
         assert_eq!(map.len(), 2);
@@ -150,9 +186,55 @@ mod tests {
     }
 
     #[test]
+    fn test_ttl_map_full_map_evicts_least_recently_used() {
+        let start = Instant::now();
+        let max = 100;
+        let mut map = TtlMap::new(start, max);
+
+        for i in 0..max {
+            map.insert(
+                i,
+                i,
+                start + Duration::from_millis(u64::try_from(i).unwrap()),
+            );
+        }
+        assert_eq!(map.len(), max);
+
+        // touching the oldest entry makes it the most recently used one
+        let now = start + Duration::from_secs(1);
+        assert_eq!(map.get(&0, now), Some(&0));
+
+        // inserting past the max evicts a batch of the least recently used entries
+        map.insert(max, max, now);
+        assert_eq!(map.len(), max - max / EVICTION_FRACTION + 1);
+        assert_eq!(map.get(&max, now), Some(&max));
+        assert_eq!(map.get(&0, now), Some(&0));
+        assert_eq!(map.get(&1, now), None);
+        assert_eq!(map.get(&2, now), None);
+        assert_eq!(map.get(&3, now), None);
+        assert_eq!(map.get(&4, now), None);
+        assert_eq!(map.get(&23, now), None);
+        assert_eq!(map.get(&24, now), None);
+        assert_eq!(map.get(&25, now), None);
+        assert_eq!(map.get(&26, now), Some(&26));
+    }
+
+    #[test]
+    fn test_ttl_map_never_grows_past_its_max() {
+        let start = Instant::now();
+        let max = 64;
+        let mut map = TtlMap::new(start, max);
+        for i in 0..10_000 {
+            map.insert(i, i, start);
+            assert!(map.len() <= max);
+        }
+        assert_eq!(map.get(&9_999, start), Some(&9_999));
+    }
+
+    #[test]
     fn test_ttl_map_get_or_insert_with_creates_then_reuses() {
         let now = Instant::now();
-        let mut map = TtlMap::new(now);
+        let mut map = TtlMap::new(now, 1_000);
         *map.get_or_insert_with("k", now, || 10) += 1;
         assert_eq!(map.get(&"k", now), Some(&11));
         *map.get_or_insert_with("k", now, || 10) += 1;

--- a/src/networking/ipfix/wire.rs
+++ b/src/networking/ipfix/wire.rs
@@ -241,12 +241,12 @@ fn apply_ie(ie_id: u16, raw: &[u8], record: &mut FlowRecord, priority: &mut Fiel
             }
         }
         ie::SOURCE_TRANSPORT_PORT => {
-            if let Some(v) = read_u16(raw) {
+            if let Some(v) = read_port(raw) {
                 record.src_port = Some(v);
             }
         }
         ie::DESTINATION_TRANSPORT_PORT => {
-            if let Some(v) = read_u16(raw) {
+            if let Some(v) = read_port(raw) {
                 record.dst_port = Some(v);
             }
         }
@@ -467,8 +467,11 @@ fn read_unsigned(raw: &[u8]) -> Option<u128> {
     Some(u128::from(u64::from_be_bytes(buf)))
 }
 
-/// Read a big-endian unsigned integer of 1 or 2 bytes into a `u16`
-fn read_u16(raw: &[u8]) -> Option<u16> {
+/// Read a big-endian unsigned integer of 1 or 2 bytes into a `u16`, returning `None` for port 0
+fn read_port(raw: &[u8]) -> Option<u16> {
+    if raw.iter().all(|b| *b == 0) {
+        return None;
+    }
     match raw.len() {
         1 => Some(u16::from(raw[0])),
         2 => Some(u16::from_be_bytes([raw[0], raw[1]])),
@@ -1228,12 +1231,15 @@ mod tests {
     }
 
     #[test]
-    fn test_read_u16() {
-        assert_eq!(read_u16(&[0x01, 0xBB]), Some(443));
+    fn test_read_port() {
+        assert_eq!(read_port(&[0x01, 0xBB]), Some(443));
         // a port narrowed to a single byte by reduced-size encoding
-        assert_eq!(read_u16(&[0xFF]), Some(255));
-        assert_eq!(read_u16(&[]), None);
-        assert_eq!(read_u16(&[0, 0, 1]), None);
+        assert_eq!(read_port(&[0xFF]), Some(255));
+        assert_eq!(read_port(&[]), None);
+        assert_eq!(read_port(&[0, 0, 1]), None);
+        // port 0 is invalid
+        assert_eq!(read_port(&[0, 0]), None);
+        assert_eq!(read_port(&[0]), None);
     }
 
     #[test]

--- a/src/networking/types/capture_context.rs
+++ b/src/networking/types/capture_context.rs
@@ -342,6 +342,13 @@ impl CaptureSource {
         }
     }
 
+    pub fn supports_export_pcap(&self) -> bool {
+        match self {
+            Self::Device(_) => true,
+            Self::Ipfix(_) | Self::File(_) => false,
+        }
+    }
+
     pub fn supports_latency(&self) -> bool {
         match self {
             Self::Device(_) => true,

--- a/src/translations/translations.rs
+++ b/src/translations/translations.rs
@@ -1519,36 +1519,36 @@ pub fn active_filters_translation(language: Language) -> &'static str {
     }
 }
 
-pub fn none_translation(language: Language) -> &'static str {
-    match language {
-        Language::EN => "none",
-        Language::CS => "žádný",
-        Language::IT => "nessuno",
-        Language::FR => "aucun",
-        Language::ES => "ninguno",
-        Language::PL => "brak",
-        Language::DE => "Keine",
-        Language::UK => "бракує",
-        Language::ZH_TW => "無",
-        Language::ZH => "无",
-        Language::RO => "niciunul",
-        Language::KO => "없음",
-        Language::TR => "hiç biri",
-        Language::RU => "ничего",
-        Language::PT => "nenhum",
-        Language::EL => "κανένα",
-        // Language::FA => "هیچ کدام",
-        Language::SV => "inga",
-        Language::FI => "ei mitään",
-        Language::JA => "なし",
-        Language::UZ => "hech biri",
-        Language::VI => "không có",
-        Language::ID => "Tidak ada",
-        Language::NL => "geen",
-        Language::HU => "semmi",
-        Language::SI => "කිසිවක් නැත",
-    }
-}
+// pub fn none_translation(language: Language) -> &'static str {
+//     match language {
+//         Language::EN => "none",
+//         Language::CS => "žádný",
+//         Language::IT => "nessuno",
+//         Language::FR => "aucun",
+//         Language::ES => "ninguno",
+//         Language::PL => "brak",
+//         Language::DE => "Keine",
+//         Language::UK => "бракує",
+//         Language::ZH_TW => "無",
+//         Language::ZH => "无",
+//         Language::RO => "niciunul",
+//         Language::KO => "없음",
+//         Language::TR => "hiç biri",
+//         Language::RU => "ничего",
+//         Language::PT => "nenhum",
+//         Language::EL => "κανένα",
+//         // Language::FA => "هیچ کدام",
+//         Language::SV => "inga",
+//         Language::FI => "ei mitään",
+//         Language::JA => "なし",
+//         Language::UZ => "hech biri",
+//         Language::VI => "không có",
+//         Language::ID => "Tidak ada",
+//         Language::NL => "geen",
+//         Language::HU => "semmi",
+//         Language::SI => "කිසිවක් නැත",
+//     }
+// }
 
 // pub fn yeti_night_translation(language: Language) -> &'static str {
 //     match language {

--- a/src/utils/types/file_info.rs
+++ b/src/utils/types/file_info.rs
@@ -2,6 +2,8 @@ use crate::translations::translations_3::select_dest_directory_translation;
 use crate::translations::translations_4::select_file_translation;
 use crate::translations::types::language::Language;
 
+pub const ALLOWED_PCAP_EXTENSIONS: [&str; 4] = ["pcap", "pcapng", "cap", "dmp"];
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum FileInfo {
     Style,
@@ -16,7 +18,7 @@ impl FileInfo {
         match self {
             FileInfo::Style => vec!["toml"],
             FileInfo::Database => vec!["mmdb"],
-            FileInfo::PcapImport => vec!["pcap", "pcapng", "cap"],
+            FileInfo::PcapImport => ALLOWED_PCAP_EXTENSIONS.to_vec(),
             FileInfo::Directory | FileInfo::Blacklist => vec![],
         }
     }


### PR DESCRIPTION
Various improvements and fixes:
- Show output file path in Overview page when exporting a PCAP file
- Fix the app freezing and exhausting memory when importing a PCAP file containing a large time gap between consecutive packets
- Restrict the PCAP export file to have a valid PCAP extension, so that files of other types can't be overwritten
- IPFIX collector: don't parse zero as a valid port number, and limit number of cached templates and baselines