### PR TITLE
Reduce font size in tooltips

### DIFF
--- a/src/countries/country_utils.rs
+++ b/src/countries/country_utils.rs
@@ -18,7 +18,7 @@ use crate::countries::flags_pictures::{
 };
 use crate::countries::types::country::Country;
 use crate::gui::styles::container::ContainerType;
-use crate::gui::styles::style_constants::TOOLTIP_DELAY;
+use crate::gui::styles::style_constants::{FONT_SIZE_FOOTER, TOOLTIP_DELAY};
 use crate::gui::types::message::Message;
 use crate::networking::types::data_info_host::DataInfoHost;
 use crate::networking::types::traffic_type::TrafficType;
@@ -347,10 +347,14 @@ pub fn get_flag_tooltip<'a>(
         ContainerType::Tooltip
     };
 
-    Tooltip::new(content, Text::new(actual_tooltip), Position::FollowCursor)
-        .snap_within_viewport(true)
-        .class(tooltip_style)
-        .delay(TOOLTIP_DELAY)
+    Tooltip::new(
+        content,
+        Text::new(actual_tooltip).size(FONT_SIZE_FOOTER),
+        Position::FollowCursor,
+    )
+    .snap_within_viewport(true)
+    .class(tooltip_style)
+    .delay(TOOLTIP_DELAY)
 }
 
 pub fn get_computer_tooltip<'a>(
@@ -382,8 +386,12 @@ pub fn get_computer_tooltip<'a>(
         (false, false, None, TrafficType::Unicast) => unknown_translation(language).to_string(),
     };
 
-    Tooltip::new(content, Text::new(tooltip), Position::FollowCursor)
-        .snap_within_viewport(true)
-        .class(ContainerType::Tooltip)
-        .delay(TOOLTIP_DELAY)
+    Tooltip::new(
+        content,
+        Text::new(tooltip).size(FONT_SIZE_FOOTER),
+        Position::FollowCursor,
+    )
+    .snap_within_viewport(true)
+    .class(ContainerType::Tooltip)
+    .delay(TOOLTIP_DELAY)
 }

--- a/src/gui/components/button.rs
+++ b/src/gui/components/button.rs
@@ -6,7 +6,7 @@ use iced::widget::tooltip::Position;
 use iced::widget::{Row, Text, Tooltip, button};
 
 use crate::gui::styles::container::ContainerType;
-use crate::gui::styles::style_constants::TOOLTIP_DELAY;
+use crate::gui::styles::style_constants::{FONT_SIZE_FOOTER, TOOLTIP_DELAY};
 use crate::gui::styles::text::TextType;
 use crate::gui::types::message::Message;
 use crate::translations::translations::hide_translation;
@@ -27,7 +27,7 @@ pub fn button_hide<'a>(message: Message, language: Language) -> Tooltip<'a, Mess
         .height(20)
         .width(20)
         .on_press(message),
-        Text::new(hide_translation(language)),
+        Text::new(hide_translation(language)).size(FONT_SIZE_FOOTER),
         Position::Right,
     )
     .gap(5)
@@ -62,21 +62,25 @@ pub fn button_open_file<'a>(
         button = button.on_press(Message::OpenFile(old_file, file_info, action));
     }
 
-    Tooltip::new(button, Text::new(tooltip_str), Position::Right)
-        .gap(5)
-        .class(tooltip_style)
-        .delay(TOOLTIP_DELAY)
+    Tooltip::new(
+        button,
+        Text::new(tooltip_str).size(FONT_SIZE_FOOTER),
+        Position::Right,
+    )
+    .gap(5)
+    .class(tooltip_style)
+    .delay(TOOLTIP_DELAY)
 }
 
 pub fn row_open_link_tooltip<'a>(str: &'static str) -> Row<'a, Message, StyleType> {
     let text = if str.is_empty() {
         None
     } else {
-        Some(Text::new(str))
+        Some(Text::new(str).size(FONT_SIZE_FOOTER))
     };
     Row::new()
         .align_y(Alignment::Center)
-        .spacing(10)
+        .spacing(7)
         .push(text)
-        .push(Icon::OpenLink.to_text().size(16).class(TextType::Title))
+        .push(Icon::OpenLink.to_text().size(13).class(TextType::Title))
 }

--- a/src/gui/components/header.rs
+++ b/src/gui/components/header.rs
@@ -10,7 +10,7 @@ use crate::gui::pages::types::settings_page::SettingsPage;
 use crate::gui::sniffer::Sniffer;
 use crate::gui::styles::button::ButtonType;
 use crate::gui::styles::container::ContainerType;
-use crate::gui::styles::style_constants::TOOLTIP_DELAY;
+use crate::gui::styles::style_constants::{FONT_SIZE_FOOTER, TOOLTIP_DELAY};
 use crate::gui::styles::types::gradient_type::GradientType;
 use crate::gui::types::message::Message;
 use crate::gui::types::settings::Settings;
@@ -96,7 +96,7 @@ fn get_button_reset<'a>(language: Language) -> Tooltip<'a, Message, StyleType> {
 
     Tooltip::new(
         content,
-        Text::new(quit_analysis_translation(language)),
+        Text::new(quit_analysis_translation(language)).size(FONT_SIZE_FOOTER),
         Position::Right,
     )
     .gap(5)
@@ -122,7 +122,7 @@ pub fn get_button_settings<'a>(
 
     Tooltip::new(
         content,
-        Text::new(settings_translation(language)),
+        Text::new(settings_translation(language)).size(FONT_SIZE_FOOTER),
         Position::Left,
     )
     .gap(5)
@@ -164,10 +164,14 @@ pub fn get_button_minimize<'a>(
     .class(ButtonType::Thumbnail)
     .on_press(Message::ToggleThumbnail(false));
 
-    Tooltip::new(content, Text::new(tooltip), Position::FollowCursor)
-        .gap(0)
-        .class(tooltip_style)
-        .delay(TOOLTIP_DELAY)
+    Tooltip::new(
+        content,
+        Text::new(tooltip).size(FONT_SIZE_FOOTER),
+        Position::FollowCursor,
+    )
+    .gap(0)
+    .class(tooltip_style)
+    .delay(TOOLTIP_DELAY)
 }
 
 pub fn get_button_freeze<'a>(
@@ -203,10 +207,14 @@ pub fn get_button_freeze<'a>(
     .class(ButtonType::Thumbnail)
     .on_press(Message::Freeze);
 
-    Tooltip::new(content, Text::new(tooltip), Position::FollowCursor)
-        .gap(0)
-        .class(tooltip_style)
-        .delay(TOOLTIP_DELAY)
+    Tooltip::new(
+        content,
+        Text::new(tooltip).size(FONT_SIZE_FOOTER),
+        Position::FollowCursor,
+    )
+    .gap(0)
+    .class(tooltip_style)
+    .delay(TOOLTIP_DELAY)
 }
 
 fn thumbnail_header<'a>(

--- a/src/gui/pages/connection_details_page.rs
+++ b/src/gui/pages/connection_details_page.rs
@@ -5,7 +5,7 @@ use crate::gui::components::button::button_hide;
 use crate::gui::styles::container::ContainerType;
 use crate::gui::styles::rule::RuleType;
 use crate::gui::styles::scrollbar::ScrollbarType;
-use crate::gui::styles::style_constants::{FONT_SIZE_TITLE, TOOLTIP_DELAY};
+use crate::gui::styles::style_constants::{FONT_SIZE_FOOTER, FONT_SIZE_TITLE, TOOLTIP_DELAY};
 use crate::gui::styles::text::TextType;
 use crate::gui::styles::types::gradient_type::GradientType;
 use crate::gui::types::message::Message;
@@ -320,7 +320,7 @@ fn latency_row<'a>(
 fn get_error_tooltip<'a>(error: &str) -> Tooltip<'a, Message, StyleType> {
     Tooltip::new(
         Icon::Error.to_text(),
-        Text::new(error.to_string()),
+        Text::new(error.to_string()).size(FONT_SIZE_FOOTER),
         Position::FollowCursor,
     )
     .class(ContainerType::Tooltip)
@@ -476,7 +476,7 @@ fn get_button_copy<'a>(
 
     Tooltip::new(
         content,
-        Text::new(format!("{} (IP)", copy_translation(language))),
+        Text::new(format!("{} (IP)", copy_translation(language))).size(FONT_SIZE_FOOTER),
         Position::Right,
     )
     .gap(5)
@@ -504,8 +504,12 @@ fn get_button_ping(
         button = button.on_press(Message::MeasureLatency(ip));
     }
 
-    Tooltip::new(button, "Ping", Position::Right)
-        .gap(5)
-        .class(ContainerType::Tooltip)
-        .delay(TOOLTIP_DELAY)
+    Tooltip::new(
+        button,
+        Text::new("Ping").size(FONT_SIZE_FOOTER),
+        Position::Right,
+    )
+    .gap(5)
+    .class(ContainerType::Tooltip)
+    .delay(TOOLTIP_DELAY)
 }

--- a/src/gui/pages/inspect_page.rs
+++ b/src/gui/pages/inspect_page.rs
@@ -172,9 +172,13 @@ fn report_header_row(
         } else {
             ContainerType::Tooltip
         };
-        let title_tooltip = Tooltip::new(title_row, Text::new(tooltip_val), Position::FollowCursor)
-            .class(tooltip_style)
-            .delay(TOOLTIP_DELAY);
+        let title_tooltip = Tooltip::new(
+            title_row,
+            Text::new(tooltip_val).size(FONT_SIZE_FOOTER),
+            Position::FollowCursor,
+        )
+        .class(tooltip_style)
+        .delay(TOOLTIP_DELAY);
 
         let mut col_header = Column::new()
             .align_x(Alignment::Center)
@@ -556,7 +560,7 @@ fn toggler_filter<'a>(
                 .size(23),
         )
         .padding([5, 0]),
-        tooltip,
+        Text::new(tooltip).size(FONT_SIZE_FOOTER),
         Position::FollowCursor,
     )
     .class(ContainerType::Tooltip)

--- a/src/gui/pages/notifications_page.rs
+++ b/src/gui/pages/notifications_page.rs
@@ -306,7 +306,7 @@ fn get_button_clear_all<'a>(language: Language) -> Tooltip<'a, Message, StyleTyp
 
     Tooltip::new(
         content,
-        Text::new(clear_all_translation(language)),
+        Text::new(clear_all_translation(language)).size(FONT_SIZE_FOOTER),
         Position::Top,
     )
     .gap(5)

--- a/src/networking/types/program_lookup.rs
+++ b/src/networking/types/program_lookup.rs
@@ -1,6 +1,6 @@
 use crate::countries::flags_pictures::ICONS_SIZE_BIG;
 use crate::gui::styles::container::ContainerType;
-use crate::gui::styles::style_constants::TOOLTIP_DELAY;
+use crate::gui::styles::style_constants::{FONT_SIZE_FOOTER, TOOLTIP_DELAY};
 use crate::gui::styles::types::style_type::StyleType;
 use crate::gui::types::message::Message;
 use crate::networking::manage_packets::get_local_port;
@@ -220,10 +220,14 @@ impl ProgramLookup {
                 .into(),
         };
 
-        Tooltip::new(content, Text::new(program_path), Position::FollowCursor)
-            .snap_within_viewport(true)
-            .class(tooltip_class)
-            .delay(TOOLTIP_DELAY)
+        Tooltip::new(
+            content,
+            Text::new(program_path).size(FONT_SIZE_FOOTER),
+            Position::FollowCursor,
+        )
+        .snap_within_viewport(true)
+        .class(tooltip_class)
+        .delay(TOOLTIP_DELAY)
     }
 }
 


### PR DESCRIPTION
Minor improvement: decrease font size in all the app tooltips to reduce visual clutter