### PR TITLE
IPFIX collector: support ARP flows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5207,7 +5207,7 @@ dependencies = [
 
 [[package]]
 name = "sniffnet-packet-parser"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "etherparse",
  "pcap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ workspace = true
 
 [dependencies]
 
-sniffnet-packet-parser = { path = "lib/sniffnet-packet-parser", version = "0.2.0" }
+sniffnet-packet-parser = { path = "lib/sniffnet-packet-parser", version = "0.2.1" }
 
 pcap.workspace = true
 
@@ -90,7 +90,7 @@ serial_test = { version = "4.0.1", default-features = false }
 
 [build-dependencies]
 
-sniffnet-packet-parser = { path = "lib/sniffnet-packet-parser", version = "0.2.0", default-features = false }
+sniffnet-packet-parser = { path = "lib/sniffnet-packet-parser", version = "0.2.1", default-features = false }
 
 phf_codegen = "0.14.0"
 phf_shared = "0.14.0"

--- a/lib/sniffnet-packet-parser/CHANGELOG.md
+++ b/lib/sniffnet-packet-parser/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All `sniffnet-packet-parser` releases with the relative changes are documented in this file.
 
+## [0.2.1] - 2026-09-05
+### Added
+- `NetInfo::ether_type`, the Ethernet type of the packet's network layer protocol (IPv4, IPv6, or ARP)
+
 ## [0.2.0] - 2026-09-04
 ### Added
 - IGMP support ([#1301](https://github.com/GyulyVGC/sniffnet/pull/1301))

--- a/lib/sniffnet-packet-parser/CHANGELOG.md
+++ b/lib/sniffnet-packet-parser/CHANGELOG.md
@@ -4,7 +4,7 @@ All `sniffnet-packet-parser` releases with the relative changes are documented i
 
 ## [0.2.1] - 2026-09-05
 ### Added
-- `NetInfo::ether_type`, the Ethernet type of the packet's network layer protocol (IPv4, IPv6, or ARP)
+- `NetInfo::ether_type`, the Ethernet type of the packet's network layer protocol ([#1304](https://github.com/GyulyVGC/sniffnet/pull/1304))
 
 ## [0.2.0] - 2026-09-04
 ### Added

--- a/lib/sniffnet-packet-parser/Cargo.toml
+++ b/lib/sniffnet-packet-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sniffnet-packet-parser"
-version = "0.2.0"
+version = "0.2.1"
 description = "Network packet parser for Sniffnet"
 readme = "README.md"
 keywords = ["network", "packet", "sniffer", "parser", "pcap"]

--- a/lib/sniffnet-packet-parser/src/headers.rs
+++ b/lib/sniffnet-packet-parser/src/headers.rs
@@ -25,6 +25,8 @@ pub struct NetInfo {
     pub dst_ip: IpAddr,
     /// ARP message type, if the packet is an ARP packet.
     pub arp_type: Option<ArpType>,
+    /// Ethernet type identifying the network layer protocol (IPv4, IPv6, or ARP).
+    pub ether_type: u16,
     pub(crate) bytes: usize,
 }
 

--- a/lib/sniffnet-packet-parser/src/packet.rs
+++ b/lib/sniffnet-packet-parser/src/packet.rs
@@ -116,10 +116,12 @@ fn analyze_net_header(network_header: Option<NetHeaders>) -> Option<NetInfo> {
             let src_ip = IpAddr::from(ipv4header.source);
             let dst_ip = IpAddr::from(ipv4header.destination);
             let bytes = usize::from(ipv4header.total_len);
+            let ether_type = EtherType::IPV4.0;
             Some(NetInfo {
                 src_ip,
                 dst_ip,
                 arp_type: None,
+                ether_type,
                 bytes,
             })
         }
@@ -127,10 +129,12 @@ fn analyze_net_header(network_header: Option<NetHeaders>) -> Option<NetInfo> {
             let src_ip = IpAddr::from(ipv6header.source);
             let dst_ip = IpAddr::from(ipv6header.destination);
             let bytes = usize::from(ipv6header.payload_length) + 40;
+            let ether_type = EtherType::IPV6.0;
             Some(NetInfo {
                 src_ip,
                 dst_ip,
                 arp_type: None,
+                ether_type,
                 bytes,
             })
         }
@@ -166,10 +170,12 @@ fn analyze_net_header(network_header: Option<NetHeaders>) -> Option<NetInfo> {
             };
             let bytes = arp_packet.packet_len();
             let arp_type = Some(ArpType::from_etherparse(arp_packet.operation));
+            let ether_type = EtherType::ARP.0;
             Some(NetInfo {
                 src_ip,
                 dst_ip,
                 arp_type,
+                ether_type,
                 bytes,
             })
         }

--- a/src/networking/ipfix/collect.rs
+++ b/src/networking/ipfix/collect.rs
@@ -309,13 +309,14 @@ mod tests {
 
     /// The field specifiers `sniffnet-agent` puts in its templates,
     /// after the two address fields that differ between the IPv4 and IPv6 variants
-    const AGENT_COMMON_FIELDS: [(u16, u16); 11] = [
+    const AGENT_COMMON_FIELDS: [(u16, u16); 12] = [
         (7, 2),
         (11, 2),
         (4, 1),
         (56, 6),
         (80, 6),
         (243, 2),
+        (256, 2),
         (61, 1),
         (352, 8),
         (2, 8),
@@ -408,6 +409,7 @@ mod tests {
         r.extend_from_slice(&[0xAA; 6]); // source MAC
         r.extend_from_slice(&[0; 6]); // destination MAC
         r.extend_from_slice(&42u16.to_be_bytes()); // dot1qVlanId
+        r.extend_from_slice(&0x0800u16.to_be_bytes()); // ethernetType
         r.push(0x00); // flowDirection
         r.extend_from_slice(&bytes.to_be_bytes());
         r.extend_from_slice(&packets.to_be_bytes());
@@ -576,6 +578,46 @@ mod tests {
         assert!(succeeded);
         assert_eq!(info.tot_data_info.tot_data(DataRepr::Packets), 19);
         assert_eq!(info.tot_data_info.tot_data(DataRepr::Bytes), 2900);
+    }
+
+    #[test]
+    fn test_process_datagram_arp() {
+        let src = Ipv4Addr::new(192, 168, 1, 10);
+        let dst = Ipv4Addr::new(192, 168, 1, 1);
+        let mut record = src.octets().to_vec();
+        record.extend_from_slice(&dst.octets());
+        record.extend_from_slice(&0u16.to_be_bytes()); // source port
+        record.extend_from_slice(&0u16.to_be_bytes()); // destination port
+        record.push(0); // protocol
+        record.extend_from_slice(&[0xAA; 6]); // source MAC
+        record.extend_from_slice(&[0xFF; 6]); // destination MAC
+        record.extend_from_slice(&0u16.to_be_bytes()); // dot1qVlanId
+        record.extend_from_slice(&0x0806u16.to_be_bytes()); // ethernetType
+        record.push(0x01); // flowDirection
+        record.extend_from_slice(&42u64.to_be_bytes());
+        record.extend_from_slice(&1u64.to_be_bytes());
+        record.extend_from_slice(&20_000u64.to_be_bytes()); // flow start
+        record.extend_from_slice(&25_000u64.to_be_bytes()); // flow end
+
+        let bytes = datagram(&[
+            template_set(256, &agent_fields([(8, 4), (12, 4)])),
+            set(256, &record),
+        ]);
+        let (info, _, succeeded) = run_all(&[&bytes]);
+        assert!(succeeded);
+
+        let key = AddressPortPair {
+            src_ip: IpAddr::V4(src),
+            src_port: None,
+            dst_ip: IpAddr::V4(dst),
+            dst_port: None,
+            protocol: Protocol::Arp,
+            exporter: Some(exporter()),
+        };
+        let entry = info.map.get(&key).unwrap();
+        assert_eq!(entry.bytes, 42);
+        assert_eq!(entry.packets, 1);
+        assert_eq!(entry.traffic_direction, TrafficDirection::Outgoing);
     }
 
     #[test]

--- a/src/networking/ipfix/flow_record.rs
+++ b/src/networking/ipfix/flow_record.rs
@@ -5,6 +5,9 @@ use crate::networking::types::traffic_direction::TrafficDirection;
 use crate::utils::types::timestamp::Timestamp;
 use std::net::IpAddr;
 
+/// `EtherType` of an ARP frame, the one non-IP flow Sniffnet keys
+const ARP_ETHER_TYPE: u16 = 0x0806;
+
 /// Decoded fields from a single data record
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(super) struct FlowRecord {
@@ -13,6 +16,7 @@ pub(super) struct FlowRecord {
     pub(super) src_port: Option<u16>,
     pub(super) dst_port: Option<u16>,
     pub(super) protocol: Option<Protocol>,
+    pub(super) ether_type: Option<u16>,
     pub(super) bytes_delta: Option<u128>,
     pub(super) packets_delta: Option<u128>,
     pub(super) bytes_total: Option<u128>,
@@ -32,8 +36,14 @@ impl FlowRecord {
     pub(super) fn get_key(&self, exporter: IpfixExporter) -> Option<AddressPortPair> {
         let src_ip = self.src_ip?;
         let dst_ip = self.dst_ip?;
-        // TODO: ARP not supported yet
-        let protocol = self.protocol?;
+
+        let protocol = self.protocol.or_else(|| {
+            if self.ether_type == Some(ARP_ETHER_TYPE) {
+                Some(Protocol::Arp)
+            } else {
+                None
+            }
+        })?;
 
         if !protocol.is_portless() && (self.src_port.is_none() || self.dst_port.is_none()) {
             return None;
@@ -65,6 +75,7 @@ impl FlowRecord {
             src_port: self.dst_port,
             dst_port: self.src_port,
             protocol: self.protocol,
+            ether_type: self.ether_type,
             bytes_delta: reverse.bytes_delta,
             packets_delta: reverse.packets_delta,
             bytes_total: reverse.bytes_total,
@@ -188,6 +199,60 @@ mod tests {
     }
 
     #[test]
+    fn test_get_key_arp() {
+        let record = FlowRecord {
+            src_ip: Some("1.1.1.1".parse().unwrap()),
+            dst_ip: Some("2.2.2.2".parse().unwrap()),
+            src_port: None,
+            dst_port: None,
+            protocol: None,
+            ether_type: Some(ARP_ETHER_TYPE),
+            ..Default::default()
+        };
+        let key = record.get_key(exporter());
+        assert_eq!(
+            key,
+            Some(AddressPortPair {
+                src_ip: "1.1.1.1".parse().unwrap(),
+                src_port: None,
+                dst_ip: "2.2.2.2".parse().unwrap(),
+                dst_port: None,
+                protocol: Protocol::Arp,
+                exporter: Some(exporter()),
+            })
+        );
+
+        let record_2 = FlowRecord {
+            src_port: Some(1234),
+            ..record
+        };
+        assert!(record_2.get_key(exporter()).is_none());
+
+        let record_3 = FlowRecord {
+            protocol: Some(Protocol::Tcp),
+            src_port: Some(1234),
+            dst_port: Some(5678),
+            ..record
+        };
+        assert_eq!(
+            record_3.get_key(exporter()).unwrap().protocol,
+            Protocol::Tcp
+        );
+
+        let record_4 = FlowRecord {
+            ether_type: Some(0x0800),
+            ..record
+        };
+        assert!(record_4.get_key(exporter()).is_none(),);
+
+        let record_5 = FlowRecord {
+            ether_type: None,
+            ..record
+        };
+        assert!(record_5.get_key(exporter()).is_none());
+    }
+
+    #[test]
     fn test_get_reverse_record() {
         let record = FlowRecord {
             src_ip: Some("1.1.1.1".parse().unwrap()),
@@ -195,6 +260,7 @@ mod tests {
             src_port: Some(1234),
             dst_port: Some(5678),
             protocol: Some(Protocol::Tcp),
+            ether_type: None,
             bytes_delta: Some(100),
             packets_delta: Some(10),
             bytes_total: Some(1000),
@@ -222,6 +288,7 @@ mod tests {
                 src_port: Some(5678),
                 dst_port: Some(1234),
                 protocol: Some(Protocol::Tcp),
+                ether_type: None,
                 bytes_delta: Some(200),
                 packets_delta: Some(20),
                 bytes_total: Some(2000),

--- a/src/networking/ipfix/ie.rs
+++ b/src/networking/ipfix/ie.rs
@@ -31,6 +31,7 @@ pub(in crate::networking::ipfix) const FLOW_END_NANOSECONDS: u16 = 157;
 pub(in crate::networking::ipfix) const POST_OCTET_TOTAL_COUNT: u16 = 171;
 pub(in crate::networking::ipfix) const POST_PACKET_TOTAL_COUNT: u16 = 172;
 pub(in crate::networking::ipfix) const DOT1Q_VLAN_ID: u16 = 243;
+pub(in crate::networking::ipfix) const ETHERNET_TYPE: u16 = 256;
 pub(in crate::networking::ipfix) const DOT1Q_CUSTOMER_VLAN_ID: u16 = 245;
 pub(in crate::networking::ipfix) const POST_DOT1Q_VLAN_ID: u16 = 254;
 pub(in crate::networking::ipfix) const POST_DOT1Q_CUSTOMER_VLAN_ID: u16 = 255;

--- a/src/networking/ipfix/wire.rs
+++ b/src/networking/ipfix/wire.rs
@@ -268,6 +268,11 @@ fn apply_ie(ie_id: u16, raw: &[u8], record: &mut FlowRecord, priority: &mut Fiel
                 record.dst_ip = Some(v);
             }
         }
+        ie::ETHERNET_TYPE => {
+            if let Some(v) = read_unsigned(raw).and_then(|n| u16::try_from(n).ok()) {
+                record.ether_type = Some(v);
+            }
+        }
         ie::FLOW_DIRECTION => {
             // 0x00 is ingress, 0x01 is egress
             if let Some(dir) = match raw.first() {
@@ -852,6 +857,7 @@ mod tests {
             (ie::SOURCE_MAC_ADDRESS, 6),
             (ie::DESTINATION_MAC_ADDRESS, 6),
             (ie::DOT1Q_VLAN_ID, 2),
+            (ie::ETHERNET_TYPE, 2),
             (ie::OCTET_DELTA_COUNT, 8),
             (ie::PACKET_DELTA_COUNT, 8),
             (ie::OCTET_TOTAL_COUNT, 8),
@@ -869,6 +875,7 @@ mod tests {
             &MAC_A,
             &MAC_B,
             &42u16.to_be_bytes(),
+            &0x0800u16.to_be_bytes(),
             &C1500,
             &10u64.to_be_bytes(),
             &9000u64.to_be_bytes(),
@@ -890,6 +897,7 @@ mod tests {
                 src_port: Some(443),
                 dst_port: Some(51234),
                 protocol: Some(Protocol::Tcp),
+                ether_type: Some(0x0800),
                 bytes_delta: Some(1500),
                 packets_delta: Some(10),
                 bytes_total: Some(9000),


### PR DESCRIPTION
Sniffnet already supports ARP traffic in the standard PCAP-parsing path.
This PR adds support for ARP even for the IPFIX collector based on the exported Ethernet type of the flows.