### PR TITLE
Show info about packets dropped by the network adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All Sniffnet releases with the relative changes are documented in this file.
 - Added support for IGMP connections and messages ([#1301](https://github.com/GyulyVGC/sniffnet/pull/1301) — fixes [#1269](https://github.com/GyulyVGC/sniffnet/issues/1269))
 - Added support for VLAN-tagged connections ([#1302](https://github.com/GyulyVGC/sniffnet/pull/1302) — fixes [#1070](https://github.com/GyulyVGC/sniffnet/issues/1070))
 - Show output file path in Overview page when exporting a PCAP file ([`3f2c42c`](https://github.com/GyulyVGC/sniffnet/pull/1290/commits/3f2c42c70f06d5d29ddad80dde956281c6705511))
+- Show more details about dropped packets ([#1306](https://github.com/GyulyVGC/sniffnet/pull/1306) — fixes [#1079](https://github.com/GyulyVGC/sniffnet/issues/1079))
 - Fix the app freezing and exhausting memory when importing a PCAP file containing a large time gap between consecutive packets ([`4605ec7`](https://github.com/GyulyVGC/sniffnet/pull/1290/commits/4605ec717bbaf8fa34268805814d5585f084201e))
 - Restrict the PCAP export file to have a valid PCAP extension, so that files of other types can't be overwritten ([`5b4801b`](https://github.com/GyulyVGC/sniffnet/pull/1290/commits/5b4801b438ff1c7968cfac423a8e8585778309a8))
 - Correctly filter by favorites-only before rDNS completes ([#1275](https://github.com/GyulyVGC/sniffnet/pull/1275))

--- a/src/chart/types/chart_series.rs
+++ b/src/chart/types/chart_series.rs
@@ -223,7 +223,7 @@ mod tests {
         };
         let mut info_traffic = InfoTraffic {
             tot_data_info,
-            dropped_packets: Some(0),
+            dropped_packets: Some(Default::default()),
             ..Default::default()
         };
 

--- a/src/gui/pages/overview_page.rs
+++ b/src/gui/pages/overview_page.rs
@@ -25,8 +25,8 @@ use crate::networking::types::data_representation::DataRepr;
 use crate::networking::types::ipfix_exporter::IpfixExporter;
 use crate::report::types::sort_type::SortType;
 use crate::translations::translations::{
-    active_filters_translation, incoming_translation, outgoing_translation,
-    traffic_rate_translation,
+    active_filters_translation, incoming_translation, network_adapter_translation,
+    outgoing_translation, traffic_rate_translation,
 };
 use crate::translations::translations_2::{
     data_representation_translation, dropped_translation, only_top_30_items_translation,
@@ -36,7 +36,7 @@ use crate::translations::translations_5::no_favorites_saved_translation;
 use crate::translations::translations_6::ipfix_exporter_translation;
 use crate::utils::formatted_strings::full_print_link_type;
 use crate::utils::types::icon::Icon;
-use crate::{Language, RunningPage, StyleType};
+use crate::{Language, RunningPage, SNIFFNET_TITLECASE, StyleType};
 use iced::Length::Fill;
 use iced::alignment::{Horizontal, Vertical};
 use iced::widget::scrollable::Direction;
@@ -474,8 +474,11 @@ fn col_data_representation<'a>(
 
 fn donut_row(language: Language, sniffer: &Sniffer) -> Container<'_, Message, StyleType> {
     let data_repr = sniffer.conf.data_repr;
+    let tot_data_info = sniffer.info_traffic.tot_data_info;
 
-    let (in_data, out_data, dropped) = sniffer.info_traffic.get_thumbnail_data(data_repr);
+    let in_data = tot_data_info.incoming_data(data_repr);
+    let out_data = tot_data_info.outgoing_data(data_repr);
+    let dropped = sniffer.info_traffic.dropped_packets;
 
     let legend_col = Column::new()
         .spacing(5)
@@ -491,7 +494,37 @@ fn donut_row(language: Language, sniffer: &Sniffer) -> Container<'_, Message, St
             RuleType::Outgoing(true),
             language,
         ))
-        .push(dropped.map(|d| donut_legend_entry(d, data_repr, RuleType::Dropped, language)));
+        .push(dropped.map(|d| {
+            let drop_tot = d.total(data_repr, tot_data_info);
+            donut_legend_entry(drop_tot, data_repr, RuleType::Dropped, language).push(
+                if drop_tot > 0 {
+                    Some(get_info_tooltip(
+                        Column::new()
+                            .spacing(5)
+                            .push(
+                                Text::new(format!(
+                                    "{SNIFFNET_TITLECASE}: {}",
+                                    data_repr
+                                        .formatted_string(d.by_sniffnet(data_repr, tot_data_info))
+                                ))
+                                .size(FONT_SIZE_FOOTER),
+                            )
+                            .push(
+                                Text::new(format!(
+                                    "{}: {}",
+                                    network_adapter_translation(language),
+                                    data_repr
+                                        .formatted_string(d.by_adapter(data_repr, tot_data_info))
+                                ))
+                                .size(FONT_SIZE_FOOTER),
+                            )
+                            .into(),
+                    ))
+                } else {
+                    None
+                },
+            )
+        }));
 
     let donut_row = Row::new()
         .align_y(Vertical::Center)
@@ -500,7 +533,7 @@ fn donut_row(language: Language, sniffer: &Sniffer) -> Container<'_, Message, St
             data_repr,
             in_data,
             out_data,
-            dropped,
+            dropped.map(|d| d.total(data_repr, tot_data_info)),
             sniffer.thumbnail,
         ))
         .push(legend_col);

--- a/src/gui/pages/thumbnail_page.rs
+++ b/src/gui/pages/thumbnail_page.rs
@@ -41,8 +41,14 @@ pub fn thumbnail_page(sniffer: &Sniffer) -> Container<'_, Message, StyleType> {
 
     let info_traffic = &sniffer.info_traffic;
     let data_repr = sniffer.conf.data_repr;
+    let tot_data_info = info_traffic.tot_data_info;
 
-    let (in_data, out_data, dropped) = info_traffic.get_thumbnail_data(data_repr);
+    let in_data = tot_data_info.incoming_data(data_repr);
+    let out_data = tot_data_info.outgoing_data(data_repr);
+    let dropped = sniffer
+        .info_traffic
+        .dropped_packets
+        .map(|d| d.total(data_repr, tot_data_info));
 
     let charts = Row::new()
         .padding(5)

--- a/src/networking/parse_packets.rs
+++ b/src/networking/parse_packets.rs
@@ -9,6 +9,7 @@ use crate::networking::capture::{
 use crate::networking::manage_packets::{modify_or_insert_in_map, update_connection_stats};
 use crate::networking::types::address_port_pair::AddressPortPair;
 use crate::networking::types::capture_context::{CaptureContext, CaptureSource, CaptureType};
+use crate::networking::types::dropped_packets::DroppedPackets;
 use crate::networking::types::info_traffic::InfoTraffic;
 use crate::networking::types::ip_blacklist::IpBlacklist;
 use crate::networking::types::message_type::MessageType;
@@ -176,7 +177,8 @@ pub fn parse_packets(
 
                     // update dropped packets number
                     if let Some(stats) = cap_stats {
-                        info_traffic_msg.dropped_packets = Some(stats.dropped);
+                        info_traffic_msg.dropped_packets =
+                            Some(DroppedPackets::from_pcap_stats(&stats));
                     }
                 }
             }

--- a/src/networking/types/dropped_packets.rs
+++ b/src/networking/types/dropped_packets.rs
@@ -23,7 +23,7 @@ impl DroppedPackets {
     /// assuming that dropped packets have the same size as the average packet
     pub fn total(self, data_repr: DataRepr, tot_data_info: DataInfo) -> u128 {
         averaged_data(
-            u128::from(self.by_adapter + self.by_sniffnet),
+            u128::from(self.by_adapter) + u128::from(self.by_sniffnet),
             data_repr,
             tot_data_info,
         )
@@ -53,4 +53,51 @@ fn averaged_data(dropped_packets: u128, data_repr: DataRepr, tot_data_info: Data
         .saturating_mul(all)
         .checked_div(all_packets)
         .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_averaged_data() {
+        // 6 packets carrying 100 bytes in total
+        let data_info = DataInfo::new_for_tests(2, 4, 30, 70);
+
+        assert_eq!(averaged_data(3, DataRepr::Packets, data_info), 3);
+        // multiply before dividing to avoid truncating the average packet size.
+        assert_eq!(averaged_data(3, DataRepr::Bytes, data_info), 50);
+        assert_eq!(averaged_data(3, DataRepr::Bits, data_info), 400);
+
+        // fractional results are truncated only after scaling by dropped packets.
+        assert_eq!(averaged_data(1, DataRepr::Bytes, data_info), 16);
+        assert_eq!(averaged_data(1, DataRepr::Bits, data_info), 133);
+        assert_eq!(averaged_data(9, DataRepr::Bytes, data_info), 150);
+
+        assert_eq!(averaged_data(0, DataRepr::Packets, data_info), 0);
+        assert_eq!(averaged_data(0, DataRepr::Bytes, data_info), 0);
+        assert_eq!(averaged_data(0, DataRepr::Bits, data_info), 0);
+    }
+
+    #[test]
+    fn test_averaged_data_no_observed_packets() {
+        let data_info = DataInfo::default();
+
+        assert_eq!(averaged_data(3, DataRepr::Packets, data_info), 3);
+        assert_eq!(averaged_data(3, DataRepr::Bytes, data_info), 0);
+        assert_eq!(averaged_data(3, DataRepr::Bits, data_info), 0);
+    }
+
+    #[test]
+    fn test_dropped_packets_total_overflow() {
+        let dropped = DroppedPackets {
+            by_adapter: u32::MAX,
+            by_sniffnet: u32::MAX,
+        };
+        let data_info = DataInfo::new_for_tests(1, 1, 100, 100);
+
+        assert_eq!(dropped.total(DataRepr::Packets, data_info), 8_589_934_590);
+        assert_eq!(dropped.total(DataRepr::Bytes, data_info), 858_993_459_000);
+        assert_eq!(dropped.total(DataRepr::Bits, data_info), 6_871_947_672_000);
+    }
 }

--- a/src/networking/types/dropped_packets.rs
+++ b/src/networking/types/dropped_packets.rs
@@ -1,0 +1,56 @@
+use crate::networking::types::data_info::DataInfo;
+use crate::networking::types::data_representation::DataRepr;
+
+/// Represents the number of dropped packets
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DroppedPackets {
+    /// Number of packets dropped by the network interface or its driver
+    by_adapter: u32,
+    /// Packets dropped because they weren't being read fast enough (PCAP buffer was full)
+    by_sniffnet: u32,
+}
+
+impl DroppedPackets {
+    /// Creates a `DroppedPackets` instance from a `pcap::Stat` struct
+    pub fn from_pcap_stats(stats: &pcap::Stat) -> Self {
+        Self {
+            by_adapter: stats.if_dropped,
+            by_sniffnet: stats.dropped,
+        }
+    }
+
+    /// Returns the total number of dropped data,
+    /// assuming that dropped packets have the same size as the average packet
+    pub fn total(self, data_repr: DataRepr, tot_data_info: DataInfo) -> u128 {
+        averaged_data(
+            u128::from(self.by_adapter + self.by_sniffnet),
+            data_repr,
+            tot_data_info,
+        )
+    }
+
+    /// Returns the number of data dropped by the network adapter,
+    /// assuming that dropped packets have the same size as the average packet
+    pub fn by_adapter(self, data_repr: DataRepr, tot_data_info: DataInfo) -> u128 {
+        averaged_data(u128::from(self.by_adapter), data_repr, tot_data_info)
+    }
+
+    /// Returns the number of data dropped by the Sniffnet,
+    /// assuming that dropped packets have the same size as the average packet
+    pub fn by_sniffnet(self, data_repr: DataRepr, tot_data_info: DataInfo) -> u128 {
+        averaged_data(u128::from(self.by_sniffnet), data_repr, tot_data_info)
+    }
+}
+
+fn averaged_data(dropped_packets: u128, data_repr: DataRepr, tot_data_info: DataInfo) -> u128 {
+    if data_repr == DataRepr::Packets {
+        return dropped_packets;
+    }
+
+    let all = tot_data_info.tot_data(data_repr);
+    let all_packets = tot_data_info.tot_data(DataRepr::Packets);
+    dropped_packets
+        .saturating_mul(all)
+        .checked_div(all_packets)
+        .unwrap_or_default()
+}

--- a/src/networking/types/info_traffic.rs
+++ b/src/networking/types/info_traffic.rs
@@ -3,7 +3,7 @@ use crate::networking::manage_packets::get_local_port;
 use crate::networking::types::address_port_pair::AddressPortPair;
 use crate::networking::types::data_info::DataInfo;
 use crate::networking::types::data_info_host::DataInfoHost;
-use crate::networking::types::data_representation::DataRepr;
+use crate::networking::types::dropped_packets::DroppedPackets;
 use crate::networking::types::host::Host;
 use crate::networking::types::info_address_port_pair::InfoAddressPortPair;
 use crate::networking::types::program_lookup::ProgramLookup;
@@ -17,7 +17,7 @@ pub struct InfoTraffic {
     /// Total amount of exchanged data
     pub tot_data_info: DataInfo,
     /// Number of dropped packets, if applicable
-    pub dropped_packets: Option<u32>,
+    pub dropped_packets: Option<DroppedPackets>,
     /// Timestamp of the latest parsed packet
     pub last_packet_timestamp: Timestamp,
     /// Map of the traffic
@@ -96,25 +96,6 @@ impl InfoTraffic {
                 .and_modify(|x| x.refresh(value))
                 .or_insert(*value);
         }
-    }
-
-    pub fn get_thumbnail_data(&self, data_repr: DataRepr) -> (u128, u128, Option<u128>) {
-        let incoming = self.tot_data_info.incoming_data(data_repr);
-        let outgoing = self.tot_data_info.outgoing_data(data_repr);
-        let all = incoming + outgoing;
-        let all_packets = self.tot_data_info.tot_data(DataRepr::Packets);
-        let dropped = self.dropped_packets.map(|dp| match data_repr {
-            DataRepr::Packets => u128::from(dp),
-            DataRepr::Bytes | DataRepr::Bits => {
-                // assume that the dropped packets have the same size as the average packet
-                u128::from(dp)
-                    .saturating_mul(all)
-                    .checked_div(all_packets)
-                    .unwrap_or_default()
-            }
-        });
-
-        (incoming, outgoing, dropped)
     }
 
     pub fn take_but_leave_something(&mut self) -> Self {

--- a/src/networking/types/mod.rs
+++ b/src/networking/types/mod.rs
@@ -7,6 +7,7 @@ pub mod config_device;
 pub mod data_info;
 pub mod data_info_host;
 pub mod data_representation;
+pub mod dropped_packets;
 pub mod host;
 pub mod info_address_port_pair;
 pub mod info_traffic;


### PR DESCRIPTION
Sniffnet already reported _"dropped packets"_ without making any distinction between PCAP-dropped and adapter-dropped.

The app only reported PCAP-dropped packets, while now _"dropped packets"_ are the sum of both, and in case of a value greater than 0, a tooltip will appear on hover to show both amounts.

Fixes #1079 

<img width="508" height="127" alt="dropped_info" src="https://github.com/user-attachments/assets/f3c86371-6244-45c3-bf1b-fb8405543b2d" />
